### PR TITLE
Sharing component perf fix

### DIFF
--- a/calyx/src/analysis/graph_coloring.rs
+++ b/calyx/src/analysis/graph_coloring.rs
@@ -102,14 +102,6 @@ where
 
 impl<T: Eq + Hash + ToString + Clone> ToString for GraphColoring<T> {
     fn to_string(&self) -> String {
-        // self.graph.to_string()
-        format!(
-            "nodes: {:?}",
-            self.graph
-                .index_map
-                .keys()
-                .map(|x| x.to_string())
-                .collect::<Vec<_>>()
-        )
+        self.graph.to_string()
     }
 }

--- a/calyx/src/utils/measure_time.rs
+++ b/calyx/src/utils/measure_time.rs
@@ -1,0 +1,11 @@
+#[macro_export]
+macro_rules! timed {
+    ($name:expr, $body:expr) => {{
+        eprint!("measuring {}: ", $name);
+        let start = std::time::Instant::now();
+        let result = $body;
+        let end = std::time::Instant::now();
+        eprintln!("{:#?}", end - start);
+        result
+    }};
+}

--- a/calyx/src/utils/mod.rs
+++ b/calyx/src/utils/mod.rs
@@ -1,4 +1,5 @@
 //! Shared utilities.
+mod measure_time;
 mod namegenerator;
 mod out_file;
 mod weight_graph;

--- a/calyx/src/utils/weight_graph.rs
+++ b/calyx/src/utils/weight_graph.rs
@@ -55,7 +55,8 @@ where
 {
     fn from(nodes: C) -> Self {
         let mut graph = MatrixGraph::new_undirected();
-        let index_map = nodes.map(|node| (node, graph.add_node(()))).collect();
+        let index_map: HashMap<_, _> =
+            nodes.map(|node| (node, graph.add_node(()))).collect();
         WeightGraph { graph, index_map }
     }
 }

--- a/tools/emacs/futil-mode/futil-mode.el
+++ b/tools/emacs/futil-mode/futil-mode.el
@@ -52,7 +52,7 @@
 
 (setq futil-font-lock-keywords
   (let* ((futil-defn '("component" "cells" "wires" "control" "primitive"))
-         (futil-control '("seq" "par" "if" "while" "else" "with"))
+         (futil-control '("seq" "par" "if" "while" "else" "with" "invoke"))
          (futil-keywords '("prim" "import" "group"))
 
          (futil-defn-regexp (regexp-opt futil-defn 'words))


### PR DESCRIPTION
Fixes resource sharing performance regression (#459) by:
 1) not adding conflict edges between cells of different types
 2) updating graph coloring algorithm to take account of node types when assigning colors to nodes.