### PR TITLE
Support for Visual Studio Code & the Remote-Containers Extension

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,34 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.134.0/containers/rust/.devcontainer/base.Dockerfile
+FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+RUN apt-get update \
+    #
+    # Install Dependencies
+    && apt-get -y install build-essential \
+    && apt-get -y install git make autoconf g++ flex bison jq python3-pip \
+    && apt-get -y install verilator \
+    #
+    # [Optional] Update UID/GID if needed
+    && if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
+        groupmod --gid $USER_GID $USERNAME \
+        && usermod --uid $USER_UID --gid $USER_GID $USERNAME \
+        && chown -R $USER_UID:$USER_GID /home/$USERNAME; \
+    fi \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,6 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.134.0/containers/rust/.devcontainer/base.Dockerfile
 FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
 
-# [Optional] Uncomment this section to install additional packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.134.0/containers/rust
+{
+	"name": "Calyx Visual Studio Code Development Environment",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+    // "runArgs": [  "-u", "1000:1000", "--security-opt", "label=disable" ],
+    "workspaceFolder": "/home/vscode/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/workspace,type=bind,consistency=delegated",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"lldb.executable": "/usr/bin/lldb",
+		// VS Code don't watch files under ./target
+		"files.watcherExclude": {
+			"**/target/**": true
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"bungcip.better-toml",
+		"vadimcn.vscode-lldb",
+		"matklad.rust-analyzer",
+		"mutantdino.resourcemonitor"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "cargo install runt vcdump && pip3 install flit",
+
+	// Comment out to run as root instead.
+	"remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ __pycache__
 !.devcontainer/devcontainer.json
 !.vscode/settings.json
 !.vscode/launch.json
+!.vscode/tasks.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ __pycache__
 *.pyc
 *.tar.gz
 *.jou
+
+!.devcontainer/devcontainer.json
+!.vscode/settings.json
+!.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=hello_remote_world",
+                    "--package=hello_remote_world",
+                    "--manifest-path=Cargo.toml"
+                ],
+                "filter": {
+                    "kind": "bin"
+                }
+            },
+            "args": []
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "search.exclude": {
+        "**/target": true
+    },
+    "lldb.verboseLogging": true
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,46 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Cargo Build",
+            "command": "cargo",
+            "args": ["build"],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        {
+            "label": "Install the FuTIL Driver",
+            "command": "/home/vscode/.local/bin/flit",
+            "args": ["install", "-s"],
+            "options": {
+                "cwd": "${workspaceFolder}/fud"
+            }
+        },
+        {
+            "label": "Install the FuTIL Python Library",
+            "command": "/home/vscode/.local/bin/flit",
+            "args": ["install", "-s"],
+            "options": {
+                "cwd": "${workspaceFolder}/calyx-py"
+            }
+        },
+        {
+            "label": "Run All Tests",
+            "command": "runt",
+            "dependsOn": ["Cargo Build", "Install the FuTIL Driver", "Install the FuTIL Python Library"]
+        },
+        {
+            "label": "Run Example Program",
+            "command": "cargo",
+            "args": ["run", "--", "examples/futil/simple.futil"],
+            "dependsOn": ["Cargo Build", "Install the FuTIL Driver", "Install the FuTIL Python Library"]
+        },
+        {
+            "label": "Run Example Program(w/ Verilog)",
+            "command": "cargo",
+            "args": ["run", "--", "examples/futil/simple.futil", "-b", "verilog"],
+            "dependsOn": ["Cargo Build", "Install the FuTIL Driver", "Install the FuTIL Python Library"]
+        }
+    ]
+}


### PR DESCRIPTION
I've added support for Visual Studio Code and it's Remote-Containers extension, to make development setup a bit easier, for example:

https://dev.to/ctison/vscode-remote-containers-5740

The PR is based off of Microsoft's own container for Rust development, which uses a Debian container underneath: 
https://github.com/microsoft/vscode-remote-try-rust