### PR TITLE
[WIP] Make calyx-py use Rust builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ itertools = "0.9.0"
 atty = "0.2.14"
 
 [workspace]
-members = ["calyx", "interp"]
+members = ["calyx", "calyx-py-rust", "interp"]
 exclude = ["site"]

--- a/calyx-py-rust/.cargo/config.toml
+++ b/calyx-py-rust/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/calyx-py-rust/Cargo.toml
+++ b/calyx-py-rust/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "calyx-py"
+version = "0.1.0"
+authors = ["Rachit Nigam <rachit.nigam12@gmail.com>"]
+edition = "2018"
+
+[lib]
+name = "calyx"
+crate-type = ["cdylib"]
+
+[dependencies]
+calyx = { path = "../calyx" }
+
+[dependencies.pyo3]
+version = "0.12.3"
+features = ["extension-module"]

--- a/calyx-py-rust/src/lib.rs
+++ b/calyx-py-rust/src/lib.rs
@@ -1,0 +1,95 @@
+//! Python bindings for the IR in Rust.
+//! Because this operates across language boundaries, it makes use of `unsafe`
+//! code.
+use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
+use std::ffi::c_void;
+
+use calyx::ir;
+
+unsafe impl Send for ComponentWrapper {}
+
+/// Opaque wrapper struct for `ir::Component`.
+/// It stores a `void*` pointer which **is not guaranteed** to be valid.
+/// Functions that unwrap this component into a `Box` must call `raw_transform`
+/// to make sure that the function does not run the drop method and frees
+/// the component.
+#[pyclass]
+#[derive(Clone)]
+struct ComponentWrapper {
+    /// Raw pointer to the underlying `ir::Component`. Not guaranteed to
+    /// be valid.
+    comp: *mut c_void,
+}
+
+/// Transform a boxed ir::Component into a ComponentWrapper.
+/// Leaks the underlying ir::Component so that it can be used by the
+/// python library.
+fn into_wrapper(comp: Box<ir::Component>) -> ComponentWrapper {
+    ComponentWrapper {
+        comp: Box::into_raw(comp) as *mut c_void,
+    }
+}
+
+/// Check if the wrapper contains a valid pointer to an ir::Component
+/// and returns a boxed representation.
+/// **Note**: Methods using this probably want to use `into_wrapper` to
+/// create a valid wrapper at the end of the function call.
+fn from_wrapper(wrap: ComponentWrapper) -> Box<ir::Component> {
+    unsafe {
+        assert!(
+            !wrap.comp.is_null(),
+            "Invalid component wrapper. The component seems to have been already dropped.");
+        let comp_raw = wrap.comp as *mut ir::Component;
+        Box::from_raw(comp_raw)
+    }
+}
+
+/// Create a new component.
+/// Returns an opaque ComponentWrapper that can be used in other functions.
+///
+/// `name`: The name of the component.
+/// `port`: List of tuples with (name, size, direction)
+#[pyfunction]
+fn new_component(
+    name: &str,
+    ports: Vec<(&str, u64, &str)>,
+) -> ComponentWrapper {
+    let port_defs = ports
+        .into_iter()
+        .map(|(name, width, dir)| {
+            (name, width, dir.into(), ir::Attributes::default())
+        })
+        .collect();
+    let comp = Box::new(ir::Component::new(name, port_defs));
+    ComponentWrapper {
+        comp: Box::into_raw(comp) as *mut c_void,
+    }
+}
+
+/// Get the name of this Component.
+#[pyfunction]
+fn get_component_name(c: ComponentWrapper) -> String {
+    let comp = from_wrapper(c);
+    let ret = comp.name.to_string();
+    into_wrapper(comp);
+    ret
+}
+
+/// Free the underlying ir::Component. All components must have this
+/// method called on them to ensure that they don't leak.
+#[pyfunction]
+fn free_component(c: ComponentWrapper) -> () {
+    from_wrapper(c);
+    // The component is dropped automatically due to Box<T> destructor.
+}
+
+/// The python module exposing the relevant functions.
+#[pymodule]
+fn libcalyx(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(new_component, m)?)?;
+    m.add_function(wrap_pyfunction!(get_component_name, m)?)?;
+    m.add_function(wrap_pyfunction!(free_component, m)?)?;
+
+    Ok(())
+}

--- a/calyx/src/ir/structure.rs
+++ b/calyx/src/ir/structure.rs
@@ -25,6 +25,20 @@ impl Direction {
     }
 }
 
+impl<T> From<T> for Direction
+where
+    T: AsRef<str> + std::fmt::Display,
+{
+    fn from(s: T) -> Self {
+        match s.as_ref() {
+            "inout" => Direction::Inout,
+            "in" => Direction::Input,
+            "out" => Direction::Output,
+            _ => panic!("Unknown port direction {}", s),
+        }
+    }
+}
+
 /// Ports can come from Cells or Groups
 #[derive(Debug, Clone)]
 pub enum PortParent {


### PR DESCRIPTION
Second attempt at a calyx-py library using Rust FFI for Python.

In order to play with it:
```
cargo build --all
```

On Mac OS:
```
cp ./target/debug/libcalyx.dylib libcalyx.so
```
On other OSes
```
cp ./target/debug/libcalyx.so libcalyx.so
```

In a `python` terminal (in the same directory as `libcalyx.so`):
```
import libcalyx as calyx
comp = calyx.new_component('main', [])
calyx.get_component_name(comp)
free_component(comp)
```

### Design

For a full library, we'll need to expose more than `get_component_name`.
The strategy is:
1. Define useful functions in `calyx-py-rust/src/lib.rs` and expose them.
2. Write Python classes and methods to wrap these functions.

For example, to expose `ir::Builder`, we can define a python class:
```
# assume it implements get_library, make_builder
import calyx

class Builder:
  def __init__(component):
    lib = calyx.get_library("primitives/std.lib")
    self.builder = calyx.make_builder(component, lib)
```

Next, we can expose useful methods such as adding primitives:
```
class Builder:
  ...
  def add_primitive(params):
    calyx.add_primitive(self.builder, params)
```

### MVP

An MVP will need to implement at least:

- [ ] The `ir::Builder` interface
- [ ] Mechanism to construct `ir::Control` nodes.
- [ ] `ir::Printer::write_component` to print components
