### PR TITLE
[Passes] Canonicalizing guard assignments

### DIFF
--- a/calyx/src/default_passes.rs
+++ b/calyx/src/default_passes.rs
@@ -4,6 +4,7 @@ use crate::passes::{
     InferStaticTiming, Inliner, MergeAssign, MinimizeRegs, Papercut,
     ResourceSharing, SimplifyGuards, StaticTiming, SynthesisPapercut,
     TopDownCompileControl, WellFormed,
+    GuardCanonical,
 };
 use crate::{
     errors::FutilResult,
@@ -38,6 +39,7 @@ impl PassManager {
         register_pass!(pm, MergeAssign);
         register_pass!(pm, TopDownCompileControl);
         register_pass!(pm, SynthesisPapercut);
+        register_pass!(pm, GuardCanonical);
 
         register_alias!(pm, "validate", [WellFormed, Papercut]);
         register_alias!(

--- a/calyx/src/ir/guard.rs
+++ b/calyx/src/ir/guard.rs
@@ -66,6 +66,13 @@ impl Hash for Guard {
 
 /// Helper functions for the guard.
 impl Guard {
+    /// Checks whether the guard is Port type.
+    pub fn is_port(&self) -> bool {
+        match self {
+            Guard::True => false,
+            _ => true,
+        }
+    }
     /// Mutates a guard by calling `f` on every leaf in the
     /// guard tree and replacing the leaf with the guard that `f`
     /// returns.

--- a/calyx/src/passes/guard_canonical.rs
+++ b/calyx/src/passes/guard_canonical.rs
@@ -1,0 +1,66 @@
+use crate::ir::{
+    self,
+    traversal::{Action, Named, VisResult, Visitor},
+    LibrarySignatures,
+};
+use crate::errors::Error;
+use crate::ir::Guard;
+
+/// Canonicalizes the guard expression.
+#[derive(Default)]
+pub struct GuardCanonical;
+
+impl Named for GuardCanonical {
+    fn name() -> &'static str {
+        "guard-canonical"
+    }
+
+    fn description() -> &'static str {
+        "canonicalizes the guard expression"
+    }
+}
+
+fn update_assign(assigns: Vec<ir::Assignment>) -> Vec<ir::Assignment> {
+    let mut new_assign : Vec<ir::Assignment> = Vec::new();
+    for assign in assigns {
+        let guard = &mut assign.guard.clone();
+        let src = assign.src.borrow();
+        if guard.is_port() && src.is_constant(1, 1) {
+            let guard_ports = assign.guard.all_ports();
+            for p in guard_ports {
+                let mut changed_assign = assign.clone();
+                changed_assign.guard = Box::new(Guard::True);
+                changed_assign.src = p;
+                new_assign.push(changed_assign);
+            }
+        }
+        else {
+            new_assign.push(assign.clone());
+        }
+    }
+    new_assign
+}
+
+impl Visitor for GuardCanonical {
+    fn start(
+        &mut self,
+        comp: &mut ir::Component,
+        _ctx: &LibrarySignatures,
+    ) -> VisResult {
+        // For each group, canonicalize guard statements that has constant 1 as
+        // either a source or a guard.
+        // # Example
+        // ```
+        // a[done] = 1'd1 ? r1.done
+        //   -> a[done] = r1.done
+        // a[done] = r1.done ? 1'd1
+        //   -> a[done] = r1.done
+        // ```
+        for group in &comp.groups {
+            let new_assign = update_assign(group.borrow_mut().assignments.clone());
+            group.borrow_mut().assignments = new_assign;
+        }
+
+        Ok(Action::Stop)
+    }
+}

--- a/calyx/src/passes/guard_canonical.rs
+++ b/calyx/src/passes/guard_canonical.rs
@@ -3,7 +3,6 @@ use crate::ir::{
     traversal::{Action, Named, VisResult, Visitor},
     LibrarySignatures,
 };
-use crate::errors::Error;
 use crate::ir::Guard;
 
 /// Canonicalizes the guard expression.

--- a/calyx/src/passes/guard_canonical.rs
+++ b/calyx/src/passes/guard_canonical.rs
@@ -46,8 +46,8 @@ impl Visitor for GuardCanonical {
         comp: &mut ir::Component,
         _ctx: &LibrarySignatures,
     ) -> VisResult {
-        // For each group, canonicalize guard statements that has constant 1 as
-        // either a source or a guard.
+        // For each group and continuous assignments, canonicalize guard 
+        // statements that has constant 1 as either a source or a guard.
         // # Example
         // ```
         // a[done] = 1'd1 ? r1.done
@@ -59,6 +59,8 @@ impl Visitor for GuardCanonical {
             let new_assign = update_assign(group.borrow_mut().assignments.clone());
             group.borrow_mut().assignments = new_assign;
         }
+        let new_cont = update_assign(comp.continuous_assignments.clone());
+        comp.continuous_assignments = new_cont;
 
         Ok(Action::Stop)
     }

--- a/calyx/src/passes/mod.rs
+++ b/calyx/src/passes/mod.rs
@@ -21,6 +21,7 @@ mod static_timing;
 mod synthesis_papercut;
 mod top_down_compile_control;
 mod well_formed;
+mod guard_canonical;
 
 pub use clk_insertion::ClkInsertion;
 pub use collapse_control::CollapseControl;
@@ -42,3 +43,4 @@ pub use static_timing::StaticTiming;
 pub use synthesis_papercut::SynthesisPapercut;
 pub use top_down_compile_control::TopDownCompileControl;
 pub use well_formed::WellFormed;
+pub use guard_canonical::GuardCanonical;


### PR DESCRIPTION
This PR attempts to create a pass that would address issue #310 by canonicalizing the guard assignments so that the static timing inference can be done properly. 

Specifically, the guard assignment of the form `a[done] = 1'd1 ? r0.done` and  `a[done] = r0.done ? 1'd1` both get represented as `a[done] = r0.done`.