### PR TITLE
Unify implementation of div and mod in stdlib

### DIFF
--- a/fud/fud/errors.py
+++ b/fud/fud/errors.py
@@ -129,8 +129,9 @@ class StepFailure(FudError):
     Indicates that a step failed.
     """
 
-    def __init__(self, step, stderr):
-        msg = f"`{step.strip()}' failed:\n=====STDERR=====\n" + stderr
+    def __init__(self, step, stdout, stderr):
+        msg = f"`{step.strip()}' failed:\n=====STDERR=====\n" + stderr + \
+            "\n=====STDOUT=====\n" + stdout
         super().__init__(msg)
 
 

--- a/fud/fud/stages/verilator/stage.py
+++ b/fud/fud/stages/verilator/stage.py
@@ -101,7 +101,6 @@ class VerilatorStage(Stage):
                     # Don't trace if we're only looking at memory outputs
                     "--trace" if self.vcd else "",
                 ],
-                stdout_as_debug=True
             )
 
         # Step 5(self.vcd == True): extract

--- a/fud/fud/stages/verilator/stage.py
+++ b/fud/fud/stages/verilator/stage.py
@@ -100,7 +100,8 @@ class VerilatorStage(Stage):
                     str(self.config["stages", self.name, "cycle_limit"]),
                     # Don't trace if we're only looking at memory outputs
                     "--trace" if self.vcd else "",
-                ]
+                ],
+                stdout_as_debug=True
             )
 
         # Step 5(self.vcd == True): extract

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -174,11 +174,17 @@ def shell(cmd, stdin=None, stdout_as_debug=False):
         cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr, env=os.environ
     )
     proc.wait()
+    stdout.seek(0)
     if proc.returncode != 0:
         if stderr is not None:
             stderr.seek(0)
-            raise errors.StepFailure(cmd, stderr.read().decode("UTF-8"))
+            raise errors.StepFailure(
+                cmd,
+                stdout.read().decode("UTF-8"),
+                stderr.read().decode("UTF-8"))
         else:
-            raise errors.StepFailure(cmd, "No stderr captured.")
-    stdout.seek(0)
+            raise errors.StepFailure(
+                cmd,
+                "No stdout captured.",
+                "No stderr captured.")
     return stdout

--- a/primitives/bitnum/math.futil
+++ b/primitives/bitnum/math.futil
@@ -1,10 +1,14 @@
+/**
+ * Implementation of math primitives.
+ * Do not prefix names with `std_`.
+ */
 extern "math.sv" {
-  primitive std_sqrt(in: 32, go: 1, clk: 1) -> (out: 32, done: 1);
+  primitive sqrt(in: 32, go: 1, clk: 1) -> (out: 32, done: 1);
 }
 
 // Computes the unsigned value b^e, where
 // b is the `base` and e is the `exp`.
-component std_pow(base: 32, exp: 32) -> (out: 32) {
+component pow(base: 32, exp: 32) -> (out: 32) {
   cells {
     pow = std_reg(32);
     count = std_reg(32);

--- a/primitives/bitnum/math.sv
+++ b/primitives/bitnum/math.sv
@@ -2,7 +2,7 @@
 * Implements the non-restoring square root algorithm's iterative
 * implementation (Figure 8): https://ieeexplore.ieee.org/document/563604
 */
-module std_sqrt (
+module sqrt (
     input  logic [31:0] in,
     input  logic        go,
     input  logic        clk,

--- a/primitives/bitnum/signed.futil
+++ b/primitives/bitnum/signed.futil
@@ -22,8 +22,6 @@ extern "signed.sv" {
   );
 
   /// ===================== Unsynthesizable Primitives ======================
-  primitive std_smod<"share"=1>[width](left: width, right: width) -> (out: width);
-  primitive std_sdiv<"share"=1>[width](left: width, right: width) -> (out: width);
   primitive std_smult<"share"=1>[width](left: width, right: width) -> (out: width);
 
 }

--- a/primitives/bitnum/signed.sv
+++ b/primitives/bitnum/signed.sv
@@ -140,27 +140,6 @@ module std_sle #(
   assign out = $signed(left <= right);
 endmodule
 
-module std_sdiv #(
-    parameter width = 32
-) (
-    input  signed [width-1:0] left,
-    input  signed [width-1:0] right,
-    output signed [width-1:0] out
-);
-  assign out = $signed(left / right);
-endmodule
-
-module std_smod #(
-    parameter width = 32
-) (
-    input  signed [width-1:0] left,
-    input  signed [width-1:0] right,
-    output signed [width-1:0] out
-);
-  assign out = $signed(left % right);
-endmodule
-
-
 module std_smult #(
     parameter width = 32
 ) (

--- a/primitives/bitnum/unsigned.futil
+++ b/primitives/bitnum/unsigned.futil
@@ -14,14 +14,18 @@ extern "unsigned.sv" {
   primitive std_div[width](
     clk: 1, go: 1, left: width, right: width
   ) -> (
-    out: width, done: 1
+    out_remainder: width,
+    out_quotient: width,
+    done: 1
   );
 
   // =============== Signed primitives that wrap unsigned ones ==============
   primitive std_sdiv[width](
     clk: 1, go: 1, left: width, right: width
   ) -> (
-    out: width, done: 1
+    out_remainder: width,
+    out_quotient: width,
+    done: 1
   );
 
 

--- a/primitives/bitnum/unsigned.futil
+++ b/primitives/bitnum/unsigned.futil
@@ -11,20 +11,14 @@ extern "unsigned.sv" {
     out: width, @done(1) done: 1
   );
 
-  primitive std_div_pipe[width](
+  primitive std_div[width](
     clk: 1, go: 1, left: width, right: width
   ) -> (
     out: width, done: 1
   );
 
   // =============== Signed primitives that wrap unsigned ones ==============
-  primitive std_smod_pipe[width](
-    clk: 1, go: 1, left: width, right: width
-  ) -> (
-    out: width, done: 1
-  );
-
-  primitive std_sdiv_pipe[width](
+  primitive std_sdiv[width](
     clk: 1, go: 1, left: width, right: width
   ) -> (
     out: width, done: 1
@@ -33,11 +27,6 @@ extern "unsigned.sv" {
 
   /// =================== Unsynthesizable Primitives =========================
   primitive std_mult<"share"=1>[width](
-    left: width, right: width
-  ) -> (
-    out: width
-  );
-  primitive std_div<"share"=1>[width](
     left: width, right: width
   ) -> (
     out: width

--- a/primitives/bitnum/unsigned.sv
+++ b/primitives/bitnum/unsigned.sv
@@ -1,12 +1,13 @@
 /* verilator lint_off WIDTH */
-module std_mod_pipe #(
+module std_div #(
     parameter width = 32
 ) (
     input                    clk,
     input                    go,
     input        [width-1:0] left,
     input        [width-1:0] right,
-    output logic [width-1:0] out,
+    output logic [width-1:0] out_remainder,
+    output logic [width-1:0] out_quotient,
     output logic             done
 );
 
@@ -19,26 +20,41 @@ module std_mod_pipe #(
   assign start = go && !running;
   assign finished = !quotient_msk && running;
 
-  always @(posedge clk) begin
-    if (!go) begin
-      running <= 0;
-      done <= 0;
-      out <= 0;
-    end else if (start && left == 0) begin
-      out <= 0;
-      done <= 1;
+  always_latch @(posedge clk) begin
+    if (start && left == 0) begin
+      out_remainder <= 0;
+      out_quotient <= 0;
     end
+    else if (finished) begin
+      out_remainder <= dividend;
+      out_quotient <= quotient;
+    end
+  end
 
-    if (start) begin
+  always_ff @(posedge clk) begin
+    if (start && left == 0)
+      done <= 1;
+    else if (finished)
+      done <= 1;
+    else
+      done <= 0;
+  end
+
+  always_latch @(posedge clk) begin
+    if (!go)
+      running <= 0;
+    else if (start)
       running <= 1;
+    else if (finished)
+      running <= 0;
+  end
+
+  always_latch @(posedge clk) begin
+    if (start) begin
       dividend <= left;
       divisor <= right << width - 1;
       quotient <= 0;
       quotient_msk <= 1 << width - 1;
-    end else if (finished) begin
-      running <= 0;
-      done <= 1;
-      out <= dividend;
     end else begin
       if (divisor <= dividend) begin
         dividend <= dividend - divisor;
@@ -54,11 +70,20 @@ module std_mod_pipe #(
     always @(posedge clk) begin
       if (finished && dividend != $unsigned(((left % right) + right) % right))
         $error(
-          "\nstd_mod_pipe: Computed and golden outputs do not match!\n",
+          "\nstd_mod_pipe: (Remainder) Computed and golden outputs do not match!\n",
           "left: %0d", $unsigned(left),
           "  right: %0d\n", $unsigned(right),
           "expected: %0d", $unsigned(((left % right) + right) % right),
-          "  computed: %0d", $unsigned(out)
+          "  computed: %0d", $unsigned(out_remainder)
+        );
+
+      if (finished && quotient != $unsigned(left / right))
+        $error(
+          "\nstd_mod_pipe: (Quotient) Computed and golden outputs do not match!\n",
+          "left: %0d", $unsigned(left),
+          "  right: %0d\n", $unsigned(right),
+          "expected: %0d", $unsigned(left / right),
+          "  computed: %0d", $unsigned(out_quotient)
         );
     end
   `endif
@@ -101,123 +126,32 @@ module std_mult_pipe #(
   end
 endmodule
 
-/* verilator lint_off WIDTH */
-module std_div_pipe #(
-    parameter width = 32
-) (
-    input                  clk,
-    input                  go,
-    input      [width-1:0] left,
-    input      [width-1:0] right,
-    output reg [width-1:0] out,
-    output reg             done
-);
-
-  wire start = go && !running;
-
-  reg [width-1:0] dividend;
-  reg [(width-1)*2:0] divisor;
-  reg [width-1:0] quotient;
-  reg [width-1:0] quotient_msk;
-  reg running;
-
-  always @(posedge clk) begin
-    if (!go) begin
-      running <= 0;
-      done <= 0;
-      out <= 0;
-    end else if (start && left == 0) begin
-      out <= 0;
-      done <= 1;
-    end
-    if (start) begin
-      running <= 1;
-      dividend <= left;
-      divisor <= right << width - 1;
-      quotient <= 0;
-      quotient_msk <= 1 << width - 1;
-    end else if (!quotient_msk && running) begin
-      running <= 0;
-      done <= 1;
-      out <= quotient;
-    end else begin
-      if (divisor <= dividend) begin
-        dividend <= dividend - divisor;
-        quotient <= quotient | quotient_msk;
-      end
-      divisor <= divisor >> 1;
-      quotient_msk <= quotient_msk >> 1;
-    end
-  end
-endmodule
-
 // ===============Signed operations that wrap unsigned ones ===============
-
-module std_smod_pipe #(
-    parameter width = 32
-) (
-    input                     clk,
-    input                     go,
-    input  signed [width-1:0] left,
-    input  signed [width-1:0] right,
-    output logic  [width-1:0] out,
-    output logic              done
-);
-
-  logic signed [width-1:0] left_abs;
-  logic signed [width-1:0] comp_out;
-
-  assign left_abs = left[width-1] == 1 ? -left : left;
-  assign out = left[width-1] == 1 ? $signed(right - comp_out) : comp_out;
-
-  std_mod_pipe #(
-    .width(width)
-  ) comp (
-    .clk(clk),
-    .done(done),
-    .go(go),
-    .left(left_abs),
-    .right(right),
-    .out(comp_out)
-  );
-
-  `ifdef VERILATOR
-    // Simulation self test against unsynthesizable implementation.
-    always @(posedge clk) begin
-      if (done && out != $signed(((left % right) + right) % right))
-        $error(
-          "\nstd_smod_pipe: Computed and golden outputs do not match!\n",
-          "left: %0d", left,
-          "  right: %0d\n", right,
-          "expected: %0d", $signed(((left % right) + right) % right),
-          "  computed: %0d", $signed(out)
-        );
-    end
-  `endif
-endmodule
-
 /* verilator lint_off WIDTH */
-module std_sdiv_pipe #(
+module std_sdiv #(
     parameter width = 32
 ) (
     input                     clk,
     input                     go,
     input  signed [width-1:0] left,
     input  signed [width-1:0] right,
-    output logic  [width-1:0] out,
+    output logic  [width-1:0] out_remainder,
+    output logic  [width-1:0] out_quotient,
     output logic              done
 );
 
   logic signed [width-1:0] left_abs;
   logic signed [width-1:0] right_abs;
-  logic signed [width-1:0] comp_out;
+  logic signed [width-1:0] comp_out_remainder;
+  logic signed [width-1:0] comp_out_quotient;
 
   assign right_abs = right[width-1] == 1 ? -right : right;
   assign left_abs = left[width-1] == 1 ? -left : left;
-  assign out =
-    (left[width-1] == 1) ^ (right[width-1] == 1) ? -comp_out : comp_out;
+  assign out_quotient =
+    (left[width-1] == 1) ^ (right[width-1] == 1) ? -comp_out_quotient : comp_out_quotient;
+  assign out_remainder = left[width-1] == 1 ? $signed(right - comp_out_remainder) : comp_out_remainder;
 
-  std_div_pipe #(
+  std_div #(
     .width(width)
   ) comp (
     .clk(clk),
@@ -225,19 +159,28 @@ module std_sdiv_pipe #(
     .go(go),
     .left(left_abs),
     .right(right_abs),
-    .out(comp_out)
+    .out_quotient(comp_out_quotient),
+    .out_remainder(comp_out_remainder)
   );
 
   `ifdef VERILATOR
     // Simulation self test against unsynthesizable implementation.
     always @(posedge clk) begin
-      if (done && out != $signed(left / right))
+      if (done && out_quotient != $signed(left / right))
         $error(
-          "\nstd_sdiv_pipe: Computed and golden outputs do not match!\n",
+          "\nstd_sdiv: (Quotient) Computed and golden outputs do not match!\n",
           "left: %0d", left,
           "  right: %0d\n", right,
           "expected: %0d", $signed(left / right),
-          "  computed: %0d", $signed(out)
+          "  computed: %0d", $signed(out_quotient)
+        );
+      if (done && out_remainder != $signed(((left % right) + right) % right))
+        $error(
+          "\nstd_sdiv: (Remainder) Computed and golden outputs do not match!\n",
+          "left: %0d", left,
+          "  right: %0d\n", right,
+          "expected: %0d", $signed(((left % right) + right) % right),
+          "  computed: %0d", $signed(out_remainder)
         );
     end
   `endif
@@ -253,16 +196,6 @@ module std_mult #(
     output logic [width-1:0] out
 );
   assign out = left * right;
-endmodule
-
-module std_div #(
-    parameter width = 32
-) (
-    input  logic [width-1:0] left,
-    input  logic [width-1:0] right,
-    output logic [width-1:0] out
-);
-  assign out = left / right;
 endmodule
 
 module std_mod #(

--- a/primitives/bitnum/unsigned.sv
+++ b/primitives/bitnum/unsigned.sv
@@ -70,7 +70,7 @@ module std_div #(
     always @(posedge clk) begin
       if (finished && dividend != $unsigned(((left % right) + right) % right))
         $error(
-          "\nstd_mod_pipe: (Remainder) Computed and golden outputs do not match!\n",
+          "\nstd_div: (Remainder) Computed and golden outputs do not match!\n",
           "left: %0d", $unsigned(left),
           "  right: %0d\n", $unsigned(right),
           "expected: %0d", $unsigned(((left % right) + right) % right),
@@ -79,7 +79,7 @@ module std_div #(
 
       if (finished && quotient != $unsigned(left / right))
         $error(
-          "\nstd_mod_pipe: (Quotient) Computed and golden outputs do not match!\n",
+          "\nstd_div: (Quotient) Computed and golden outputs do not match!\n",
           "left: %0d", $unsigned(left),
           "  right: %0d\n", $unsigned(right),
           "expected: %0d", $unsigned(left / right),

--- a/tests/correctness/pow.futil
+++ b/tests/correctness/pow.futil
@@ -7,7 +7,7 @@ component main() -> () {
     exp = std_mem_d1(32, 1, 1);
     base_reg = std_reg(32);
     exp_reg = std_reg(32);
-    std_pow0 = std_pow();
+    pow0 = pow();
   }
   wires {
     group init {
@@ -20,7 +20,7 @@ component main() -> () {
       init[done] = base_reg.done & exp_reg.done ? 1'd1;
     }
     group fill_memory {
-      out.write_data = std_pow0.out;
+      out.write_data = pow0.out;
       out.addr0 = 1'd0;
       out.write_en = 1'd1;
       fill_memory[done] = out.done;
@@ -29,7 +29,7 @@ component main() -> () {
   control {
     seq {
       init;
-      invoke std_pow0(base=base_reg.out, exp=exp_reg.out)();
+      invoke pow0(base=base_reg.out, exp=exp_reg.out)();
       fill_memory;
     }
   }


### PR DESCRIPTION
Fixes #330.

Also removes the unsynthesizable `std_div`, `std_mod`, and the
corresponding signed implmentations.

- [ ] Test with full polybench implementations (current failing `lu`)