### PR TITLE
Fix tutorial docs + add to contributors

### DIFF
--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -12,6 +12,7 @@ Here is a list of all the people who have worked on Calyx:
 - Chris Gyurgyik
 - Karen Zhang
 - YoungSeok Na
+- Andrii Iermolaiev
 
 **Previous Contributors**
 

--- a/docs/tutorial/language-tut.md
+++ b/docs/tutorial/language-tut.md
@@ -192,7 +192,7 @@ We need to extend our control program to orchestrate the execution of the three 
 We will need a `seq` statement to say we want to the three steps sequentially:
 
 ```
-{{#include ../../examples/tutorial/language-tutorial-compute.futil:cells}}
+{{#include ../../examples/tutorial/language-tutorial-compute.futil:control}}
 ```
 
 Try running this program again.


### PR DESCRIPTION
Old docs referred to cells in the part of the tutorial that referred control.