### PR TITLE
Dont insert empty group when control is completely empty

### DIFF
--- a/calyx/src/ir/traversal/visitor.rs
+++ b/calyx/src/ir/traversal/visitor.rs
@@ -101,9 +101,14 @@ pub trait Visitor {
                 // Create a clone of the reference to the Control
                 // program.
                 let control_ref = Rc::clone(&comp.control);
-                // Borrow the control program mutably and visit it.
+                if let Control::Empty(_) = &*control_ref.borrow() {
+                    // Don't traverse if the control program is empty.
+                    return Ok(Action::Continue);
+                }
+                // Mutably borrow the control program and traverse.
                 control_ref.borrow_mut().visit(self, comp, signatures)?;
                 Ok(Action::Continue)
+
             })?
             .and_then(|| self.finish(comp, signatures))?
             .apply_change(&mut comp.control.borrow_mut());

--- a/calyx/src/ir/traversal/visitor.rs
+++ b/calyx/src/ir/traversal/visitor.rs
@@ -108,7 +108,6 @@ pub trait Visitor {
                 // Mutably borrow the control program and traverse.
                 control_ref.borrow_mut().visit(self, comp, signatures)?;
                 Ok(Action::Continue)
-
             })?
             .and_then(|| self.finish(comp, signatures))?
             .apply_change(&mut comp.control.borrow_mut());

--- a/calyx/src/passes/inliner.rs
+++ b/calyx/src/passes/inliner.rs
@@ -110,10 +110,11 @@ impl Visitor for Inliner {
     ) -> VisResult {
         // get the only group in the enable
         let top_level = match &*comp.control.borrow() {
+            ir::Control::Empty(_) => return Ok(Action::Stop),
             ir::Control::Enable(en) => Rc::clone(&en.group),
             _ => return Err(
                 Error::MalformedControl(
-                    "The hole inliner requires control to be a single enable. Try running `compile-control` before inlining.".to_string()
+                    "The hole inliner requires control to be a single enable. Try running `top-down-cc` before inlining.".to_string()
                 )
             )
         };

--- a/calyx/src/passes/top_down_compile_control.rs
+++ b/calyx/src/passes/top_down_compile_control.rs
@@ -530,7 +530,10 @@ impl Visitor for TopDownCompileControl {
         sigs: &LibrarySignatures,
     ) -> VisResult {
         // Do not try to compile an enable
-        if matches!(*comp.control.borrow(), ir::Control::Enable(..)) {
+        if matches!(
+            *comp.control.borrow(),
+            ir::Control::Enable(..) | ir::Control::Empty(..)
+        ) {
             return Ok(Action::Stop);
         }
 

--- a/tests/backend/verilog/memory-with-external-attribute.expect
+++ b/tests/backend/verilog/memory-with-external-attribute.expect
@@ -400,7 +400,7 @@ module main (
         .write_en(m1_write_en)
     );
     assign done =
-     1'b1 ? 1'd1 : 1'd0;
+     1'b1 ? m1_done : 1'd0;
     assign m0_clk =
      1'b1 ? clk : 1'd0;
     assign m1_clk =

--- a/tests/backend/verilog/memory-with-external-attribute.futil
+++ b/tests/backend/verilog/memory-with-external-attribute.futil
@@ -5,6 +5,8 @@ component main() -> () {
     m0 = std_mem_d1(32, 4, 4);
     @external(1) m1 = std_mem_d1(32, 4, 4);
   }
-  wires {}
+  wires {
+    done = m1.done;
+  }
   control {}
 }

--- a/tests/errors/papercut-no-control-no-done.expect
+++ b/tests/errors/papercut-no-control-no-done.expect
@@ -1,0 +1,4 @@
+---CODE---
+1
+---STDERR---
+Error: [Papercut] Component `main` has an empty control program and does not assign to the `done` port. Without an assignment to the `done`, the component cannot return control flow.

--- a/tests/errors/papercut-no-control-no-done.futil
+++ b/tests/errors/papercut-no-control-no-done.futil
@@ -1,0 +1,17 @@
+import "primitives/std.lib";
+
+component main(go: 1) -> (done: 1) {
+  // ANCHOR: cells
+  cells {
+    @external(1) mem = std_mem_d1(32, 1, 1);
+  }
+  // ANCHOR_END: cells
+  // ANCHOR: wires
+  wires {
+      mem.addr0 = 1'b0;
+      mem.write_data = 32'd42;
+      mem.write_en = 1'b1;
+  }
+  // ANCHOR_END: wires
+  control {}
+}

--- a/tests/passes/compile-empty.expect
+++ b/tests/passes/compile-empty.expect
@@ -1,13 +1,24 @@
+import "primitives/core.futil";
 component main(go: 1, clk: 1) -> (done: 1) {
   cells {
+    r = std_reg(1);
   }
   wires {
+    group do_incr {
+      r.in = 1'd1;
+      r.write_en = 1'd1;
+      do_incr[done] = r.done;
+    }
     group _empty<"static"=0> {
       _empty[done] = 1'd1;
     }
   }
 
   control {
-    _empty;
+    if r.out with do_incr {
+      do_incr;
+    } else {
+      _empty;
+    }
   }
 }

--- a/tests/passes/compile-empty.futil
+++ b/tests/passes/compile-empty.futil
@@ -1,7 +1,20 @@
 // -p compile-empty
+import "primitives/core.futil";
 
 component main() -> () {
-  cells {}
-  wires {}
-  control {}
+  cells {
+    r = std_reg(1);
+  }
+  wires {
+    group do_incr {
+      r.in = 1'd1;
+      r.write_en = 1'd1;
+      do_incr[done] = r.done;
+    }
+  }
+  control {
+    if r.out with do_incr {
+      do_incr;
+    }
+  }
 }


### PR DESCRIPTION
Fix behavior of compile-empty and other passes when the input program truly has an empty control block.

## TODO

- [x] Papercut check to see if `done` is assigned in the `wires` section if the control block is empty (otherwise the component cannot implement `go`/`done`).
- [x] Test for the behavior.
