### PR TITLE
Attribute-based Interface

### DIFF
--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -60,10 +60,9 @@ fn check_signature(sig: &[PortDef]) -> FutilResult<()> {
 }
 
 /// Definition of special interface ports.
-const INTERFACE_PORTS: [(&str, u64, Direction); 4] = [
+const INTERFACE_PORTS: [(&str, u64, Direction); 3] = [
     ("go", 1, Direction::Input),
     ("clk", 1, Direction::Input),
-    ("reset", 1, Direction::Input),
     ("done", 1, Direction::Output),
 ];
 

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -1,10 +1,12 @@
 use super::{
-    Assignment, Builder, CellType, Component, Context, Control, Direction,
-    GetAttributes, Guard, Id, LibrarySignatures, Port, PortDef, RRC,
+    Assignment, Attributes, Builder, CellType, Component, Context, Control,
+    Direction, GetAttributes, Guard, Id, LibrarySignatures, Port, PortDef,
+    Width, RRC,
 };
 use crate::{
     errors::{Error, FutilResult},
     frontend::ast,
+    utils::NameGenerator,
 };
 use linked_hash_map::LinkedHashMap;
 use std::cell::RefCell;
@@ -22,25 +24,67 @@ struct SigCtx {
     lib: LibrarySignatures,
 }
 
+/// Validates a component signature to make sure there are not duplicate ports.
+fn check_signature(sig: &[PortDef]) -> FutilResult<()> {
+    let mut inputs: HashSet<&Id> = HashSet::new();
+    let mut outputs: HashSet<&Id> = HashSet::new();
+    for pd in sig {
+        // check for uniqueness
+        match pd.direction {
+            Direction::Input => {
+                if !inputs.contains(&pd.name) {
+                    inputs.insert(&pd.name);
+                } else {
+                    return Err(Error::AlreadyBound(
+                        pd.name.clone(),
+                        "component".to_string(),
+                    ));
+                }
+            }
+            Direction::Output => {
+                if !outputs.contains(&pd.name) {
+                    outputs.insert(&pd.name);
+                } else {
+                    return Err(Error::AlreadyBound(
+                        pd.name.clone(),
+                        "component".to_string(),
+                    ));
+                }
+            }
+            Direction::Inout => {
+                panic!("Components shouldn't have inout ports.")
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Definition of special interface ports.
+const INTERFACE_PORTS: [(&str, u64, Direction); 4] = [
+    ("go", 1, Direction::Input),
+    ("clk", 1, Direction::Input),
+    ("reset", 1, Direction::Input),
+    ("done", 1, Direction::Output),
+];
+
 /// Extend the signature with magical ports.
 fn extend_signature(sig: &mut Vec<PortDef>) {
-    // XXX(Sam): checking to see if the port exists is a hack.
-    let (mut has_go, mut has_clk, mut has_done) = (false, false, false);
-    sig.iter().for_each(|pd| match pd.name.as_ref() {
-        "go" => has_go = true,
-        "clk" => has_clk = true,
-        "done" => has_done = true,
-        _ => (),
-    });
-
-    if !has_go {
-        sig.push(("go".into(), 1, Direction::Input).into())
-    }
-    if !has_clk {
-        sig.push(("clk".into(), 1, Direction::Input).into())
-    }
-    if !has_done {
-        sig.push(("done".into(), 1, Direction::Output).into())
+    let port_names: HashSet<_> =
+        sig.iter().map(|pd| pd.name.to_string()).collect();
+    let mut namegen = NameGenerator::with_prev_defined_names(port_names);
+    for (name, width, direction) in INTERFACE_PORTS.iter() {
+        // Check if there is already another interface port defined for the
+        // component
+        if !sig.iter().any(|pd| pd.attributes.has(name)) {
+            let mut attributes = Attributes::default();
+            attributes.insert(name, 1);
+            sig.push(PortDef {
+                name: namegen.gen_name(name.to_string()),
+                width: Width::Const { value: *width },
+                direction: direction.clone(),
+                attributes,
+            });
+        }
     }
 }
 
@@ -78,6 +122,7 @@ pub fn ast_to_ir(
 
     // Add component signatures to context
     for comp in &mut namespace.components {
+        check_signature(&comp.signature)?;
         // extend the signature
         extend_signature(&mut comp.signature);
         sig_ctx

--- a/calyx/src/ir/structure.rs
+++ b/calyx/src/ir/structure.rs
@@ -155,6 +155,17 @@ impl Cell {
             .map(|r| Rc::clone(r))
     }
 
+    /// Get a reference to the first port that has the attribute [[attr]]
+    pub fn find_with_attr<S>(&self, attr: S) -> Option<RRC<Port>>
+    where
+        S: AsRef<str>,
+    {
+        self.ports
+            .iter()
+            .find(|&g| g.borrow().attributes.has(attr.as_ref()))
+            .map(|r| Rc::clone(r))
+    }
+
     /// Get a reference to the named port and throw an error if it doesn't
     /// exist.
     pub fn get<S>(&self, name: S) -> RRC<Port>
@@ -165,6 +176,21 @@ impl Cell {
             panic!(
                 "Port `{}' not found on cell `{}'",
                 name.to_string(),
+                self.name.to_string()
+            )
+        })
+    }
+
+    /// Get a reference to the first port with the attribute `attr` and throw an error if none
+    /// exist.
+    pub fn get_with_attr<S>(&self, attr: S) -> RRC<Port>
+    where
+        S: AsRef<str>,
+    {
+        self.find_with_attr(&attr).unwrap_or_else(|| {
+            panic!(
+                "Port with attribute `{}' not found on cell `{}'",
+                attr.as_ref(),
                 self.name.to_string()
             )
         })

--- a/calyx/src/passes/clk_insertion.rs
+++ b/calyx/src/passes/clk_insertion.rs
@@ -30,11 +30,15 @@ impl Visitor for ClkInsertion {
 
         for cell_ref in builder.component.cells.iter() {
             let cell = cell_ref.borrow();
-            if let Some(port) = cell.find("clk") {
+            if let Some(port) = cell.find_with_attr("clk") {
                 builder.component.continuous_assignments.push(
                     builder.build_assignment(
                         port,
-                        builder.component.signature.borrow().get("clk"),
+                        builder
+                            .component
+                            .signature
+                            .borrow()
+                            .get_with_attr("clk"),
                         ir::Guard::True,
                     ),
                 )

--- a/calyx/src/passes/inliner.rs
+++ b/calyx/src/passes/inliner.rs
@@ -1,6 +1,5 @@
 use crate::{
     analysis::GraphAnalysis,
-    build_assignments,
     errors::Error,
     ir::traversal::{Action, Named, VisResult, Visitor},
     ir::{self, LibrarySignatures},
@@ -123,11 +122,18 @@ impl Visitor for Inliner {
         let mut builder = ir::Builder::new(comp, sigs);
 
         // add top_level[go] = this.go
-        let mut asgns = build_assignments!(
-            builder;
-            top_level["go"] = ? this_comp["go"];
-            this_comp["done"] = ? top_level["done"];
-        );
+        let mut asgns = vec![
+            builder.build_assignment(
+                top_level.borrow().get("go"),
+                this_comp.borrow().get_with_attr("go"),
+                ir::Guard::True,
+            ),
+            builder.build_assignment(
+                this_comp.borrow().get_with_attr("done"),
+                top_level.borrow().get("done"),
+                ir::Guard::True,
+            ),
+        ];
         builder.component.continuous_assignments.append(&mut asgns);
 
         // construct analysis graph and find sub-graph of all edges that include a hole

--- a/examples/futil/dot-product.expect
+++ b/examples/futil/dot-product.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     @external A0 = std_mem_d1(32, 8, 4);
     A_read0_0 = std_reg(32);

--- a/examples/futil/multi-component.expect
+++ b/examples/futil/multi-component.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component identity<"static"=1>(in: 32, go: 1, clk: 1) -> (out: 32, done: 1) {
+component identity<"static"=1>(in: 32, @go go: 1, @clk clk: 1) -> (out: 32, @done done: 1) {
   cells {
     r = std_reg(32);
   }
@@ -13,7 +13,7 @@ component identity<"static"=1>(in: 32, go: 1, clk: 1) -> (out: 32, done: 1) {
 
   control {}
 }
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     id = identity();
     current_value = std_reg(32);

--- a/examples/futil/pass-in-register.expect
+++ b/examples/futil/pass-in-register.expect
@@ -1,6 +1,6 @@
 import "primitives/std.lib";
 import "primitives/unsynthesizable.futil";
-component times_10_and_add_1(reg_done: 1, reg_out: 32, go: 1, clk: 1) -> (reg_in: 32, reg_write_en: 1, done: 1) {
+component times_10_and_add_1(reg_done: 1, reg_out: 32, @go go: 1, @clk clk: 1) -> (reg_in: 32, reg_write_en: 1, @done done: 1) {
   cells {
     add = std_add(32);
     mult = std_unsyn_mult(32);
@@ -17,7 +17,7 @@ component times_10_and_add_1(reg_done: 1, reg_out: 32, go: 1, clk: 1) -> (reg_in
 
   control {}
 }
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     op = times_10_and_add_1();
     r = std_reg(32);

--- a/examples/futil/simple.expect
+++ b/examples/futil/simple.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     const0 = std_const(32, 4);
     const1 = std_const(32, 5);

--- a/examples/futil/vectorized-add.expect
+++ b/examples/futil/vectorized-add.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     @external A0 = std_mem_d1(32, 8, 4);
     A_read0_0 = std_reg(32);

--- a/primitives/binary_operators.futil
+++ b/primitives/binary_operators.futil
@@ -11,7 +11,7 @@ extern "binary_operators.sv" {
   primitive std_fp_mult_pipe[
     WIDTH, INT_WIDTH, FRAC_WIDTH
   ](
-    clk: 1, go: 1, left: WIDTH, right: WIDTH
+    @clk(1) clk: 1, go: 1, left: WIDTH, right: WIDTH
   ) -> (
     out: WIDTH, done: 1
   );
@@ -19,7 +19,7 @@ extern "binary_operators.sv" {
   primitive std_fp_div_pipe[
     WIDTH, INT_WIDTH, FRAC_WIDTH
   ](
-    clk: 1, go: 1, left: WIDTH, right: WIDTH
+    @clk(1) clk: 1, go: 1, left: WIDTH, right: WIDTH
   ) -> (
     out_remainder: WIDTH,
     out_quotient: WIDTH,
@@ -52,7 +52,7 @@ extern "binary_operators.sv" {
   primitive std_fp_smult_pipe[
     WIDTH, INT_WIDTH, FRAC_WIDTH
   ](
-    clk: 1, go: 1, left: WIDTH, right: WIDTH
+    @clk(1) clk: 1, go: 1, left: WIDTH, right: WIDTH
   ) -> (
     out: WIDTH, done: 1
   );
@@ -60,7 +60,7 @@ extern "binary_operators.sv" {
   primitive std_fp_sdiv_pipe[
     WIDTH, INT_WIDTH, FRAC_WIDTH
   ](
-    clk: 1, go: 1, left: WIDTH, right: WIDTH
+    @clk(1) clk: 1, go: 1, left: WIDTH, right: WIDTH
   ) -> (
     out_remainder: WIDTH,
     out_quotient: WIDTH,
@@ -68,6 +68,10 @@ extern "binary_operators.sv" {
   );
 
   primitive std_fp_sgt<"share"=1>[
+    WIDTH, INT_WIDTH, FRAC_WIDTH
+  ](left: WIDTH, right: WIDTH) -> (out: 1);
+
+  primitive std_fp_slt<"share"=1>[
     WIDTH, INT_WIDTH, FRAC_WIDTH
   ](left: WIDTH, right: WIDTH) -> (out: 1);
 
@@ -86,13 +90,13 @@ extern "binary_operators.sv" {
   /// since they're required for FSM encoding.
 
   primitive std_mult_pipe[WIDTH](
-    clk: 1, go: 1, left: WIDTH, right: WIDTH
+    @clk(1) clk: 1, go: 1, left: WIDTH, right: WIDTH
   ) -> (
     out: WIDTH, done: 1
   );
 
   primitive std_div_pipe<"static"=3>[WIDTH](
-    left: WIDTH, right: WIDTH, @go(1) go: 1, clk: 1
+    left: WIDTH, right: WIDTH, @go(1) go: 1, @clk(1) clk: 1
   ) -> (
     out_quotient: WIDTH,
     out_remainder: WIDTH,
@@ -104,13 +108,13 @@ extern "binary_operators.sv" {
   primitive std_ssub<"share"=1>[WIDTH](left: WIDTH, right: WIDTH) -> (out: WIDTH);
 
   primitive std_smult_pipe[WIDTH](
-    left: WIDTH, right: WIDTH, go: 1, clk: 1
+    left: WIDTH, right: WIDTH, go: 1, @clk(1) clk: 1
   ) -> (
     out: WIDTH, done: 1
   );
 
   primitive std_sdiv_pipe[WIDTH](
-    clk: 1, @go(1) go: 1, left: WIDTH, right: WIDTH
+    @clk(1) clk: 1, @go(1) go: 1, left: WIDTH, right: WIDTH
   ) -> (
     out_quotient: WIDTH,
     out_remainder: WIDTH,

--- a/primitives/binary_operators.sv
+++ b/primitives/binary_operators.sv
@@ -356,6 +356,18 @@ module std_fp_sgt #(
   assign out = $signed(left > right);
 endmodule
 
+module std_fp_slt #(
+    parameter WIDTH = 32,
+    parameter INT_WIDTH = 16,
+    parameter FRAC_WIDTH = 16
+) (
+   input logic signed [WIDTH-1:0] left,
+   input logic signed [WIDTH-1:0] right,
+   output logic signed            out
+);
+  assign out = $signed(left < right);
+endmodule
+
 /// =================== Unsigned, Bitnum =========================
 module std_mult_pipe #(
     parameter WIDTH = 32

--- a/primitives/core.futil
+++ b/primitives/core.futil
@@ -27,7 +27,8 @@ extern "core.sv" {
   primitive std_reg<"static"=1>[WIDTH](
     in: WIDTH,
     @go(1) write_en: 1,
-    clk: 1
+    @clk(1) clk: 1,
+    @reset(1) reset: 1
   ) -> (
     out: WIDTH,
     @done(1) done: 1
@@ -37,7 +38,7 @@ extern "core.sv" {
     addr0: IDX_SIZE,
     write_data: WIDTH,
     @go(1) write_en: 1,
-    clk: 1
+    @clk(1) clk: 1
   ) -> (
     read_data: WIDTH,
     @done(1) done: 1
@@ -48,7 +49,7 @@ extern "core.sv" {
     addr1: D1_IDX_SIZE,
     write_data: WIDTH,
     @go(1) write_en: 1,
-    clk: 1
+    @clk(1) clk: 1
   ) -> (
     read_data: WIDTH,
     @done(1) done: 1
@@ -68,7 +69,7 @@ extern "core.sv" {
     addr2: D2_IDX_SIZE,
     write_data: WIDTH,
     @go(1) write_en: 1,
-    clk: 1
+    @clk(1) clk: 1
   ) -> (
     read_data: WIDTH,
     @done(1) done: 1
@@ -91,7 +92,7 @@ extern "core.sv" {
     addr3: D3_IDX_SIZE,
     write_data: WIDTH,
     @go(1) write_en: 1,
-    clk: 1
+    @clk(1) clk: 1
   ) -> (
     read_data: WIDTH,
     @done(1) done: 1

--- a/primitives/core.futil
+++ b/primitives/core.futil
@@ -27,8 +27,7 @@ extern "core.sv" {
   primitive std_reg<"static"=1>[WIDTH](
     in: WIDTH,
     @go(1) write_en: 1,
-    @clk(1) clk: 1,
-    @reset(1) reset: 1
+    @clk(1) clk: 1
   ) -> (
     out: WIDTH,
     @done(1) done: 1

--- a/primitives/core.sv
+++ b/primitives/core.sv
@@ -219,13 +219,17 @@ module std_reg #(
    input wire [ WIDTH-1:0]    in,
    input wire                 write_en,
    input wire                 clk,
+   input wire                 reset,
     // output
    output logic [WIDTH - 1:0] out,
    output logic               done
 );
 
   always_ff @(posedge clk) begin
-    if (write_en) begin
+    if (reset) begin
+       out <= 0;
+       done <= 0;
+    end else if (write_en) begin
       out <= in;
       done <= 1'd1;
     end else done <= 1'd0;

--- a/primitives/core.sv
+++ b/primitives/core.sv
@@ -219,7 +219,6 @@ module std_reg #(
    input wire [ WIDTH-1:0]    in,
    input wire                 write_en,
    input wire                 clk,
-   input wire                 reset,
     // output
    output logic [WIDTH - 1:0] out,
    output logic               done

--- a/primitives/core.sv
+++ b/primitives/core.sv
@@ -226,10 +226,7 @@ module std_reg #(
 );
 
   always_ff @(posedge clk) begin
-    if (reset) begin
-       out <= 0;
-       done <= 0;
-    end else if (write_en) begin
+    if (write_en) begin
       out <= in;
       done <= 1'd1;
     end else done <= 1'd0;

--- a/primitives/math.futil
+++ b/primitives/math.futil
@@ -4,7 +4,7 @@ extern "math.sv" {
   primitive fp_sqrt[
     WIDTH, INT_WIDTH, FRAC_WIDTH
   ](
-    clk: 1, go: 1, in: WIDTH
+    @clk(1) clk: 1, go: 1, in: WIDTH
   ) -> (
     out: WIDTH, done: 1
   );
@@ -12,7 +12,7 @@ extern "math.sv" {
   primitive sqrt[
     WIDTH
   ](
-    clk: 1, go: 1, in: WIDTH
+    @clk(1) clk: 1, go: 1, in: WIDTH
   ) -> (
     out: WIDTH, done: 1
   );

--- a/tests/passes/collapse-control.expect
+++ b/tests/passes/collapse-control.expect
@@ -1,4 +1,4 @@
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
   }
   wires {

--- a/tests/passes/compile-control/compile-if-static.expect
+++ b/tests/passes/compile-control/compile-if-static.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     t = std_reg(1);
     f = std_reg(1);

--- a/tests/passes/compile-control/compile-if.expect
+++ b/tests/passes/compile-control/compile-if.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     t = std_reg(1);
     f = std_reg(1);

--- a/tests/passes/compile-control/compile-par-static.expect
+++ b/tests/passes/compile-control/compile-par-static.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     a = std_reg(2);
     b = std_reg(2);

--- a/tests/passes/compile-control/compile-par.expect
+++ b/tests/passes/compile-control/compile-par.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     a = std_reg(2);
     b = std_reg(2);

--- a/tests/passes/compile-control/compile-seq-static.expect
+++ b/tests/passes/compile-control/compile-seq-static.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     a = std_reg(2);
     b = std_reg(2);

--- a/tests/passes/compile-control/compile-seq.expect
+++ b/tests/passes/compile-control/compile-seq.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     a = std_reg(2);
     b = std_reg(2);

--- a/tests/passes/compile-control/compile-while-static.expect
+++ b/tests/passes/compile-control/compile-while-static.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     add = std_add(32);
     add_r = std_reg(32);

--- a/tests/passes/compile-control/compile-while.expect
+++ b/tests/passes/compile-control/compile-while.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     add = std_add(32);
     lt = std_lt(32);

--- a/tests/passes/compile-empty.expect
+++ b/tests/passes/compile-empty.expect
@@ -1,5 +1,5 @@
 import "primitives/core.futil";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     r = std_reg(1);
   }

--- a/tests/passes/compile-invoke.expect
+++ b/tests/passes/compile-invoke.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component exponent(base: 32, exp: 4, go: 1, clk: 1) -> (out: 32, done: 1) {
+component exponent(base: 32, exp: 4, @go go: 1, @clk clk: 1) -> (out: 32, @done done: 1) {
   cells {
     pow = std_reg(32);
   }
@@ -9,7 +9,7 @@ component exponent(base: 32, exp: 4, go: 1, clk: 1) -> (out: 32, done: 1) {
 
   control {}
 }
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     r = std_reg(32);
     const3 = std_const(4, 3);

--- a/tests/passes/component-interface.expect
+++ b/tests/passes/component-interface.expect
@@ -1,4 +1,4 @@
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
   }
   wires {

--- a/tests/passes/dead-cell-removal.expect
+++ b/tests/passes/dead-cell-removal.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component add(left: 32, right: 32, go: 1, clk: 1) -> (out: 32, done: 1) {
+component add(left: 32, right: 32, @go go: 1, @clk clk: 1) -> (out: 32, @done done: 1) {
   cells {
     adder = std_add(32);
     outpt = std_reg(32);
@@ -20,7 +20,7 @@ component add(left: 32, right: 32, go: 1, clk: 1) -> (out: 32, done: 1) {
     }
   }
 }
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     used_reg = std_reg(32);
     used_le = std_le(1);

--- a/tests/passes/externalize.expect
+++ b/tests/passes/externalize.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1, A_read_data: 32, A_done: 1) -> (done: 1, A_addr0: 4, A_write_data: 32, A_write_en: 1, A_clk: 1) {
+component main(@go go: 1, @clk clk: 1, A_read_data: 32, A_done: 1) -> (@done done: 1, A_addr0: 4, A_write_data: 32, A_write_en: 1, A_clk: 1) {
   cells {
     B = std_mem_d1(32, 16, 4);
     state = std_reg(32);

--- a/tests/passes/go-insertion.expect
+++ b/tests/passes/go-insertion.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     add = std_add(32);
   }

--- a/tests/passes/guard-canonicalize.expect
+++ b/tests/passes/guard-canonicalize.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (out: 1, done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (out: 1, @done done: 1) {
   cells {
     r0 = std_reg(1);
     r1 = std_reg(1);

--- a/tests/passes/infer-static/bounded-loop.expect
+++ b/tests/passes/infer-static/bounded-loop.expect
@@ -1,5 +1,5 @@
 import "primitives/core.futil";
-component main<"static"=10>(go: 1, clk: 1) -> (done: 1) {
+component main<"static"=10>(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     @external i = std_mem_d1(32, 1, 1);
     @external j = std_mem_d1(32, 1, 1);

--- a/tests/passes/infer-static/component.expect
+++ b/tests/passes/infer-static/component.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main<"static"=3>(go: 1, clk: 1) -> (done: 1) {
+component main<"static"=3>(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     a = std_reg(2);
     b = std_reg(2);

--- a/tests/passes/infer-static/constant-done.expect
+++ b/tests/passes/infer-static/constant-done.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main<"static"=0>(go: 1, clk: 1) -> (done: 1) {
+component main<"static"=0>(go: 1, clk: 1, @go go0: 1, @clk clk0: 1) -> (done: 1, @done done0: 1) {
   cells {
     r0 = std_reg(1);
     r1 = std_reg(1);

--- a/tests/passes/infer-static/groups.expect
+++ b/tests/passes/infer-static/groups.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(go: 1, clk: 1, @go go0: 1, @clk clk0: 1) -> (done: 1, @done done0: 1) {
   cells {
     r0 = std_reg(1);
     r1 = std_reg(1);

--- a/tests/passes/infer-static/invoke.expect
+++ b/tests/passes/infer-static/invoke.expect
@@ -1,5 +1,5 @@
 import "primitives/core.futil";
-component main<"static"=3>(go: 1, clk: 1) -> (done: 1) {
+component main<"static"=3>(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     r = std_reg(32);
     exp0 = exponent();
@@ -22,7 +22,7 @@ component main<"static"=3>(go: 1, clk: 1) -> (done: 1) {
     }
   }
 }
-component exponent<"static"=2>(base: 32, exp: 4, go: 1, clk: 1) -> (out: 32, done: 1) {
+component exponent<"static"=2>(base: 32, exp: 4, @go go: 1, @clk clk: 1) -> (out: 32, @done done: 1) {
   cells {
     r1 = std_reg(32);
     r2 = std_reg(32);

--- a/tests/passes/inliner.expect
+++ b/tests/passes/inliner.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     r1 = std_reg(32);
     r2 = std_reg(32);

--- a/tests/passes/merge-assign.expect
+++ b/tests/passes/merge-assign.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     r = std_reg(4);
     add = std_add(32);

--- a/tests/passes/minimize-regs/condition-register.expect
+++ b/tests/passes/minimize-regs/condition-register.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     x = std_reg(1);
   }

--- a/tests/passes/minimize-regs/continuous-assignment.expect
+++ b/tests/passes/minimize-regs/continuous-assignment.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (x_out: 32, done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (x_out: 32, @done done: 1) {
   cells {
     x_0 = std_reg(32);
     y_0 = std_reg(32);

--- a/tests/passes/minimize-regs/escape-boundary.expect
+++ b/tests/passes/minimize-regs/escape-boundary.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (x_out: 32, done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (x_out: 32, @done done: 1) {
   cells {
     x_0 = std_reg(32);
     y_0 = std_reg(32);

--- a/tests/passes/minimize-regs/invoke.expect
+++ b/tests/passes/minimize-regs/invoke.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component add(left: 32, right: 32, go: 1, clk: 1) -> (out: 32, done: 1) {
+component add(left: 32, right: 32, @go go: 1, @clk clk: 1) -> (out: 32, @done done: 1) {
   cells {
     adder = std_add(32);
     outpt = std_reg(32);
@@ -20,7 +20,7 @@ component add(left: 32, right: 32, go: 1, clk: 1) -> (out: 32, done: 1) {
     }
   }
 }
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     x = std_reg(32);
     add_x = std_add(32);

--- a/tests/passes/minimize-regs/live-register-analysis.expect
+++ b/tests/passes/minimize-regs/live-register-analysis.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component kernel(go: 1, clk: 1) -> (done: 1) {
+component kernel(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     @external A0 = std_mem_d1(32, 32, 6);
     A_read0_0 = std_reg(32);

--- a/tests/passes/minimize-regs/nested-par.expect
+++ b/tests/passes/minimize-regs/nested-par.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component kernel(go: 1, clk: 1) -> (done: 1) {
+component kernel(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     b0 = std_reg(32);
     before0 = std_reg(4);

--- a/tests/passes/minimize-regs/par-while-liveness.expect
+++ b/tests/passes/minimize-regs/par-while-liveness.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     @external a_src0 = std_mem_d1(32, 8, 4);
     a_src_read0_0 = std_reg(32);

--- a/tests/passes/minimize-regs/par-write.expect
+++ b/tests/passes/minimize-regs/par-write.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     x = std_reg(32);
     y = std_reg(32);

--- a/tests/passes/minimize-regs/simple-liveness.expect
+++ b/tests/passes/minimize-regs/simple-liveness.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component kernel(go: 1, clk: 1) -> (done: 1) {
+component kernel(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     b = std_reg(32);
     before = std_reg(4);

--- a/tests/passes/minimize-regs/thread-local.expect
+++ b/tests/passes/minimize-regs/thread-local.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     x = std_reg(32);
     y = std_reg(32);

--- a/tests/passes/regressions/group-multi-drive.expect
+++ b/tests/passes/regressions/group-multi-drive.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     r = std_reg(32);
     add = std_add(32);

--- a/tests/passes/resource-sharing/cond-port.expect
+++ b/tests/passes/resource-sharing/cond-port.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     gt0 = std_gt(32);
     gt1 = std_gt(32);

--- a/tests/passes/resource-sharing/multiple-cells.expect
+++ b/tests/passes/resource-sharing/multiple-cells.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     add0 = std_add(32);
     add1 = std_add(32);

--- a/tests/passes/resource-sharing/share-component.expect
+++ b/tests/passes/resource-sharing/share-component.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component my_add<"share"=1>(left: 32, right: 32, go: 1, clk: 1) -> (out: 32, done: 1) {
+component my_add<"share"=1>(left: 32, right: 32, @go go: 1, @clk clk: 1) -> (out: 32, @done done: 1) {
   cells {
     add = std_add(32);
   }
@@ -11,7 +11,7 @@ component my_add<"share"=1>(left: 32, right: 32, go: 1, clk: 1) -> (out: 32, don
 
   control {}
 }
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     add0 = my_add();
     add1 = my_add();

--- a/tests/passes/resource-sharing/share.expect
+++ b/tests/passes/resource-sharing/share.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     add0 = std_add(32);
     add1 = std_add(32);

--- a/tests/passes/unsharing/continuous.expect
+++ b/tests/passes/unsharing/continuous.expect
@@ -1,5 +1,5 @@
 import "primitives/core.futil";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     r = std_reg(32);
     x = std_reg(32);

--- a/tests/passes/unsharing/invoke.expect
+++ b/tests/passes/unsharing/invoke.expect
@@ -1,5 +1,5 @@
 import "primitives/std.lib";
-component add(left: 32, right: 32, go: 1, clk: 1) -> (out: 32, done: 1) {
+component add(left: 32, right: 32, @go go: 1, @clk clk: 1) -> (out: 32, @done done: 1) {
   cells {
     adder = std_add(32);
     outpt = std_reg(32);
@@ -21,7 +21,7 @@ component add(left: 32, right: 32, go: 1, clk: 1) -> (out: 32, done: 1) {
     }
   }
 }
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     x = std_reg(32);
     y = std_reg(32);

--- a/tests/passes/unsharing/unshare-par.expect
+++ b/tests/passes/unsharing/unshare-par.expect
@@ -1,5 +1,5 @@
 import "primitives/core.futil";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     x = std_reg(32);
     y = std_reg(32);

--- a/tests/passes/unsharing/unsharing.expect
+++ b/tests/passes/unsharing/unsharing.expect
@@ -1,5 +1,5 @@
 import "primitives/core.futil";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     r = std_reg(32);
     x = std_reg(32);

--- a/tests/passes/unsharing/while.expect
+++ b/tests/passes/unsharing/while.expect
@@ -1,5 +1,5 @@
 import "primitives/core.futil";
-component main(go: 1, clk: 1) -> (done: 1) {
+component main(@go go: 1, @clk clk: 1) -> (@done done: 1) {
   cells {
     r = std_reg(32);
     add2 = std_add(32);


### PR DESCRIPTION
Another slice from #571. This makes transitions the interface signals from `go/done` ports to ports with the `@go/@done` attributes.
