### PR TITLE
Quantized example.

### DIFF
--- a/frontends/relay/example.py
+++ b/frontends/relay/example.py
@@ -68,8 +68,30 @@ def mlp_net():
 def vgg_net():
     """The VGG test from Relay."""
     from tvm.relay.testing import vgg
-    return vgg.get_net(batch_size=5, image_shape=(3, 224, 224), num_classes=10, dtype='int32', num_layers=13,
-                       batch_norm=True)
+    return vgg.get_net(
+        batch_size=5,
+        image_shape=(3, 224, 224),
+        num_classes=10,
+        dtype='int32',
+        num_layers=13,
+        batch_norm=True
+    )
+
+
+def quantized_net():
+    """Quantized test."""
+    from tvm.relay.testing import vgg
+    mod, params = vgg.get_workload(
+        batch_size=5,
+        image_shape=(3, 224, 224),
+        num_classes=10,
+        dtype='float32',
+        num_layers=13,
+        batch_norm=True
+    )
+    with relay.quantize.qconfig(skip_k_conv=0, round_for_shift=True):
+        mod = relay.quantize.quantize(mod, params)
+    return mod
 
 
 FUNCTIONS = {
@@ -84,7 +106,8 @@ FUNCTIONS = {
     'conv2d': conv2d,
     'max_pool2d': max_pool2d,
     'mlp_net': mlp_net,
-    'vgg_net': vgg_net
+    'vgg_net': vgg_net,
+    'quantized_net': quantized_net
 }
 
 

--- a/frontends/relay/example.py
+++ b/frontends/relay/example.py
@@ -150,9 +150,16 @@ relay -r    Displays the Relay IR. Displays Calyx otherwise.
         relay.transform.ToANormalForm(),
     ])
 
-    mod_opt = tvm.IRModule.from_expr(func)
-    mod_opt = seq(mod_opt)
+    mod_opt = func
+    if all(['quantized' not in i for i in input]):
+        # Quantized nets return the IRModule directly,
+        # so we can skip this step.
+        mod_opt = tvm.IRModule.from_expr(
+            seq(mod_opt)
+        )
+
     relay_IR = mod_opt['main']
+
     if '-r' in input:
         # Dump the Relay IR.
         print(relay_IR)


### PR DESCRIPTION

We need LLVM to run this quantized example:
```
python3 frontends/relay/example.py quantized_net
```
Otherwise, we get:
```
...
TVMError: Check failed: bf != nullptr: target.build.llvm -keys=cpu is not enabled
```
Similar errors usually points to "Install LLVM", e.g. [this](https://discuss.tvm.apache.org/t/tvmerror-check-failed-bf-nullptr-target-llvm-is-not-enabled/5561) and [this as well](https://github.com/apache/tvm/issues/1020).

1. Install LLVM. I had issues with this before, but it looks like everything works fine now with llvm-11.1.0 (on MacOS):
```
brew install llvm
```
2. Change the LLVM configuration in `tvm/build/config.cmake`:
```
set(USE_LLVM /usr/local/Cellar/llvm/11.1.0/bin/llvm-config)
```
3. Build TVM:
Follow steps 3-7 in the [TVM Relay frontend docs](https://capra.cs.cornell.edu/docs/calyx/frontends/tvm-relay.html).

One thing I noticed was that with step 4,
```
 pip3 install --user dist/tvm-*.whl
```
I'm now getting the following error: 
```
ERROR: tvm-0.7.dev1-cp37-cp37m-macosx_10_14_x86_64.whl is not a supported wheel on this platform.
```
I have no idea whether these are actually related. So instead, I followed the directions provided on the [TVM Python Bindings](https://tvm.apache.org/docs/install/from_source.html#python-package-installation) page:
```
export MACOSX_DEPLOYMENT_TARGET=10.9  # This is required for mac to avoid symbol conflicts with libstdc++
cd python; python setup.py install --user; cd ..
```
This successfully installed the Python bindings.

Unfortunately, when I retry to run the quantized net example, I'm still getting the same error as above.

