### PR TITLE
Interpreter cleaning (#521)

### DIFF
--- a/calyx/src/ir/id.rs
+++ b/calyx/src/ir/id.rs
@@ -1,5 +1,6 @@
 use crate::errors::Span;
 use derivative::Derivative;
+use serde::Serialize;
 
 /// Represents an identifier in a Futil program
 #[derive(Derivative, Clone, PartialOrd, Ord)]
@@ -68,5 +69,14 @@ impl PartialEq<str> for Id {
 impl<S: AsRef<str>> PartialEq<S> for Id {
     fn eq(&self, other: &S) -> bool {
         self.id == other.as_ref()
+    }
+}
+
+impl Serialize for Id {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.id)
     }
 }

--- a/interp/src/environment.rs
+++ b/interp/src/environment.rs
@@ -7,11 +7,6 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 //use std::rc::Rc;
 
-// #[derive(Serialize, Debug)]
-// struct Cycle (HashMap<String, HashMap<String, u64>>);
-#[derive(Serialize, Debug)]
-struct Cycle(BTreeMap<String, BTreeMap<String, BTreeMap<String, u64>>>);
-
 /// The environment to interpret a Calyx program.
 #[derive(Clone, Debug)]
 pub struct Environment {
@@ -29,7 +24,7 @@ impl Environment {
     /// ctx : A context from the IR
     pub fn init(ctx: ir::RRC<ir::Context>) -> Self {
         Self {
-            map: Environment::construct_map(&*ctx.borrow()),
+            map: Environment::construct_map(&ctx.borrow()),
             context: ctx.clone(),
         }
     }
@@ -128,37 +123,31 @@ impl Environment {
     ///TODO (write to a specified output in the future) We could do the printing
     ///of values here for tracing purposes as discussed. Could also have a
     ///separate DS that we could put the cell states into for more custom tracing
-    pub fn cell_state(&self) {
-        let mut cyc1: BTreeMap<
-            String,
-            BTreeMap<String, BTreeMap<String, u64>>,
-        > = BTreeMap::new();
-        // component id to component cell mappings
-        for (key, value) in &self.map {
-            //println!("{}",key.to_string());
-            let mut cyc2 = BTreeMap::new();
-            // component cell to component port id mappings
-            for (k, v) in value {
-                let mut cyc3 = BTreeMap::new();
-                // port id to port value mappings
-                for (p, i) in v {
-                    cyc3.insert(p.to_string(), *i);
-                }
-                // println!("{}",k.to_string());
-                cyc2.insert(k.to_string(), cyc3);
-            }
-            cyc1.insert(key.to_string(), cyc2);
-        }
+    pub fn print_env(&self) {
+        println!("{}", serde_json::to_string_pretty(&self).unwrap());
+    }
+}
 
-        let state_str = Cycle(cyc1);
-
-        // for (key, value) in &cyc1 {
-        //     println!("{}", key);
-        //     for (k,v) in value{
-        //         println!("{}: {}", k, v);
-        //     }
-        // }
-        let serialized = serde_json::to_string(&state_str).unwrap();
-        println!("{}", serialized);
+impl Serialize for Environment {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // use collect to make the nested hashmap a nested btreemap
+        let ordered: BTreeMap<_, _> = self
+            .map
+            .iter()
+            .map(|(id, map)| {
+                let inner_map: BTreeMap<_, _> = map
+                    .iter()
+                    .map(|(id, map)| {
+                        let inner_map: BTreeMap<_, _> = map.iter().collect();
+                        (id, inner_map)
+                    })
+                    .collect();
+                (id, inner_map)
+            })
+            .collect();
+        ordered.serialize(serializer)
     }
 }

--- a/interp/src/interpret_component.rs
+++ b/interp/src/interpret_component.rs
@@ -35,7 +35,7 @@ impl ComponentInterpreter {
     pub fn interpret(self) -> FutilResult<Environment> {
         let ci: ControlInterpreter = ControlInterpreter::init(
             self.environment,
-            self.component.name.id.clone(),
+            self.component.name.clone(),
             self.component.control,
         );
         ci.interpret()

--- a/interp/src/interpret_group.rs
+++ b/interp/src/interpret_group.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 /// Might be better to make this a subset of a trait implemented by all interpreters, later on
 pub struct GroupInterpreter {
     /// The name of the component with the group to interpret
-    pub component: String,
+    pub component: ir::Id,
     /// The group to interpret
     pub group: ir::RRC<ir::Group>,
     /// The environment for the interpreter.
@@ -26,7 +26,7 @@ impl GroupInterpreter {
     /// grp: The group to interpret
     /// env: The initial environment
     pub fn init(
-        comp: String,
+        comp: ir::Id,
         grp: ir::RRC<ir::Group>,
         env: Environment,
     ) -> Self {
@@ -49,7 +49,7 @@ impl GroupInterpreter {
             self.component,
         )?;
         // Print out final state of environment
-        finalenv.cell_state();
+        finalenv.print_env();
         Ok(finalenv)
     }
 }

--- a/interp/src/interpreter.rs
+++ b/interp/src/interpreter.rs
@@ -8,7 +8,7 @@ use calyx::{errors::FutilResult, ir};
 pub fn eval_group(
     group: ir::RRC<ir::Group>,
     env: Environment,
-    component: String,
+    component: ir::Id,
 ) -> FutilResult<Environment> {
     eval_assigns(&(group.borrow()).assignments, env, component)
 }
@@ -27,10 +27,8 @@ pub fn eval_group(
 fn eval_assigns(
     assigns: &[ir::Assignment],
     mut env: Environment,
-    component: String,
+    component: ir::Id,
 ) -> FutilResult<Environment> {
-    let cid = ir::Id::from(component.clone());
-
     // Find the done signal in the sequence of assignments
     let done_assign = get_done_signal(assigns);
 
@@ -49,21 +47,21 @@ fn eval_assigns(
         .filter(|&a| {
             !a.dst.borrow().is_hole()
                 // dummy way of making sure the map has the a.src cell
-                && env.get_cell(&cid, &get_cell_from_port(&a.src)).is_some()
-                && env.get_cell(&cid, &get_cell_from_port(&a.dst)).is_some()
+                && env.get_cell(&component, &get_cell_from_port(&a.src)).is_some()
+                && env.get_cell(&component, &get_cell_from_port(&a.dst)).is_some()
         })
         .collect::<Vec<_>>();
 
     // XXX(yoona): At the moment interpreter rejects direct assignment of 1 to the groups
     // needs to be fixed
-    if write_env.get_from_port(&cid, &done_assign.src.borrow()) == 1 {
+    if write_env.get_from_port(&component, &done_assign.src.borrow()) == 1 {
         panic!("TODO: done[group]=1 this group woud but be evaluated ");
     }
 
     // While done_assign.src is 0
     // (we use done_assign.src because done_assign.dst is not a cell's port; it should be a group's port
 
-    while write_env.get_from_port(&cid, &done_assign.src.borrow()) == 0
+    while write_env.get_from_port(&component, &done_assign.src.borrow()) == 0
         && counter < 5
     {
         env = write_env.clone();
@@ -76,7 +74,7 @@ fn eval_assigns(
         for assign in &ok_assigns {
             // check if the assign.guard != 0
             // should it be evaluating the guard in write_env environment?
-            if eval_guard(&cid, &assign.guard, &write_env) != 0 {
+            if eval_guard(&component, &assign.guard, &write_env) != 0 {
                 // check if the cells are constants?
                 // cell of assign.src
                 let src_cell = get_cell_from_port(&assign.src);
@@ -85,7 +83,8 @@ fn eval_assigns(
 
                 // perform a read from `env` for assign.src
                 // XXX(karen): should read from the previous iteration's env?
-                let read_val = env.get_from_port(&cid, &assign.src.borrow());
+                let read_val =
+                    env.get_from_port(&component, &assign.src.borrow());
 
                 // update internal state of the cell and
                 // queue any required updates.
@@ -93,13 +92,13 @@ fn eval_assigns(
                 //determine if dst_cell is a combinational cell or not.
                 // If so, it should be immediately evaluated and stored.
                 if is_combinational(
-                    &cid,
+                    &component,
                     &dst_cell,
                     &assign.dst.borrow().name,
                     &env,
                 ) {
                     write_env.put(
-                        &cid,
+                        &component,
                         &dst_cell,
                         &assign.dst.borrow().name,
                         read_val,
@@ -115,7 +114,7 @@ fn eval_assigns(
                     // Also, how to get input and output vectors in general??
                     if &assign.dst.borrow().name != "write_en" {
                         // get dst_cell's input vector
-                        match &write_env.get_cell(&cid, &dst_cell) {
+                        match &write_env.get_cell(&component, &dst_cell) {
                             Some(cell) => {
                                 inputs = vec![
                                     (cell.borrow())
@@ -134,7 +133,7 @@ fn eval_assigns(
                         }
 
                         // get dst_cell's output vector
-                        match &write_env.get_cell(&cid, &dst_cell) {
+                        match &write_env.get_cell(&component, &dst_cell) {
                             Some(cell) => {
                                 outputs = vec![(cell.borrow())
                                     .get("out")

--- a/interp/src/primitives.rs
+++ b/interp/src/primitives.rs
@@ -12,17 +12,15 @@ pub fn update_cell_state(
     inputs: &[ir::Id],
     output: &[ir::Id],
     env: &Environment, // should this be a reference
-    component: String,
+    component: ir::Id,
 ) -> FutilResult<Environment> {
     // get the actual cell, based on the id
     // let cell_r = cell.as_ref();
 
     let mut new_env = env.clone();
 
-    let cid = ir::Id::from(component);
-
     let cell_r = new_env
-        .get_cell(&cid, cell)
+        .get_cell(&component, cell)
         .unwrap_or_else(|| panic!("Cannot find cell with name"));
 
     let temp = cell_r.borrow();
@@ -36,27 +34,27 @@ pub fn update_cell_state(
             let write_en = ir::Id::from("write_en");
 
             // register's write_en must be high to write reg.out and reg.done
-            if new_env.get(&cid, &cell, &write_en) != 0 {
+            if new_env.get(&component, &cell, &write_en) != 0 {
                 let out = ir::Id::from("out"); //assuming reg.in = cell.out, always
                 let inp = ir::Id::from("in"); //assuming reg.in = cell.out, always
                 let done = ir::Id::from("done"); //done id
 
                 new_env.put(
-                    &cid,
+                    &component,
                     cell,
                     &output[0],
-                    env.get(&cid, &inputs[0], &out),
+                    env.get(&component, &inputs[0], &out),
                 ); //reg.in = cell.out; should this be in init?
 
                 if output[0].id == "in" {
                     new_env.put(
-                        &cid,
+                        &component,
                         cell,
                         &out,
-                        new_env.get(&cid, cell, &inp),
+                        new_env.get(&component, cell, &inp),
                     ); // reg.out = reg.in
-                    new_env.put(&cid, cell, &done, 1); // reg.done = 1'd1
-                                                       //new_env.remove_update(cell); // remove from update queue
+                    new_env.put(&component, cell, &done, 1); // reg.done = 1'd1
+                                                             //new_env.remove_update(cell); // remove from update queue
                 }
             }
         }
@@ -67,19 +65,19 @@ pub fn update_cell_state(
             let done = ir::Id::from("done"); //done id
 
             // memory should write to addres
-            if new_env.get(&cid, &cell, &write_en) != 0 {
+            if new_env.get(&component, &cell, &write_en) != 0 {
                 let addr0 = ir::Id::from("addr0");
                 let _read_data = ir::Id::from("read_data");
                 let write_data = ir::Id::from("write_data");
 
                 new_env.put(
-                    &cid,
+                    &component,
                     cell,
                     &output[0],
-                    env.get(&cid, &inputs[0], &out),
+                    env.get(&component, &inputs[0], &out),
                 );
 
-                let data = new_env.get(&cid, cell, &write_data);
+                let data = new_env.get(&component, cell, &write_data);
                 mem.insert(addr0, data);
             }
             // read data
@@ -91,9 +89,9 @@ pub fn update_cell_state(
                     _ => panic!("nothing in the memory"),
                 };
 
-                new_env.put(&cid, cell, &output[0], dat);
+                new_env.put(&component, cell, &output[0], dat);
             }
-            new_env.put(&cid, cell, &done, 1);
+            new_env.put(&component, cell, &done, 1);
         }
         "std_sqrt" => {
             //TODO; wrong implementation
@@ -104,119 +102,119 @@ pub fn update_cell_state(
             // );
         }
         "std_add" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            new_env.get(&cid, cell, &inputs[0])
-                + env.get(&cid, cell, &inputs[1]),
+            new_env.get(&component, cell, &inputs[0])
+                + env.get(&component, cell, &inputs[1]),
         ),
         "std_sub" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            new_env.get(&cid, cell, &inputs[0])
-                - env.get(&cid, cell, &inputs[1]),
+            new_env.get(&component, cell, &inputs[0])
+                - env.get(&component, cell, &inputs[1]),
         ),
         "std_mod" => {
-            if env.get(&cid, cell, &inputs[1]) != 0 {
+            if env.get(&component, cell, &inputs[1]) != 0 {
                 new_env.put(
-                    &cid,
+                    &component,
                     cell,
                     &output[0],
-                    new_env.get(&cid, cell, &inputs[0])
-                        % env.get(&cid, cell, &inputs[1]),
+                    new_env.get(&component, cell, &inputs[0])
+                        % env.get(&component, cell, &inputs[1]),
                 )
             }
         }
         "std_mult" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            new_env.get(&cid, cell, &inputs[0])
-                * env.get(&cid, cell, &inputs[1]),
+            new_env.get(&component, cell, &inputs[0])
+                * env.get(&component, cell, &inputs[1]),
         ),
         "std_div" => {
             // need this condition to avoid divide by 0
             // (e.g. if only one of left/right ports has been updated from the initial nonzero value?)
             // TODO: what if the program specifies a divide by 0? how to catch??
-            if env.get(&cid, cell, &inputs[1]) != 0 {
+            if env.get(&component, cell, &inputs[1]) != 0 {
                 new_env.put(
-                    &cid,
+                    &component,
                     cell,
                     &output[0],
-                    new_env.get(&cid, cell, &inputs[0])
-                        / env.get(&cid, cell, &inputs[1]),
+                    new_env.get(&component, cell, &inputs[0])
+                        / env.get(&component, cell, &inputs[1]),
                 )
             }
         }
         "std_not" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            !new_env.get(&cid, cell, &inputs[0]),
+            !new_env.get(&component, cell, &inputs[0]),
         ),
         "std_and" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            new_env.get(&cid, cell, &inputs[0])
-                & env.get(&cid, cell, &inputs[1]),
+            new_env.get(&component, cell, &inputs[0])
+                & env.get(&component, cell, &inputs[1]),
         ),
         "std_or" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            new_env.get(&cid, cell, &inputs[0])
-                | env.get(&cid, cell, &inputs[1]),
+            new_env.get(&component, cell, &inputs[0])
+                | env.get(&component, cell, &inputs[1]),
         ),
         "std_xor" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            new_env.get(&cid, cell, &inputs[0])
-                ^ env.get(&cid, cell, &inputs[1]),
+            new_env.get(&component, cell, &inputs[0])
+                ^ env.get(&component, cell, &inputs[1]),
         ),
         "std_gt" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            (new_env.get(&cid, cell, &inputs[0])
-                > env.get(&cid, cell, &inputs[1])) as u64,
+            (new_env.get(&component, cell, &inputs[0])
+                > env.get(&component, cell, &inputs[1])) as u64,
         ),
         "std_lt" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            (new_env.get(&cid, cell, &inputs[0])
-                < env.get(&cid, cell, &inputs[1])) as u64,
+            (new_env.get(&component, cell, &inputs[0])
+                < env.get(&component, cell, &inputs[1])) as u64,
         ),
         "std_eq" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            (new_env.get(&cid, cell, &inputs[0])
-                == env.get(&cid, cell, &inputs[1])) as u64,
+            (new_env.get(&component, cell, &inputs[0])
+                == env.get(&component, cell, &inputs[1])) as u64,
         ),
         "std_neq" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            (new_env.get(&cid, cell, &inputs[0])
-                != env.get(&cid, cell, &inputs[1])) as u64,
+            (new_env.get(&component, cell, &inputs[0])
+                != env.get(&component, cell, &inputs[1])) as u64,
         ),
         "std_ge" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            (new_env.get(&cid, cell, &inputs[0])
-                >= env.get(&cid, cell, &inputs[1])) as u64,
+            (new_env.get(&component, cell, &inputs[0])
+                >= env.get(&component, cell, &inputs[1])) as u64,
         ),
         "std_le" => new_env.put(
-            &cid,
+            &component,
             cell,
             &output[0],
-            (new_env.get(&cid, cell, &inputs[0])
-                <= env.get(&cid, cell, &inputs[1])) as u64,
+            (new_env.get(&component, cell, &inputs[0])
+                <= env.get(&component, cell, &inputs[1])) as u64,
         ),
         _ => unimplemented!("{}", cell_type),
     }

--- a/interp/src/update.rs
+++ b/interp/src/update.rs
@@ -13,19 +13,19 @@ pub struct Update {
     pub outputs: Vec<ir::Id>,
     /// Map of intermediate variables
     /// (could refer to a port or it could be "new", e.g. in the sqrt)
-    pub vars: HashMap<String, u64>,
+    pub vars: HashMap<ir::Id, u64>,
 }
 
 /// Queue of updates.
 #[derive(Clone, Debug)]
 pub struct UpdateQueue {
-    pub component: String,
+    pub component: ir::Id,
     pub updates: Vec<Update>,
 }
 
 impl UpdateQueue {
     // TODO: incomplete
-    pub fn init(component: String) -> Self {
+    pub fn init(component: ir::Id) -> Self {
         Self {
             component,
             updates: Vec::new(),
@@ -46,7 +46,7 @@ impl UpdateQueue {
         env: Environment,
     ) -> Self {
         let cell_r = env
-            .get_cell(&ir::Id::from(self.component.clone()), cell)
+            .get_cell(&self.component, cell)
             .unwrap_or_else(|| panic!("Cannot find cell with name"));
         // get the cell type
         match cell_r.borrow().type_name() {
@@ -56,12 +56,12 @@ impl UpdateQueue {
                      // has intermediate steps/computation
                 }
                 "std_reg" => {
-                    let map: HashMap<String, u64> = HashMap::new();
+                    let map: HashMap<ir::Id, u64> = HashMap::new();
                     // reg.in = dst port should go here
                     self.add_update(cell.clone(), inputs, outputs, map);
                 }
                 "std_mem_d1" => {
-                    let map: HashMap<String, u64> = HashMap::new();
+                    let map: HashMap<ir::Id, u64> = HashMap::new();
                     self.add_update(cell.clone(), inputs, outputs, map);
                 }
                 _ => panic!(
@@ -78,7 +78,7 @@ impl UpdateQueue {
         ucell: ir::Id,
         uinput: Vec<ir::Id>,
         uoutput: Vec<ir::Id>,
-        uvars: HashMap<String, u64>,
+        uvars: HashMap<ir::Id, u64>,
     ) {
         //println!("add update!");
         let update = Update {


### PR DESCRIPTION
* Use serde serialization for environment, rather than adding new custom structs

* rename print function

* unnecessary *

* replace String with Id

* remove comment

* tiny fix

* replace unimplemented control statements with !todo()

* last fix related to removing string for id