### PR TITLE
Interpreter cleaning

### DIFF
--- a/calyx/src/ir/id.rs
+++ b/calyx/src/ir/id.rs
@@ -1,5 +1,6 @@
 use crate::errors::Span;
 use derivative::Derivative;
+use serde::Serialize;
 
 /// Represents an identifier in a Futil program
 #[derive(Derivative, Clone, PartialOrd, Ord)]
@@ -68,5 +69,14 @@ impl PartialEq<str> for Id {
 impl<S: AsRef<str>> PartialEq<S> for Id {
     fn eq(&self, other: &S) -> bool {
         self.id == other.as_ref()
+    }
+}
+
+impl Serialize for Id {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.id)
     }
 }

--- a/interp/src/environment.rs
+++ b/interp/src/environment.rs
@@ -126,9 +126,8 @@ impl Environment {
     ///TODO (write to a specified output in the future) We could do the printing
     ///of values here for tracing purposes as discussed. Could also have a
     ///separate DS that we could put the cell states into for more custom tracing
-    pub fn cell_state(&self) {
-        let serialized = serde_json::to_string_pretty(&self).unwrap();
-        println!("{}", serialized);
+    pub fn print_env(&self) {
+        println!("{}", serde_json::to_string_pretty(&self).unwrap());
     }
 }
 

--- a/interp/src/environment.rs
+++ b/interp/src/environment.rs
@@ -27,7 +27,7 @@ impl Environment {
     /// ctx : A context from the IR
     pub fn init(ctx: ir::RRC<ir::Context>) -> Self {
         Self {
-            map: Environment::construct_map(&*ctx.borrow()),
+            map: Environment::construct_map(&ctx.borrow()),
             context: ctx.clone(),
         }
     }

--- a/interp/src/environment.rs
+++ b/interp/src/environment.rs
@@ -7,9 +7,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 //use std::rc::Rc;
 
-// #[derive(Serialize, Debug)]
-// struct Cycle (HashMap<String, HashMap<String, u64>>);
-
 /// The environment to interpret a Calyx program.
 #[derive(Clone, Debug)]
 pub struct Environment {

--- a/interp/src/interpret_component.rs
+++ b/interp/src/interpret_component.rs
@@ -35,7 +35,7 @@ impl ComponentInterpreter {
     pub fn interpret(self) -> FutilResult<Environment> {
         let ci: ControlInterpreter = ControlInterpreter::init(
             self.environment,
-            self.component.name.id.clone(),
+            self.component.name.clone(),
             self.component.control,
         );
         ci.interpret()

--- a/interp/src/interpret_control.rs
+++ b/interp/src/interpret_control.rs
@@ -79,14 +79,14 @@ fn eval_seq(
 /// Interpret Par
 /// at the moment behaves like seq
 fn eval_par(
-    p: &ir::Par,
-    comp: ir::Id,
-    mut env: Environment,
+    _p: &ir::Par,
+    _comp: ir::Id,
+    mut _env: Environment,
 ) -> FutilResult<Environment> {
-    for stmt in &p.stmts {
-        env = eval_control(stmt, comp.clone(), env)?;
-    }
-    Ok(env)
+    // for stmt in &p.stmts {
+    //     env = eval_control(stmt, comp.clone(), env)?;
+    // }
+    todo!()
 }
 
 /// Interpret If
@@ -98,9 +98,8 @@ fn eval_if(
     //first set the environment for cond
     env = interpreter::eval_group(i.cond.clone(), env, comp.clone())?;
 
-    let cid = ir::Id::from(comp.clone());
     // if i.port is not high fbranch else tbranch
-    if env.get_from_port(&cid, &i.port.borrow()) == 0 {
+    if env.get_from_port(&comp, &i.port.borrow()) == 0 {
         env = eval_control(&i.fbranch, comp, env)?;
         Ok(env)
     } else {
@@ -137,9 +136,9 @@ fn eval_while(
 fn eval_invoke(
     _i: &ir::Invoke,
     _comp: ir::Id,
-    env: Environment,
+    _env: Environment,
 ) -> FutilResult<Environment> {
-    Ok(env)
+    todo!()
 }
 
 /// Interpret Enable

--- a/interp/src/interpret_control.rs
+++ b/interp/src/interpret_control.rs
@@ -119,11 +119,10 @@ fn eval_while(
     comp: ir::Id,
     mut env: Environment,
 ) -> FutilResult<Environment> {
-    let cid = ir::Id::from(comp.clone());
     // currently ports don't update properly in mutli-cycle and runs into infinite loop
     // count needs to be removed when the infinite loop problem is fixed
     let mut count = 0;
-    while env.get_from_port(&cid, &w.port.borrow()) != 1 && count < 5 {
+    while env.get_from_port(&comp, &w.port.borrow()) != 1 && count < 5 {
         env = eval_control(&w.body, comp.clone(), env)?;
         env = interpreter::eval_group(w.cond.clone(), env, comp.clone())?;
         // count needs to be remved

--- a/interp/src/interpret_control.rs
+++ b/interp/src/interpret_control.rs
@@ -14,7 +14,7 @@ pub struct ControlInterpreter {
 
     /// The component the control belongs to
     // XX(2/25 meeting): we might not need this? all the information is in the IR
-    pub component: String,
+    pub component: ir::Id,
 
     /// The control to interpret
     pub control: ir::RRC<ir::Control>,
@@ -27,7 +27,7 @@ impl ControlInterpreter {
     /// ctrl : The control to interpret
     pub fn init(
         env: Environment,
-        comp: String,
+        comp: ir::Id,
         ctrl: ir::RRC<ir::Control>,
     ) -> Self {
         Self {
@@ -50,7 +50,7 @@ impl ControlInterpreter {
 /// Helper function to evaluate control
 fn eval_control(
     ctrl: &ir::Control,
-    comp: String,
+    comp: ir::Id,
     env: Environment,
 ) -> FutilResult<Environment> {
     match ctrl {
@@ -67,7 +67,7 @@ fn eval_control(
 /// Interpret Seq
 fn eval_seq(
     s: &ir::Seq,
-    comp: String,
+    comp: ir::Id,
     mut env: Environment,
 ) -> FutilResult<Environment> {
     for stmt in &s.stmts {
@@ -80,7 +80,7 @@ fn eval_seq(
 /// at the moment behaves like seq
 fn eval_par(
     p: &ir::Par,
-    comp: String,
+    comp: ir::Id,
     mut env: Environment,
 ) -> FutilResult<Environment> {
     for stmt in &p.stmts {
@@ -92,7 +92,7 @@ fn eval_par(
 /// Interpret If
 fn eval_if(
     i: &ir::If,
-    comp: String,
+    comp: ir::Id,
     mut env: Environment,
 ) -> FutilResult<Environment> {
     //first set the environment for cond
@@ -116,7 +116,7 @@ fn eval_if(
 // using cond_group.
 fn eval_while(
     w: &ir::While,
-    comp: String,
+    comp: ir::Id,
     mut env: Environment,
 ) -> FutilResult<Environment> {
     let cid = ir::Id::from(comp.clone());
@@ -137,7 +137,7 @@ fn eval_while(
 #[allow(clippy::unnecessary_wraps)]
 fn eval_invoke(
     _i: &ir::Invoke,
-    _comp: String,
+    _comp: ir::Id,
     env: Environment,
 ) -> FutilResult<Environment> {
     Ok(env)
@@ -146,7 +146,7 @@ fn eval_invoke(
 /// Interpret Enable
 fn eval_enable(
     e: &ir::Enable,
-    comp: String,
+    comp: ir::Id,
     env: Environment,
 ) -> FutilResult<Environment> {
     let gp = Rc::clone(&(e.group));
@@ -162,7 +162,7 @@ fn eval_enable(
 #[allow(clippy::unnecessary_wraps)]
 fn eval_empty(
     _e: &ir::Empty,
-    _comp: String,
+    _comp: ir::Id,
     env: Environment,
 ) -> FutilResult<Environment> {
     Ok(env)

--- a/interp/src/interpret_group.rs
+++ b/interp/src/interpret_group.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 /// Might be better to make this a subset of a trait implemented by all interpreters, later on
 pub struct GroupInterpreter {
     /// The name of the component with the group to interpret
-    pub component: String,
+    pub component: ir::Id,
     /// The group to interpret
     pub group: ir::RRC<ir::Group>,
     /// The environment for the interpreter.
@@ -26,7 +26,7 @@ impl GroupInterpreter {
     /// grp: The group to interpret
     /// env: The initial environment
     pub fn init(
-        comp: String,
+        comp: ir::Id,
         grp: ir::RRC<ir::Group>,
         env: Environment,
     ) -> Self {

--- a/interp/src/interpret_group.rs
+++ b/interp/src/interpret_group.rs
@@ -49,7 +49,7 @@ impl GroupInterpreter {
             self.component,
         )?;
         // Print out final state of environment
-        finalenv.cell_state();
+        finalenv.print_env();
         Ok(finalenv)
     }
 }

--- a/interp/src/interpreter.rs
+++ b/interp/src/interpreter.rs
@@ -8,7 +8,7 @@ use calyx::{errors::FutilResult, ir};
 pub fn eval_group(
     group: ir::RRC<ir::Group>,
     env: Environment,
-    component: String,
+    component: ir::Id,
 ) -> FutilResult<Environment> {
     eval_assigns(&(group.borrow()).assignments, env, component)
 }
@@ -27,7 +27,7 @@ pub fn eval_group(
 fn eval_assigns(
     assigns: &[ir::Assignment],
     mut env: Environment,
-    component: String,
+    component: ir::Id,
 ) -> FutilResult<Environment> {
     let cid = ir::Id::from(component.clone());
 

--- a/interp/src/primitives.rs
+++ b/interp/src/primitives.rs
@@ -12,7 +12,7 @@ pub fn update_cell_state(
     inputs: &[ir::Id],
     output: &[ir::Id],
     env: &Environment, // should this be a reference
-    component: String,
+    component: ir::Id,
 ) -> FutilResult<Environment> {
     // get the actual cell, based on the id
     // let cell_r = cell.as_ref();

--- a/interp/src/update.rs
+++ b/interp/src/update.rs
@@ -13,19 +13,19 @@ pub struct Update {
     pub outputs: Vec<ir::Id>,
     /// Map of intermediate variables
     /// (could refer to a port or it could be "new", e.g. in the sqrt)
-    pub vars: HashMap<String, u64>,
+    pub vars: HashMap<ir::Id, u64>,
 }
 
 /// Queue of updates.
 #[derive(Clone, Debug)]
 pub struct UpdateQueue {
-    pub component: String,
+    pub component: ir::Id,
     pub updates: Vec<Update>,
 }
 
 impl UpdateQueue {
     // TODO: incomplete
-    pub fn init(component: String) -> Self {
+    pub fn init(component: ir::Id) -> Self {
         Self {
             component,
             updates: Vec::new(),
@@ -46,7 +46,7 @@ impl UpdateQueue {
         env: Environment,
     ) -> Self {
         let cell_r = env
-            .get_cell(&ir::Id::from(self.component.clone()), cell)
+            .get_cell(&self.component, cell)
             .unwrap_or_else(|| panic!("Cannot find cell with name"));
         // get the cell type
         match cell_r.borrow().type_name() {
@@ -56,12 +56,12 @@ impl UpdateQueue {
                      // has intermediate steps/computation
                 }
                 "std_reg" => {
-                    let map: HashMap<String, u64> = HashMap::new();
+                    let map: HashMap<ir::Id, u64> = HashMap::new();
                     // reg.in = dst port should go here
                     self.add_update(cell.clone(), inputs, outputs, map);
                 }
                 "std_mem_d1" => {
-                    let map: HashMap<String, u64> = HashMap::new();
+                    let map: HashMap<ir::Id, u64> = HashMap::new();
                     self.add_update(cell.clone(), inputs, outputs, map);
                 }
                 _ => panic!(
@@ -78,7 +78,7 @@ impl UpdateQueue {
         ucell: ir::Id,
         uinput: Vec<ir::Id>,
         uoutput: Vec<ir::Id>,
-        uvars: HashMap<String, u64>,
+        uvars: HashMap<ir::Id, u64>,
     ) {
         //println!("add update!");
         let update = Update {


### PR DESCRIPTION
Just a series of small changes to clean up various pieces of the existing interpreter code. Replacing the custom printing structure with a direct implementation of serde serialize. Adding `todo!()` in a few places. Replacing use of `String` w/ `ir::Id` where appropriate and removing some code made obsolete by this change.