### PR TITLE
Unsharing bug

### DIFF
--- a/calyx/src/analysis/reaching_defns.rs
+++ b/calyx/src/analysis/reaching_defns.rs
@@ -384,13 +384,17 @@ fn build_reaching_def(
             );
             // Run the analysis a second time to get the fixed point of the
             // while loop using the defsets calculated during the first iteration
-            build_reaching_def(
+            let (final_def, mut final_kill) = build_reaching_def(
                 body,
-                post_cond2_def,
+                post_cond2_def.clone(),
                 post_cond2_killed,
                 rd,
                 counter,
-            )
+            );
+
+            remove_entries_defined_by(&mut final_kill, &post_cond2_def);
+
+            (&final_def | &post_cond2_def, final_kill)
         }
         ir::Control::Invoke(invoke) => {
             *counter += 1;

--- a/calyx/src/analysis/reaching_defns.rs
+++ b/calyx/src/analysis/reaching_defns.rs
@@ -354,14 +354,14 @@ fn build_reaching_def(
 
             let (round_1_def, round_1_killed) = build_reaching_def(
                 body,
-                post_cond_def,
+                post_cond_def.clone(),
                 post_cond_killed,
                 rd,
                 counter,
             );
             let (post_cond2_def, post_cond2_killed) = build_reaching_def(
                 &fake_enable,
-                round_1_def,
+                &round_1_def | &post_cond_def,
                 round_1_killed,
                 rd,
                 counter,

--- a/calyx/src/analysis/reaching_defns.rs
+++ b/calyx/src/analysis/reaching_defns.rs
@@ -274,6 +274,14 @@ impl ReachingDefinitionAnalysis {
 
 type KilledSet = BTreeSet<ir::Id>;
 
+fn remove_entries_defined_by(set: &mut KilledSet, defs: &DefSet) {
+    let tmp_set: BTreeSet<_> = defs.set.iter().map(|(id, _)| id).collect();
+    *set = std::mem::take(set)
+        .into_iter()
+        .filter(|x| !tmp_set.contains(x))
+        .collect();
+}
+
 fn build_reaching_def(
     c: &ir::Control,
     reach: DefSet,
@@ -349,19 +357,27 @@ fn build_reaching_def(
                 attributes: ir::Attributes::default(),
                 group: Rc::clone(cond),
             });
-            let (post_cond_def, post_cond_killed) =
-                build_reaching_def(&fake_enable, reach, killed, rd, counter);
+            let (post_cond_def, post_cond_killed) = build_reaching_def(
+                &fake_enable,
+                reach.clone(),
+                killed,
+                rd,
+                counter,
+            );
 
-            let (round_1_def, round_1_killed) = build_reaching_def(
+            let (round_1_def, mut round_1_killed) = build_reaching_def(
                 body,
-                post_cond_def.clone(),
+                post_cond_def,
                 post_cond_killed,
                 rd,
                 counter,
             );
+
+            remove_entries_defined_by(&mut round_1_killed, &reach);
+
             let (post_cond2_def, post_cond2_killed) = build_reaching_def(
                 &fake_enable,
-                &round_1_def | &post_cond_def,
+                &round_1_def | &reach,
                 round_1_killed,
                 rd,
                 counter,

--- a/tests/passes/unsharing/while.expect
+++ b/tests/passes/unsharing/while.expect
@@ -7,13 +7,12 @@ component main(go: 1, clk: 1) -> (done: 1) {
     other = std_reg(32);
     unshr_r = std_reg(32);
     unshr_r0 = std_reg(32);
-    unshr_r1 = std_reg(32);
   }
   wires {
     group zero {
-      unshr_r1.in = 32'd0;
-      unshr_r1.write_en = 1'd1;
-      zero[done] = unshr_r1.done;
+      unshr_r0.in = 32'd0;
+      unshr_r0.write_en = 1'd1;
+      zero[done] = unshr_r0.done;
     }
     group one {
       unshr_r0.in = 32'd1;


### PR DESCRIPTION
Tiny patch for #526. The issue was the analysis not being appropriately conservative with respect to the while loop and allowing the while loop to kill definitions that should not be killed due to being re-introduced through the cond (i.e. not assuming that the while always runs).

This wasn't noticed previously because the test happened to still be correct with this non-conservative assumption. 

@rachitnigam if you could re-run your benchmark tests or point me in the right direction, I would be very grateful.