### PR TITLE
Builder marks cells added by passes using the `@generated` attribute

### DIFF
--- a/calyx/src/ir/builder.rs
+++ b/calyx/src/ir/builder.rs
@@ -5,9 +5,13 @@ use smallvec::smallvec;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-/// An IR builder.
+/// IR builder.
 /// Uses internal references to the component to construct and validate
 /// constructs when needed.
+/// By default, assumes that the cells are being added by a pass and marks
+/// them with the `@generated` attribute.
+///
+/// In order to disable this behavior, call [[ir::Builder::not_generated()]].
 pub struct Builder<'a> {
     /// Component for which this builder is constructing.
     pub component: &'a mut ir::Component,
@@ -16,20 +20,35 @@ pub struct Builder<'a> {
     /// Enable validation of components.
     /// Useful for debugging malformed AST errors.
     validate: bool,
+    /// Cells added are generated during a compiler pass.
+    generated: bool,
 }
 
 impl<'a> Builder<'a> {
     /// Instantiate a new builder using for a component.
-    pub fn from(
+    pub fn new(
         component: &'a mut ir::Component,
         lib: &'a LibrarySignatures,
-        validate: bool,
     ) -> Self {
         Self {
             component,
             lib,
-            validate,
+            validate: false,
+            // By default, assume that builder is called from a pass
+            generated: true,
         }
+    }
+
+    /// Enable the validation flag on a builder.
+    pub fn validate(mut self) -> Self {
+        self.validate = true;
+        self
+    }
+
+    /// Disable the generated flag on the builder
+    pub fn not_generated(mut self) -> Self {
+        self.generated = false;
+        self
     }
 
     /// Construct a new group and add it to the Component.
@@ -136,6 +155,9 @@ impl<'a> Builder<'a> {
             },
             ports,
         );
+        if self.generated {
+            cell.borrow_mut().add_attribute("generated", 1);
+        }
         self.component.cells.add(Rc::clone(&cell));
         cell
     }

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -162,7 +162,8 @@ fn build_component(
             })
             .collect::<Result<_, _>>()?,
     );
-    let mut builder = Builder::from(&mut ir_component, &sig_ctx.lib, false);
+    let mut builder =
+        Builder::new(&mut ir_component, &sig_ctx.lib).not_generated();
 
     // For each ast::Cell, add a Cell that contains all the
     // required information.

--- a/calyx/src/passes/clk_insertion.rs
+++ b/calyx/src/passes/clk_insertion.rs
@@ -26,7 +26,7 @@ impl Visitor for ClkInsertion {
         comp: &mut ir::Component,
         sigs: &LibrarySignatures,
     ) -> VisResult {
-        let builder = ir::Builder::from(comp, sigs, false);
+        let builder = ir::Builder::new(comp, sigs);
 
         for cell_ref in builder.component.cells.iter() {
             let cell = cell_ref.borrow();

--- a/calyx/src/passes/compile_control.rs
+++ b/calyx/src/passes/compile_control.rs
@@ -73,7 +73,7 @@ impl Visitor for CompileControl {
         comp: &mut ir::Component,
         ctx: &LibrarySignatures,
     ) -> VisResult {
-        let mut builder = ir::Builder::from(comp, ctx, false);
+        let mut builder = ir::Builder::new(comp, ctx);
 
         // create a new group for if related structure
         let if_group = builder.add_group("if");
@@ -172,7 +172,7 @@ impl Visitor for CompileControl {
         comp: &mut ir::Component,
         ctx: &LibrarySignatures,
     ) -> VisResult {
-        let mut builder = ir::Builder::from(comp, ctx, false);
+        let mut builder = ir::Builder::new(comp, ctx);
 
         // create group
         let while_group = builder.add_group("while");
@@ -263,7 +263,7 @@ impl Visitor for CompileControl {
         comp: &mut ir::Component,
         ctx: &LibrarySignatures,
     ) -> VisResult {
-        let mut builder = ir::Builder::from(comp, ctx, false);
+        let mut builder = ir::Builder::new(comp, ctx);
 
         // Create a new group for the seq related structure.
         let seq_group = builder.add_group("seq");
@@ -346,7 +346,7 @@ impl Visitor for CompileControl {
         comp: &mut ir::Component,
         ctx: &LibrarySignatures,
     ) -> VisResult {
-        let mut builder = ir::Builder::from(comp, ctx, false);
+        let mut builder = ir::Builder::new(comp, ctx);
 
         // Name of the parent group.
         let par_group = builder.add_group("par");

--- a/calyx/src/passes/compile_empty.rs
+++ b/calyx/src/passes/compile_empty.rs
@@ -39,7 +39,7 @@ impl Visitor for CompileEmpty {
         let group_ref = match comp.find_group(&CompileEmpty::EMPTY_GROUP) {
             Some(g) => g,
             None => {
-                let mut builder = ir::Builder::from(comp, sigs, false);
+                let mut builder = ir::Builder::new(comp, sigs);
                 // Create a group that always outputs done if it doesn't exist.
 
                 // Add the new group

--- a/calyx/src/passes/compile_invoke.rs
+++ b/calyx/src/passes/compile_invoke.rs
@@ -24,7 +24,7 @@ impl Visitor for CompileInvoke {
         comp: &mut ir::Component,
         ctx: &LibrarySignatures,
     ) -> VisResult {
-        let mut builder = ir::Builder::from(comp, ctx, false);
+        let mut builder = ir::Builder::new(comp, ctx);
 
         let invoke_group = builder.add_group("invoke");
 

--- a/calyx/src/passes/component_interface.rs
+++ b/calyx/src/passes/component_interface.rs
@@ -53,7 +53,7 @@ impl Visitor for ComponentInterface {
 
         if let ir::Control::Enable(data) = &*control {
             let this = Rc::clone(&comp.signature);
-            let mut builder = ir::Builder::from(comp, ctx, false);
+            let mut builder = ir::Builder::new(comp, ctx);
             let group = &data.group;
 
             structure!(builder;

--- a/calyx/src/passes/inliner.rs
+++ b/calyx/src/passes/inliner.rs
@@ -120,7 +120,7 @@ impl Visitor for Inliner {
         };
 
         let this_comp = Rc::clone(&comp.signature);
-        let mut builder = ir::Builder::from(comp, sigs, false);
+        let mut builder = ir::Builder::new(comp, sigs);
 
         // add top_level[go] = this.go
         let mut asgns = build_assignments!(

--- a/calyx/src/passes/register_unsharing.rs
+++ b/calyx/src/passes/register_unsharing.rs
@@ -152,10 +152,10 @@ impl Visitor for RegisterUnsharing {
     fn start(
         &mut self,
         comp: &mut ir::Component,
-        _c: &LibrarySignatures,
+        sigs: &LibrarySignatures,
     ) -> VisResult {
         self.bookkeeper.replace(Bookkeeper::new(comp));
-        let mut builder = Builder::from(comp, _c, false);
+        let mut builder = Builder::new(comp, sigs);
 
         let rename_list = self
             .bookkeeper

--- a/calyx/src/passes/sharing_components.rs
+++ b/calyx/src/passes/sharing_components.rs
@@ -165,7 +165,7 @@ impl<T: ShareComponents> Visitor for T {
 
         // apply the coloring as a renaming of registers for both groups
         // and continuous assignments
-        let builder = ir::Builder::from(comp, sigs, false);
+        let builder = ir::Builder::new(comp, sigs);
         for group_ref in builder.component.groups.iter() {
             let mut group = group_ref.borrow_mut();
             let mut assigns: Vec<_> = group.assignments.drain(..).collect();

--- a/calyx/src/passes/static_timing.rs
+++ b/calyx/src/passes/static_timing.rs
@@ -55,7 +55,7 @@ impl Visitor for StaticTiming {
             let cond = &while_s.cond;
             let port = &while_s.port;
             let body = &data.group;
-            let mut builder = ir::Builder::from(comp, ctx, false);
+            let mut builder = ir::Builder::new(comp, ctx);
 
             // FSM Encoding:
             //   0:   init state. we haven't started loop iterations
@@ -185,7 +185,7 @@ impl Visitor for StaticTiming {
                 tru.borrow().attributes.get("static"),
                 fal.borrow().attributes.get("static"),
             ) {
-                let mut builder = ir::Builder::from(comp, ctx, false);
+                let mut builder = ir::Builder::new(comp, ctx);
                 let if_group = builder.add_group("static_if");
                 if_group
                     .borrow_mut()
@@ -298,7 +298,7 @@ impl Visitor for StaticTiming {
     ) -> VisResult {
         // Early return if this group is not compilable.
         if let Some(max_time) = accumulate_static_time(&s.stmts, cmp::max) {
-            let mut builder = ir::Builder::from(comp, ctx, false);
+            let mut builder = ir::Builder::new(comp, ctx);
 
             let par_group = builder.add_group("static_par");
             par_group.borrow_mut().attributes.insert("static", max_time);
@@ -374,7 +374,7 @@ impl Visitor for StaticTiming {
             return Ok(Action::Continue);
         }
 
-        let mut builder = ir::Builder::from(comp, ctx, false);
+        let mut builder = ir::Builder::new(comp, ctx);
         let fsm_size = get_bit_width_from(1 + total_time.unwrap());
 
         // Create new group for compiling this seq.

--- a/calyx/src/passes/top_down_compile_control.rs
+++ b/calyx/src/passes/top_down_compile_control.rs
@@ -441,7 +441,7 @@ impl Visitor for TopDownCompileControl {
         comp: &mut ir::Component,
         sigs: &LibrarySignatures,
     ) -> VisResult {
-        let mut builder = ir::Builder::from(comp, sigs, false);
+        let mut builder = ir::Builder::new(comp, sigs);
 
         // Compilation group
         let par_group = builder.add_group("par");
@@ -538,7 +538,7 @@ impl Visitor for TopDownCompileControl {
         }
 
         let control = Rc::clone(&comp.control);
-        let mut builder = ir::Builder::from(comp, sigs, false);
+        let mut builder = ir::Builder::new(comp, sigs);
         let mut schedule = Schedule::default();
         calculate_states(
             &control.borrow(),

--- a/docs/lang/attributes.md
+++ b/docs/lang/attributes.md
@@ -67,3 +67,8 @@ can be shared.
 ### `bound(n)`
 Used in `infer-static-timing` and `static-timing` when the number of iterations 
 of a `While` control is known statically, as indicated by `n`.
+
+### `generated`
+Added by [`ir::Builder`][builder] to denote that the cell was added by a pass.
+
+[builder]: https://capra.cs.cornell.edu/docs/calyx/source/calyx/ir/struct.Builder.html

--- a/examples/futil/dot-product.expect
+++ b/examples/futil/dot-product.expect
@@ -17,14 +17,14 @@ component main(go: 1, clk: 1) -> (done: 1) {
     le0 = std_le(4);
     mult_pipe0 = std_mult_pipe(32);
     @external v0 = std_mem_d1(32, 1, 1);
-    fsm = std_reg(1);
-    incr = std_add(1);
-    fsm0 = std_reg(4);
-    incr0 = std_add(4);
-    fsm1 = std_reg(4);
-    cond_stored = std_reg(1);
-    incr1 = std_add(4);
-    fsm2 = std_reg(2);
+    @generated fsm = std_reg(1);
+    @generated incr = std_add(1);
+    @generated fsm0 = std_reg(4);
+    @generated incr0 = std_add(4);
+    @generated fsm1 = std_reg(4);
+    @generated cond_stored = std_reg(1);
+    @generated incr1 = std_add(4);
+    @generated fsm2 = std_reg(2);
   }
   wires {
     A0.addr0 = fsm.out < 1'd1 & fsm0.out == 4'd0 & cond_stored.out & fsm1.out >= 4'd1 & fsm1.out < 4'd9 & !(fsm1.out == 4'd1 & !cond_stored.out) & fsm2.out == 2'd1 & go ? i0.out;

--- a/examples/futil/multi-component.expect
+++ b/examples/futil/multi-component.expect
@@ -17,7 +17,7 @@ component main(go: 1, clk: 1) -> (done: 1) {
   cells {
     id = identity();
     current_value = std_reg(32);
-    fsm = std_reg(2);
+    @generated fsm = std_reg(2);
   }
   wires {
     done = fsm.out == 2'd2 ? 1'd1;

--- a/examples/futil/pass-in-register.expect
+++ b/examples/futil/pass-in-register.expect
@@ -21,7 +21,7 @@ component main(go: 1, clk: 1) -> (done: 1) {
   cells {
     op = times_10_and_add_1();
     r = std_reg(32);
-    fsm = std_reg(2);
+    @generated fsm = std_reg(2);
   }
   wires {
     done = fsm.out == 2'd2 ? 1'd1;

--- a/examples/futil/simple.expect
+++ b/examples/futil/simple.expect
@@ -7,7 +7,7 @@ component main(go: 1, clk: 1) -> (done: 1) {
     mult = std_mult_pipe(32);
     reg0 = std_reg(32);
     reg1 = std_reg(32);
-    fsm = std_reg(2);
+    @generated fsm = std_reg(2);
   }
   wires {
     done = fsm.out == 2'd2 ? 1'd1;

--- a/examples/futil/vectorized-add.expect
+++ b/examples/futil/vectorized-add.expect
@@ -13,14 +13,14 @@ component main(go: 1, clk: 1) -> (done: 1) {
     const2 = std_const(4, 1);
     i0 = std_reg(4);
     le0 = std_le(4);
-    fsm = std_reg(1);
-    incr = std_add(1);
-    fsm0 = std_reg(2);
-    incr0 = std_add(2);
-    fsm1 = std_reg(3);
-    cond_stored = std_reg(1);
-    incr1 = std_add(3);
-    fsm2 = std_reg(2);
+    @generated fsm = std_reg(1);
+    @generated incr = std_add(1);
+    @generated fsm0 = std_reg(2);
+    @generated incr0 = std_add(2);
+    @generated fsm1 = std_reg(3);
+    @generated cond_stored = std_reg(1);
+    @generated incr1 = std_add(3);
+    @generated fsm2 = std_reg(2);
   }
   wires {
     A0.addr0 = fsm.out < 1'd1 & fsm0.out == 2'd0 & cond_stored.out & fsm1.out >= 3'd1 & fsm1.out < 3'd4 & !(fsm1.out == 3'd1 & !cond_stored.out) & fsm2.out == 2'd1 & go ? i0.out;

--- a/tests/passes/compile-control/compile-if-static.expect
+++ b/tests/passes/compile-control/compile-if-static.expect
@@ -4,9 +4,9 @@ component main(go: 1, clk: 1) -> (done: 1) {
     t = std_reg(1);
     f = std_reg(1);
     lt = std_lt(1);
-    fsm = std_reg(2);
-    cond_stored = std_reg(1);
-    incr = std_add(2);
+    @generated fsm = std_reg(2);
+    @generated cond_stored = std_reg(1);
+    @generated incr = std_add(2);
   }
   wires {
     group true<"static"=1> {

--- a/tests/passes/compile-control/compile-if.expect
+++ b/tests/passes/compile-control/compile-if.expect
@@ -4,9 +4,9 @@ component main(go: 1, clk: 1) -> (done: 1) {
     t = std_reg(1);
     f = std_reg(1);
     lt = std_lt(1);
-    cond_computed = std_reg(1);
-    cond_stored = std_reg(1);
-    done_reg = std_reg(1);
+    @generated cond_computed = std_reg(1);
+    @generated cond_stored = std_reg(1);
+    @generated done_reg = std_reg(1);
   }
   wires {
     group true {

--- a/tests/passes/compile-control/compile-par-static.expect
+++ b/tests/passes/compile-control/compile-par-static.expect
@@ -4,8 +4,8 @@ component main(go: 1, clk: 1) -> (done: 1) {
     a = std_reg(2);
     b = std_reg(2);
     c = std_reg(2);
-    fsm = std_reg(1);
-    incr = std_add(1);
+    @generated fsm = std_reg(1);
+    @generated incr = std_add(1);
   }
   wires {
     group A<"static"=1> {

--- a/tests/passes/compile-control/compile-par.expect
+++ b/tests/passes/compile-control/compile-par.expect
@@ -4,10 +4,10 @@ component main(go: 1, clk: 1) -> (done: 1) {
     a = std_reg(2);
     b = std_reg(2);
     c = std_reg(2);
-    par_reset = std_reg(1);
-    par_done_reg = std_reg(1);
-    par_done_reg0 = std_reg(1);
-    par_done_reg1 = std_reg(1);
+    @generated par_reset = std_reg(1);
+    @generated par_done_reg = std_reg(1);
+    @generated par_done_reg0 = std_reg(1);
+    @generated par_done_reg1 = std_reg(1);
   }
   wires {
     group A {

--- a/tests/passes/compile-control/compile-seq-static.expect
+++ b/tests/passes/compile-control/compile-seq-static.expect
@@ -4,8 +4,8 @@ component main(go: 1, clk: 1) -> (done: 1) {
     a = std_reg(2);
     b = std_reg(2);
     c = std_reg(2);
-    fsm = std_reg(2);
-    incr = std_add(2);
+    @generated fsm = std_reg(2);
+    @generated incr = std_add(2);
   }
   wires {
     group A<"static"=1> {

--- a/tests/passes/compile-control/compile-seq.expect
+++ b/tests/passes/compile-control/compile-seq.expect
@@ -4,7 +4,7 @@ component main(go: 1, clk: 1) -> (done: 1) {
     a = std_reg(2);
     b = std_reg(2);
     c = std_reg(2);
-    fsm = std_reg(2);
+    @generated fsm = std_reg(2);
   }
   wires {
     group A {

--- a/tests/passes/compile-control/compile-while-static.expect
+++ b/tests/passes/compile-control/compile-while-static.expect
@@ -5,9 +5,9 @@ component main(go: 1, clk: 1) -> (done: 1) {
     add_r = std_reg(32);
     lt = std_lt(32);
     lt_r = std_reg(1);
-    fsm = std_reg(2);
-    cond_stored = std_reg(1);
-    incr = std_add(2);
+    @generated fsm = std_reg(2);
+    @generated cond_stored = std_reg(1);
+    @generated incr = std_add(2);
   }
   wires {
     group do_add<"static"=1> {

--- a/tests/passes/compile-control/compile-while.expect
+++ b/tests/passes/compile-control/compile-while.expect
@@ -3,9 +3,9 @@ component main(go: 1, clk: 1) -> (done: 1) {
   cells {
     add = std_add(32);
     lt = std_lt(32);
-    cond_computed = std_reg(1);
-    cond_stored = std_reg(1);
-    done_reg = std_reg(1);
+    @generated cond_computed = std_reg(1);
+    @generated cond_stored = std_reg(1);
+    @generated done_reg = std_reg(1);
   }
   wires {
     group do_add {

--- a/tests/passes/regressions/group-multi-drive.expect
+++ b/tests/passes/regressions/group-multi-drive.expect
@@ -3,7 +3,7 @@ component main(go: 1, clk: 1) -> (done: 1) {
   cells {
     r = std_reg(32);
     add = std_add(32);
-    fsm = std_reg(2);
+    @generated fsm = std_reg(2);
   }
   wires {
     done = fsm.out == 2'd2 ? 1'd1;

--- a/tests/passes/unsharing/continuous.expect
+++ b/tests/passes/unsharing/continuous.expect
@@ -7,8 +7,8 @@ component main(go: 1, clk: 1) -> (done: 1) {
     add2 = std_add(32);
     flag = std_reg(1);
     other = std_reg(32);
-    unshr_x = std_reg(32);
-    unshr_y = std_reg(32);
+    @generated unshr_x = std_reg(32);
+    @generated unshr_y = std_reg(32);
   }
   wires {
     group zero {

--- a/tests/passes/unsharing/invoke.expect
+++ b/tests/passes/unsharing/invoke.expect
@@ -27,8 +27,8 @@ component main(go: 1, clk: 1) -> (done: 1) {
     y = std_reg(32);
     my_add = add();
     result = std_reg(32);
-    unshr_x = std_reg(32);
-    unshr_y = std_reg(32);
+    @generated unshr_x = std_reg(32);
+    @generated unshr_y = std_reg(32);
   }
   wires {
     group zero_x {

--- a/tests/passes/unsharing/unshare-par.expect
+++ b/tests/passes/unsharing/unshare-par.expect
@@ -5,8 +5,8 @@ component main(go: 1, clk: 1) -> (done: 1) {
     y = std_reg(32);
     add2 = std_add(32);
     result = std_reg(32);
-    unshr_x = std_reg(32);
-    unshr_y = std_reg(32);
+    @generated unshr_x = std_reg(32);
+    @generated unshr_y = std_reg(32);
   }
   wires {
     group zero_x {

--- a/tests/passes/unsharing/unsharing.expect
+++ b/tests/passes/unsharing/unsharing.expect
@@ -7,8 +7,8 @@ component main(go: 1, clk: 1) -> (done: 1) {
     add2 = std_add(32);
     flag = std_reg(1);
     other = std_reg(32);
-    unshr_r = std_reg(32);
-    unshr_r0 = std_reg(32);
+    @generated unshr_r = std_reg(32);
+    @generated unshr_r0 = std_reg(32);
   }
   wires {
     group zero {

--- a/tests/passes/unsharing/while.expect
+++ b/tests/passes/unsharing/while.expect
@@ -5,8 +5,8 @@ component main(go: 1, clk: 1) -> (done: 1) {
     add2 = std_add(32);
     flag = std_reg(1);
     other = std_reg(32);
-    unshr_r = std_reg(32);
-    unshr_r0 = std_reg(32);
+    @generated unshr_r = std_reg(32);
+    @generated unshr_r0 = std_reg(32);
   }
   wires {
     group zero {


### PR DESCRIPTION
Another PR sliced out from #571. This one changes the builder to add `@generated` annotations to cells that were added by passes.
