### PR TITLE
Support bare @ attribute syntax

### DIFF
--- a/calyx/src/frontend/futil_syntax.pest
+++ b/calyx/src/frontend/futil_syntax.pest
@@ -190,8 +190,11 @@ attributes = {
 }
 
 // @static(1) style annotation
+attr_val = {
+  "(" ~ bitwidth ~ ")"
+}
 at_attribute = {
-      "@" ~ identifier ~ "(" ~ bitwidth ~ ")"
+      "@" ~ identifier ~ attr_val?
 }
 at_attributes = {
       at_attribute*

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -217,10 +217,18 @@ impl FutilParser {
         ))
     }
 
+    fn attr_val(input: Node) -> ParseResult<u64> {
+        Ok(match_nodes!(
+            input.into_children();
+            [bitwidth(num)] => num
+        ))
+    }
+
     fn at_attribute(input: Node) -> ParseResult<(String, u64)> {
         Ok(match_nodes!(
             input.into_children();
-            [identifier(key), bitwidth(num)] => (key.id, num)
+            [identifier(key), attr_val(num)] => (key.id, num),
+            [identifier(key)] => (key.id, 1)
         ))
     }
 

--- a/calyx/src/ir/printer.rs
+++ b/calyx/src/ir/printer.rs
@@ -15,7 +15,13 @@ impl IRPrinter {
         attrs
             .attrs
             .iter()
-            .map(|(k, v)| format!("@{}({})", k, v))
+            .map(|(k, v)| {
+                if *v == 1 {
+                    format!("@{}", k)
+                } else {
+                    format!("@{}({})", k, v)
+                }
+            })
             .collect::<Vec<_>>()
             .join(" ")
     }

--- a/examples/futil/dot-product.expect
+++ b/examples/futil/dot-product.expect
@@ -1,9 +1,9 @@
 import "primitives/std.lib";
 component main(go: 1, clk: 1) -> (done: 1) {
   cells {
-    @external(1) A0 = std_mem_d1(32, 8, 4);
+    @external A0 = std_mem_d1(32, 8, 4);
     A_read0_0 = std_reg(32);
-    @external(1) B0 = std_mem_d1(32, 8, 4);
+    @external B0 = std_mem_d1(32, 8, 4);
     B_read0_0 = std_reg(32);
     add0 = std_add(32);
     add1 = std_add(4);
@@ -16,7 +16,7 @@ component main(go: 1, clk: 1) -> (done: 1) {
     i0 = std_reg(4);
     le0 = std_le(4);
     mult_pipe0 = std_mult_pipe(32);
-    @external(1) v0 = std_mem_d1(32, 1, 1);
+    @external v0 = std_mem_d1(32, 1, 1);
     fsm = std_reg(1);
     incr = std_add(1);
     fsm0 = std_reg(4);

--- a/examples/futil/vectorized-add.expect
+++ b/examples/futil/vectorized-add.expect
@@ -1,11 +1,11 @@
 import "primitives/std.lib";
 component main(go: 1, clk: 1) -> (done: 1) {
   cells {
-    @external(1) A0 = std_mem_d1(32, 8, 4);
+    @external A0 = std_mem_d1(32, 8, 4);
     A_read0_0 = std_reg(32);
-    @external(1) B0 = std_mem_d1(32, 8, 4);
+    @external B0 = std_mem_d1(32, 8, 4);
     B_read0_0 = std_reg(32);
-    @external(1) Sum0 = std_mem_d1(32, 8, 4);
+    @external Sum0 = std_mem_d1(32, 8, 4);
     add0 = std_add(32);
     add1 = std_add(4);
     const0 = std_const(4, 0);

--- a/tests/parsing/attributes.expect
+++ b/tests/parsing/attributes.expect
@@ -1,9 +1,9 @@
 import "primitives/core.futil";
 import "primitives/binary_operators.futil";
-component main<"static"=1>(@stable(1) @go_port(1) in: 32, go: 1, clk: 1) -> (@stable(0) out: 32, done: 1) {
+component main<"static"=1>(@stable(32) @go_port in: 32, go: 1, clk: 1) -> (@stable(0) out: 32, done: 1) {
   cells {
-    @precious(1) out = std_reg(32);
-    le = std_le(32);
+    @precious out = std_reg(32);
+    @external(32) le = std_le(32);
   }
   wires {
     group cond<"stable"=1> {

--- a/tests/passes/guard-canonicalize.expect
+++ b/tests/passes/guard-canonicalize.expect
@@ -3,7 +3,7 @@ component main(go: 1, clk: 1) -> (out: 1, done: 1) {
   cells {
     r0 = std_reg(1);
     r1 = std_reg(1);
-    @external(1) mem = std_mem_d1(32, 1, 1);
+    @external mem = std_mem_d1(32, 1, 1);
   }
   wires {
     group a {

--- a/tests/passes/infer-static/bounded-loop.expect
+++ b/tests/passes/infer-static/bounded-loop.expect
@@ -1,8 +1,8 @@
 import "primitives/core.futil";
 component main<"static"=10>(go: 1, clk: 1) -> (done: 1) {
   cells {
-    @external(1) i = std_mem_d1(32, 1, 1);
-    @external(1) j = std_mem_d1(32, 1, 1);
+    @external i = std_mem_d1(32, 1, 1);
+    @external j = std_mem_d1(32, 1, 1);
     lt = std_lt(32);
     add = std_add(32);
   }
@@ -33,8 +33,8 @@ component main<"static"=10>(go: 1, clk: 1) -> (done: 1) {
   control {
     @bound(5) @static(10) while lt.out with cond {
       @static(2) seq {
-        @static(1) incr_i;
-        @static(1) incr_j;
+        @static incr_i;
+        @static incr_j;
       }
     }
   }

--- a/tests/passes/infer-static/component.expect
+++ b/tests/passes/infer-static/component.expect
@@ -25,9 +25,9 @@ component main<"static"=3>(go: 1, clk: 1) -> (done: 1) {
 
   control {
     @static(3) seq {
-      @static(1) A;
-      @static(1) B;
-      @static(1) C;
+      @static A;
+      @static B;
+      @static C;
     }
   }
 }

--- a/tests/passes/infer-static/groups.expect
+++ b/tests/passes/infer-static/groups.expect
@@ -33,9 +33,9 @@ component main(go: 1, clk: 1) -> (done: 1) {
   control {
     seq {
       @static(0) zero_cycles;
-      @static(1) one_cycle;
+      @static one_cycle;
       @static(2) two_cycles;
-      @static(1) mem_wrt_to_done;
+      @static mem_wrt_to_done;
       mult_wrts_to_done;
     }
   }

--- a/tests/passes/infer-static/invoke.expect
+++ b/tests/passes/infer-static/invoke.expect
@@ -14,7 +14,7 @@ component main<"static"=3>(go: 1, clk: 1) -> (done: 1) {
 
   control {
     @static(3) seq {
-      @static(1) upd0;
+      @static upd0;
       @static(2) invoke exp0(
         base = r.out,
         exp = r.out
@@ -42,8 +42,8 @@ component exponent<"static"=2>(base: 32, exp: 4, go: 1, clk: 1) -> (out: 32, don
 
   control {
     @static(2) seq {
-      @static(1) upd1;
-      @static(1) upd2;
+      @static upd1;
+      @static upd2;
     }
   }
 }

--- a/tests/passes/minimize-regs/live-register-analysis.expect
+++ b/tests/passes/minimize-regs/live-register-analysis.expect
@@ -1,11 +1,11 @@
 import "primitives/std.lib";
 component kernel(go: 1, clk: 1) -> (done: 1) {
   cells {
-    @external(1) A0 = std_mem_d1(32, 32, 6);
+    @external A0 = std_mem_d1(32, 32, 6);
     A_read0_0 = std_reg(32);
-    @external(1) B0 = std_mem_d1(32, 32, 6);
+    @external B0 = std_mem_d1(32, 32, 6);
     B_read0_0 = std_reg(32);
-    @external(1) C0 = std_mem_d1(32, 32, 6);
+    @external C0 = std_mem_d1(32, 32, 6);
     add0 = std_add(6);
     add1 = std_add(6);
     i0 = std_reg(6);

--- a/tests/passes/minimize-regs/par-while-liveness.expect
+++ b/tests/passes/minimize-regs/par-while-liveness.expect
@@ -1,17 +1,17 @@
 import "primitives/std.lib";
 component main(go: 1, clk: 1) -> (done: 1) {
   cells {
-    @external(1) a_src0 = std_mem_d1(32, 8, 4);
+    @external a_src0 = std_mem_d1(32, 8, 4);
     a_src_read0_0 = std_reg(32);
-    @external(1) a_tar0 = std_mem_d1(32, 8, 4);
+    @external a_tar0 = std_mem_d1(32, 8, 4);
     add0 = std_add(4);
     add1 = std_add(4);
     add2 = std_add(4);
-    @external(1) b_src0 = std_mem_d1(32, 8, 4);
+    @external b_src0 = std_mem_d1(32, 8, 4);
     b_src_read0_0 = std_reg(32);
-    @external(1) b_tar0 = std_mem_d1(32, 8, 4);
-    @external(1) c_src0 = std_mem_d1(32, 8, 4);
-    @external(1) c_tar0 = std_mem_d1(32, 8, 4);
+    @external b_tar0 = std_mem_d1(32, 8, 4);
+    @external c_src0 = std_mem_d1(32, 8, 4);
+    @external c_tar0 = std_mem_d1(32, 8, 4);
     const0 = std_const(4, 0);
     const1 = std_const(4, 7);
     const2 = std_const(4, 1);


### PR DESCRIPTION
Parser now supports `@external` syntax for attributes and defaults the value to one.

This means `@external` is the same as `@external(1)`.
