### PR TITLE
Parser tweaks

### DIFF
--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -169,16 +169,21 @@ impl FutilParser {
 
         // the below cast is safe since the width must be less than 64 for
         // the given literal to be unrepresentable
-        if num.width == 0 || (num.width < 64 && !(u64::pow(2,num.width as u32) - 1 >= num.val)) {
+        if num.width == 0
+            || (num.width < 64
+                && !(u64::pow(2, num.width as u32) - 1 >= num.val))
+        {
             let lit_str = match num.num_type {
                 NumType::Binary => format!("{:b}", num.val),
                 NumType::Decimal => format!("{}", num.val),
                 NumType::Octal => format!("{:o}", num.val),
-                NumType::Hex => format!("{:x}", num.val)
+                NumType::Hex => format!("{:x}", num.val),
             };
-            let bit_plural = if num.width == 1 {"bit"} else {"bits"};
-            Err(input.error(format!("Cannot represent given literal '{}' in {} {}",
-                    lit_str, num.width, bit_plural)))
+            let bit_plural = if num.width == 1 { "bit" } else { "bits" };
+            Err(input.error(format!(
+                "Cannot represent given literal '{}' in {} {}",
+                lit_str, num.width, bit_plural
+            )))
         } else {
             Ok(num)
         }

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -126,7 +126,7 @@ impl FutilParser {
     }
 
     fn num_lit(input: Node) -> ParseResult<BitNum> {
-        Ok(match_nodes!(
+        let num = match_nodes!(
             input.clone().into_children();
             [bitwidth(width), decimal(val)] => BitNum {
                     width,
@@ -165,7 +165,21 @@ impl FutilParser {
                     )),
                 },
 
-        ))
+        );
+
+        if num.width == 0 || (num.width < 64 && !(u64::pow(2,num.width as u32) >= num.val)) {
+            let lit_str = match num.num_type {
+                NumType::Binary => format!("{:b}", num.val),
+                NumType::Decimal => format!("{}", num.val),
+                NumType::Octal => format!("{:o}", num.val),
+                NumType::Hex => format!("{:x}", num.val)
+            };
+            let bit_plural = if num.width == 1 {"bit"} else {"bits"};
+            Err(input.error(format!("Cannot represent given literal '{}' in {} {}",
+                    lit_str, num.width, bit_plural)))
+        } else {
+            Ok(num)
+        }
     }
 
     fn char(input: Node) -> ParseResult<&str> {

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -167,7 +167,9 @@ impl FutilParser {
 
         );
 
-        if num.width == 0 || (num.width < 64 && !(u64::pow(2,num.width as u32) >= num.val)) {
+        // the below cast is safe since the width must be less than 64 for
+        // the given literal to be unrepresentable
+        if num.width == 0 || (num.width < 64 && !(u64::pow(2,num.width as u32) - 1 >= num.val)) {
             let lit_str = match num.num_type {
                 NumType::Binary => format!("{:b}", num.val),
                 NumType::Decimal => format!("{}", num.val),

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -171,7 +171,7 @@ impl FutilParser {
         // the given literal to be unrepresentable
         if num.width == 0
             || (num.width < 64
-                && !(u64::pow(2, num.width as u32) - 1 >= num.val))
+                && !(u64::pow(2, num.width as u32) > num.val))
         {
             let lit_str = match num.num_type {
                 NumType::Binary => format!("{:b}", num.val),

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -170,8 +170,7 @@ impl FutilParser {
         // the below cast is safe since the width must be less than 64 for
         // the given literal to be unrepresentable
         if num.width == 0
-            || (num.width < 64
-                && !(u64::pow(2, num.width as u32) > num.val))
+            || (num.width < 64 && !(u64::pow(2, num.width as u32) > num.val))
         {
             let lit_str = match num.num_type {
                 NumType::Binary => format!("{:b}", num.val),

--- a/tests/errors/parser/invalid-width.expect
+++ b/tests/errors/parser/invalid-width.expect
@@ -1,0 +1,9 @@
+---CODE---
+1
+---STDERR---
+Error: Calyx Parser:  --> 4:12
+  |
+4 |     r.in = 0'd1;␊
+  |            ^--^
+  |
+  = Cannot represent given literal '1' in 0 bits

--- a/tests/errors/parser/invalid-width.futil
+++ b/tests/errors/parser/invalid-width.futil
@@ -1,0 +1,7 @@
+component main() -> () {
+  cells { }
+  wires {
+    r.in = 0'd1;
+  }
+  control { }
+}

--- a/tests/errors/parser/invalid-width2.expect
+++ b/tests/errors/parser/invalid-width2.expect
@@ -1,0 +1,9 @@
+---CODE---
+1
+---STDERR---
+Error: Calyx Parser:  --> 4:12
+  |
+4 |     r.in = 5'xaa;␊
+  |            ^---^
+  |
+  = Cannot represent given literal 'aa' in 5 bits

--- a/tests/errors/parser/invalid-width2.futil
+++ b/tests/errors/parser/invalid-width2.futil
@@ -1,0 +1,7 @@
+component main() -> () {
+  cells { }
+  wires {
+    r.in = 5'xaa;
+  }
+  control { }
+}

--- a/tests/errors/parser/invalid-width3.expect
+++ b/tests/errors/parser/invalid-width3.expect
@@ -1,0 +1,9 @@
+---CODE---
+1
+---STDERR---
+Error: Calyx Parser:  --> 4:12
+  |
+4 |     r.in = 1'o10;␊
+  |            ^---^
+  |
+  = Cannot represent given literal '10' in 1 bit

--- a/tests/errors/parser/invalid-width3.futil
+++ b/tests/errors/parser/invalid-width3.futil
@@ -1,0 +1,7 @@
+component main() -> () {
+  cells { }
+  wires {
+    r.in = 1'o10;
+  }
+  control { }
+}

--- a/tests/errors/parser/invalid-width4.expect
+++ b/tests/errors/parser/invalid-width4.expect
@@ -1,0 +1,9 @@
+---CODE---
+1
+---STDERR---
+Error: Calyx Parser:  --> 4:12
+  |
+4 |     r.in = 2'd4;␊
+  |            ^--^
+  |
+  = Cannot represent given literal '4' in 2 bits

--- a/tests/errors/parser/invalid-width4.futil
+++ b/tests/errors/parser/invalid-width4.futil
@@ -1,0 +1,7 @@
+component main() -> () {
+  cells { }
+  wires {
+    r.in = 2'd4;
+  }
+  control { }
+}


### PR DESCRIPTION
Adds parser error messages for literals that cannot be represented in the given bitwidth. Closes #438.

Will need to be adjusted later to support zero width literals like `0'null` 