### PR TITLE
[Docs] Tutorial hotfix

### DIFF
--- a/docs/lang/attributes.md
+++ b/docs/lang/attributes.md
@@ -15,8 +15,8 @@ component main<"static"=10>(@go_port(1) go: 1) -> (@done_port(1) done: 1) {
 #### **Cell Attributes**
 ```
 cells {
-  @external(1) mem = prim std_mem_d1(32, 8, 4);
-  reg = prim std_reg(32);
+  @external(1) mem = std_mem_d1(32, 8, 4);
+  reg = std_reg(32);
   ...
 }
 ```

--- a/docs/tutorial/frontend-tut.md
+++ b/docs/tutorial/frontend-tut.md
@@ -86,14 +86,14 @@ component main() -> {
 `Decl` nodes instantiate new memories and registers. We need these to be instantiated in the `cells` section of our Calyx output. Here's Calyx code that creates a new memory `foo`, with 4 32-bit elements and a 32-bit indexor:
 
 ```
-foo = prim std_mem_d1(32, 4, 32);
+foo = std_mem_d1(32, 4, 32);
 ```
 
 For each `Decl` node, we need to determine if we're instantiating a memory or a register, and then translate that to a corresponding Calyx declaration and place that inside the `cells` section of our generated program. Here's some code from our compiler that walks through each register and memory declaration, and generates a Calyx program with those registers:
 
 {{#include ../../frontends/mrxl/mrxl/gen_futil.py:283:290}}
 
-(`emit_mem_decl` emits a string of the form `"mem_name = prim std_mem_d1(<element_width>, <num_elements>, <index_width>)"`.)
+(`emit_mem_decl` emits a string of the form `"mem_name = std_mem_d1(<element_width>, <num_elements>, <index_width>)"`.)
 
 #### `Map` and `Reduce` nodes
 

--- a/docs/tutorial/language-tut.md
+++ b/docs/tutorial/language-tut.md
@@ -40,11 +40,10 @@ Let's turn our skeleton into a tiny, nearly no-op Calyx program.
 We'll start by adding a memory component to the cells:
 
     cells {
-      mem = prim std_mem_d1(32, 1, 1);
+      mem = std_mem_d1(32, 1, 1);
     }
 
-This new line declares a new cell called `mem`.
-The `prim` keyword means that we're instantiating a primitive component: here, `std_mem_d1`, our standard-library component that represents a 1D memory.
+This new line declares a new cell called `mem` and the primitive component `std_mem_d1` represents a 1D memory.
 You can see the definition of `std_mem_d1`, and all the other standard components, in the `primitives/std.lib` library we imported.
 This one has three parameters:
 the data width (here, 32 bits),
@@ -156,8 +155,8 @@ In this version of the program, we'll read a value from the memory, increment it
 
 First, we will add two components to the `cells` section:
 
-    val = prim std_reg(32);
-    add = prim std_add(32);
+    val = std_reg(32);
+    add = std_add(32);
 
 We make a register `val` and an integer adder `add`, both configured to work on 32-bit values.
 
@@ -248,9 +247,9 @@ The body of the loop runs our old `seq` block in parallel with a new `incr` grou
 
 Let's add some cells to our component:
 
-    counter = prim std_reg(32);
-    add2 = prim std_add(32);
-    lt = prim std_lt(32);
+    counter = std_reg(32);
+    add2 = std_add(32);
+    lt = std_lt(32);
 
 We'll need a new register, an adder to do the incrementing, and a less-than comparator.
 


### PR DESCRIPTION
### Description
This PR attempts to make minor adjustments to parts of the tutorial documentation with `prim` prefix still being used.