### PR TITLE
Fud interpreter integration

### DIFF
--- a/calyx/src/ir/id.rs
+++ b/calyx/src/ir/id.rs
@@ -1,14 +1,16 @@
 use crate::errors::Span;
 use derivative::Derivative;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Represents an identifier in a Futil program
-#[derive(Derivative, Clone, PartialOrd, Ord)]
+#[derive(Derivative, Clone, PartialOrd, Ord, Deserialize)]
 #[derivative(Hash, Eq, Debug)]
+#[serde(transparent)]
 pub struct Id {
     pub id: String,
     #[derivative(Hash = "ignore")]
     #[derivative(Debug = "ignore")]
+    #[serde(skip)]
     span: Option<Span>,
 }
 

--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -30,6 +30,7 @@ DEFAULT_CONFIGURATION = {
             "exec": "./target/debug/interp",
             "flags": None,
             "data": None,
+            "round_float_to_fixed": True,
         },
         "dahlia": {
             "exec": "dahlia",

--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -26,6 +26,11 @@ DEFAULT_CONFIGURATION = {
             "file_extensions": [".futil"],
             "flags": None,
         },
+        "interpreter": {
+            "exec": "./target/debug/interp",
+            "flags": None,
+            "data": None,
+        },
         "dahlia": {
             "exec": "dahlia",
             "file_extensions": [".fuse", ".dahlia"],

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -17,6 +17,7 @@ from .stages import (
     verilator,
     vivado,
     xilinx,
+    interpreter,
 )
 
 
@@ -105,6 +106,14 @@ def register_stages(registry, cfg):
             "Generate the XML metadata for Xilinx",
         )
     )
+    registry.register(
+        futil.FutilStage(
+            cfg,
+            "interpreter",
+            "-p none",
+            "Compile Calyx to Calyx",
+        )
+    )
 
     # Verilator
     registry.register(
@@ -131,6 +140,9 @@ def register_stages(registry, cfg):
     registry.register(xilinx.XilinxStage(cfg))
     registry.register(xilinx.HwEmulationStage(cfg))
     registry.register(xilinx.HwExecutionStage(cfg))
+
+    # Interpreter
+    registry.register(interpreter.InterpreterStage(cfg, "", "Run the interpreter"))
 
 
 def display_config(args, cfg):

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -3,12 +3,12 @@ from pathlib import Path
 import simplejson as sjson
 import numpy as np
 from fud.stages.verilator.numeric_types import FixedPoint, Bitnum
-from fud.errors import InvalidNumericType, Malformed
+from fud.errors import InvalidNumericType
 from fud.stages.verilator.json_to_dat import parse_fp_widths
 from calyx.utils import float_to_fixed_point
 
 
-from ..utils import shell, unwrap_or, TmpDir
+from ..utils import shell, TmpDir
 
 _FILE_NAME = "data.json"
 

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -140,7 +140,7 @@ def convert_to_json(output_dir, data, round_float_to_fixed):
                     raise error
 
         output_json[k] = list([convert(x) for x in arr.flatten()])
-    out_path = output_dir / "data.json"
+    out_path = output_dir / _FILE_NAME
 
     with out_path.open("w") as f:
         sjson.dump(output_json, f, indent=2, use_decimal=True)

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -1,0 +1,84 @@
+from fud.stages import Stage, SourceType, Source
+from pathlib import Path
+
+from ..utils import shell, unwrap_or, TmpDir
+
+_FILE_NAME = "data.json"
+
+
+class InterpreterStage(Stage):
+    def __init__(self, config, flags, desc):
+        super().__init__(
+            "interpreter",
+            "interpreter-out",
+            SourceType.Stream,
+            SourceType.Stream,
+            config,
+            desc,
+        )
+
+        self.flags = flags
+        self.data_path = self.config["stages", self.name, "data"]
+
+        self.setup()
+
+    def _define_steps(self, input_data):
+
+        cmd = " ".join(
+            [
+                self.cmd,
+                self.flags,
+                "-l",
+                self.config["global", "futil_directory"],
+                "--data {data_file}" if self.data_path else "",
+                "{target}",
+            ]
+        )
+
+        @self.step()
+        def mktmp() -> SourceType.Directory:
+            """
+            Make temporary directory to store Verilator build files.
+            """
+            return TmpDir()
+
+        @self.step()
+        def convert_json_to_interp_json(
+            tmpdir: SourceType.Directory, json_path: SourceType.Stream
+        ):
+            """
+            Creates a data file to initialze the interpreter memories
+            """
+            pass
+
+        @self.step()
+        def interpret(
+            target: SourceType.Path, tmpdir: SourceType.Directory
+        ) -> SourceType.Stream:
+            """
+            Invoke the interpreter
+            """
+            return shell(
+                cmd.format(data_file=Path(tmpdir.name) / _FILE_NAME, target=str(target))
+            )
+
+        @self.step()
+        def cleanup(tmpdir: SourceType.Directory):
+            """
+            Remove the temporary directory
+            """
+            tmpdir.remove()
+
+        # schedule
+
+        tmpdir = mktmp()
+
+        if self.data_path is not None:
+            convert_json_to_interp_json(
+                tmpdir, Source(Path(self.data_path), SourceType.Path)
+            )
+
+        result = interpret(input_data, tmpdir)
+        cleanup(tmpdir)
+
+        return result

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -1,5 +1,12 @@
 from fud.stages import Stage, SourceType, Source
 from pathlib import Path
+import simplejson as sjson
+import numpy as np
+from fud.stages.verilator.numeric_types import FixedPoint, Bitnum
+from fud.errors import InvalidNumericType, Malformed
+from fud.stages.verilator.json_to_dat import parse_fp_widths
+from calyx.utils import float_to_fixed_point
+
 
 from ..utils import shell, unwrap_or, TmpDir
 
@@ -49,7 +56,14 @@ class InterpreterStage(Stage):
             """
             Creates a data file to initialze the interpreter memories
             """
-            pass
+            round_float_to_fixed = self.config[
+                "stages", self.name, "round_float_to_fixed"
+            ]
+            convert_to_json(
+                tmpdir.name,
+                sjson.load(json_path, use_decimal=True),
+                round_float_to_fixed,
+            )
 
         @self.step()
         def interpret(
@@ -82,3 +96,51 @@ class InterpreterStage(Stage):
         cleanup(tmpdir)
 
         return result
+
+
+def convert_to_json(output_dir, data, round_float_to_fixed):
+    output_dir = Path(output_dir)
+    shape = {}
+    output_json = {}
+    for k, item in data.items():
+        arr = np.array(item["data"], str)
+        format = item["format"]
+
+        numeric_type = format["numeric_type"]
+        is_signed = format["is_signed"]
+        shape[k] = {"is_signed": is_signed}
+
+        if numeric_type not in {"bitnum", "fixed_point"}:
+            raise InvalidNumericType('Fud only supports "fixed_point" and "bitnum".')
+
+        is_fp = numeric_type == "fixed_point"
+        if is_fp:
+            width, int_width = parse_fp_widths(format)
+            shape[k]["int_width"] = int_width
+        else:
+            width = format["width"]
+
+        shape[k]["width"] = width
+
+        def convert(x):
+            with_prefix = False
+            if not is_fp:
+                return Bitnum(x, **shape[k]).bit_string(with_prefix)
+
+            try:
+                return FixedPoint(x, **shape[k]).bit_string(with_prefix)
+            except InvalidNumericType as error:
+                if round_float_to_fixed:
+                    # Only round if it is not already representable.
+                    fractional_width = width - int_width
+                    x = float_to_fixed_point(float(x), fractional_width)
+                    x = str(x)
+                    return FixedPoint(x, **shape[k]).bit_string(with_prefix)
+                else:
+                    raise error
+
+        output_json[k] = list([convert(x) for x in arr.flatten()])
+    out_path = output_dir / "data.json"
+
+    with out_path.open("w") as f:
+        sjson.dump(output_json, f, indent=2, use_decimal=True)

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -10,6 +10,8 @@ from calyx.utils import float_to_fixed_point
 
 from ..utils import shell, TmpDir
 
+# A local constant used only within this file largely for organizational
+# purposes and to avoid magic strings
 _FILE_NAME = "data.json"
 
 

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -141,7 +141,7 @@ def convert_to_json(output_dir, data, round_float_to_fixed):
                 else:
                     raise error
 
-        output_json[k] = list([convert(x) for x in arr.flatten()])
+        output_json[k] = [convert(x) for x in arr.flatten()]
     out_path = output_dir / _FILE_NAME
 
     with out_path.open("w") as f:

--- a/interp/src/environment.rs
+++ b/interp/src/environment.rs
@@ -198,31 +198,48 @@ impl InterpreterState {
                             map.insert(cl as ConstCell, Primitive::StdLt(lt));
                         }
                         "std_mem_d1" => {
-                            let m1 = primitives::StdMemD1::new(
+                            let mut m1 = primitives::StdMemD1::new(
                                 cl.get_parameter("WIDTH").unwrap(),
                                 cl.get_parameter("SIZE").unwrap(),
                                 cl.get_parameter("IDX_SIZE").unwrap(),
                             );
+                            if let Some(v) = mems
+                                .as_ref()
+                                .map(|x| x.get(cell_name))
+                                .flatten()
+                            {
+                                m1.initialize_memory(v)
+                            }
+
                             map.insert(
                                 cl as ConstCell,
                                 Primitive::StdMemD1(m1),
                             );
                         }
                         "std_mem_d2" => {
-                            let m2 = primitives::StdMemD2::new(
+                            let mut m2 = primitives::StdMemD2::new(
                                 cl.get_parameter("WIDTH").unwrap(),
                                 cl.get_parameter("D0_SIZE").unwrap(),
                                 cl.get_parameter("D1_SIZE").unwrap(),
                                 cl.get_parameter("D0_IDX_SIZE").unwrap(),
                                 cl.get_parameter("D1_IDX_SIZE").unwrap(),
                             );
+
+                            if let Some(v) = mems
+                                .as_ref()
+                                .map(|x| x.get(cell_name))
+                                .flatten()
+                            {
+                                m2.initialize_memory(v)
+                            }
+
                             map.insert(
                                 cl as ConstCell,
                                 Primitive::StdMemD2(m2),
                             );
                         }
                         "std_mem_d3" => {
-                            let m3 = primitives::StdMemD3::new(
+                            let mut m3 = primitives::StdMemD3::new(
                                 cl.get_parameter("WIDTH").unwrap(),
                                 cl.get_parameter("D0_SIZE").unwrap(),
                                 cl.get_parameter("D1_SIZE").unwrap(),
@@ -231,13 +248,22 @@ impl InterpreterState {
                                 cl.get_parameter("D1_IDX_SIZE").unwrap(),
                                 cl.get_parameter("D2_IDX_SIZE").unwrap(),
                             );
+
+                            if let Some(v) = mems
+                                .as_ref()
+                                .map(|x| x.get(cell_name))
+                                .flatten()
+                            {
+                                m3.initialize_memory(v)
+                            }
+
                             map.insert(
                                 cl as ConstCell,
                                 Primitive::StdMemD3(m3),
                             );
                         }
                         "std_mem_d4" => {
-                            let m4 = primitives::StdMemD4::new(
+                            let mut m4 = primitives::StdMemD4::new(
                                 cl.get_parameter("WIDTH").unwrap(),
                                 cl.get_parameter("D0_SIZE").unwrap(),
                                 cl.get_parameter("D1_SIZE").unwrap(),
@@ -248,6 +274,15 @@ impl InterpreterState {
                                 cl.get_parameter("D2_IDX_SIZE").unwrap(),
                                 cl.get_parameter("D3_IDX_SIZE").unwrap(),
                             );
+
+                            if let Some(v) = mems
+                                .as_ref()
+                                .map(|x| x.get(cell_name))
+                                .flatten()
+                            {
+                                m4.initialize_memory(v)
+                            }
+
                             map.insert(
                                 cl as ConstCell,
                                 Primitive::StdMemD4(m4),

--- a/interp/src/lib.rs
+++ b/interp/src/lib.rs
@@ -6,3 +6,5 @@ pub mod values;
 
 mod test;
 mod utils;
+
+pub use utils::MemoryMap;

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -26,6 +26,10 @@ pub struct Opts {
     /// Path to the primitives library
     #[structopt(long, short, default_value = "..")]
     pub lib_path: PathBuf,
+
+    /// Path to optional datafile
+    #[structopt(long = "data", short = "d", parse(from_os_str))]
+    pub data_file: Option<PathBuf>,
 }
 
 //first half of this is tests

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -47,7 +47,9 @@ fn main() -> FutilResult<()> {
 
     pm.execute_plan(&mut ctx.borrow_mut(), &["validate".to_string()], &[])?;
 
-    let env = environment::InterpreterState::init(&ctx);
+    let mems = interp::MemoryMap::inflate_map(&opts.data_file)?;
+
+    let env = environment::InterpreterState::init(&ctx, &mems);
 
     // Get main component; assuming that opts.component is main
     // TODO: handle when component, group are not default values

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -27,7 +27,8 @@ pub struct Opts {
     #[structopt(long, short, default_value = "..")]
     pub lib_path: PathBuf,
 
-    /// Path to optional datafile
+    /// Path to optional datafile used to initialze memories. If it is not
+    /// provided memories will be initialzed with zeros
     #[structopt(long = "data", short = "d", parse(from_os_str))]
     pub data_file: Option<PathBuf>,
 }

--- a/interp/src/primitives.rs
+++ b/interp/src/primitives.rs
@@ -2,6 +2,7 @@
 // standard library.
 use super::values::{OutputValue, PulseValue, TimeLockedValue, Value};
 use calyx::ir;
+use itertools::Itertools;
 use serde::Serialize;
 use std::ops::*;
 
@@ -475,6 +476,15 @@ impl StdMemD1 {
             update: None,
         }
     }
+
+    pub fn initialize_memory(&mut self, vals: &[Value]) {
+        assert_eq!(self.size as usize, vals.len());
+
+        for (idx, val) in vals.iter().enumerate() {
+            assert_eq!(val.len(), self.width as usize);
+            self.data[idx] = val.clone()
+        }
+    }
 }
 
 impl ValidateInput for StdMemD1 {
@@ -641,7 +651,7 @@ pub struct StdMemD2 {
     pub d1_size: u64,
     pub d0_idx_size: u64,
     pub d1_idx_size: u64, // # bits needed to index a piece of mem
-    pub data: Vec<Vec<Value>>,
+    pub data: Vec<Value>,
     update: Option<(u64, u64, Value)>,
 }
 
@@ -658,10 +668,8 @@ impl StdMemD2 {
         d1_idx_size: u64,
     ) -> StdMemD2 {
         //data is a 2d vector
-        let data = vec![
-            vec![Value::zeroes(width as usize); d1_size as usize];
-            d0_size as usize
-        ];
+        let data =
+            vec![Value::zeroes(width as usize); (d0_size * d1_size) as usize];
         StdMemD2 {
             width,
             d0_size,
@@ -671,6 +679,20 @@ impl StdMemD2 {
             data,
             update: None,
         }
+    }
+
+    pub fn initialize_memory(&mut self, vals: &[Value]) {
+        assert_eq!((self.d0_size * self.d1_size) as usize, vals.len());
+
+        for (idx, val) in vals.iter().enumerate() {
+            assert_eq!(val.len(), self.width as usize);
+            self.data[idx] = val.clone()
+        }
+    }
+
+    #[inline]
+    fn calc_addr(&self, addr0: u64, addr1: u64) -> u64 {
+        addr1 + addr0 * self.d1_size
     }
 }
 
@@ -727,9 +749,10 @@ impl ExecuteStateful for StdMemD2 {
 
         //chech that addr1 is not out of bounds and that it is the proper iwdth
         let addr1 = addr1.as_u64();
+        let real_addr = self.calc_addr(addr0, addr1);
 
-        let old = self.data[addr0 as usize][addr1 as usize].clone(); //not sure if this could lead to errors (Some(old)) is borrow?
-                                                                     // only write to memory if write_en is 1
+        let old = self.data[real_addr as usize].clone(); //not sure if this could lead to errors (Some(old)) is borrow?
+                                                         // only write to memory if write_en is 1
         if write_en.as_u64() == 1 {
             self.update = Some((addr0, addr1, (*input).clone()));
             // what's in this vector:
@@ -770,7 +793,9 @@ impl ExecuteStateful for StdMemD2 {
         let addr0 = addr0.as_u64();
         let addr1 = addr1.as_u64();
 
-        let old = self.data[addr0 as usize][addr1 as usize].clone();
+        let real_addr = self.calc_addr(addr0, addr1);
+
+        let old = self.data[real_addr as usize].clone();
 
         vec![
             (ir::Id::from("read_data"), old.into()),
@@ -780,7 +805,8 @@ impl ExecuteStateful for StdMemD2 {
 
     fn commit_updates(&mut self) {
         if let Some((addr0, addr1, val)) = self.update.take() {
-            self.data[addr0 as usize][addr1 as usize] = val;
+            let real_addr = self.calc_addr(addr0, addr1);
+            self.data[real_addr as usize] = val;
         }
     }
 
@@ -797,7 +823,9 @@ impl Serialize for StdMemD2 {
         let mem = self
             .data
             .iter()
-            .map(|x| x.iter().map(|y| y.as_u64()).collect::<Vec<_>>())
+            .chunks(self.d1_size as usize)
+            .into_iter()
+            .map(|x| x.into_iter().map(|y| y.as_u64()).collect::<Vec<_>>())
             .collect::<Vec<_>>();
         mem.serialize(serializer)
     }
@@ -831,7 +859,7 @@ pub struct StdMemD3 {
     d0_idx_size: u64,
     d1_idx_size: u64,
     d2_idx_size: u64,
-    data: Vec<Vec<Vec<Value>>>,
+    data: Vec<Value>,
     update: Option<(u64, u64, u64, Value)>,
 }
 
@@ -849,14 +877,10 @@ impl StdMemD3 {
         d1_idx_size: u64,
         d2_idx_size: u64,
     ) -> StdMemD3 {
-        let data =
-            vec![
-                vec![
-                    vec![Value::zeroes(width as usize); d2_size as usize];
-                    d1_size as usize
-                ];
-                d0_size as usize
-            ];
+        let data = vec![
+            Value::zeroes(width as usize);
+            (d0_size * d1_size * d2_size) as usize
+        ];
         StdMemD3 {
             width,
             d0_size,
@@ -868,6 +892,23 @@ impl StdMemD3 {
             data,
             update: None,
         }
+    }
+
+    pub fn initialize_memory(&mut self, vals: &[Value]) {
+        assert_eq!(
+            (self.d0_size * self.d1_size * self.d2_size) as usize,
+            vals.len()
+        );
+
+        for (idx, val) in vals.iter().enumerate() {
+            assert_eq!(val.len(), self.width as usize);
+            self.data[idx] = val.clone()
+        }
+    }
+
+    #[inline]
+    fn calc_addr(&self, addr0: u64, addr1: u64, addr2: u64) -> u64 {
+        addr2 + self.d2_size * (addr1 + addr0 * self.d1_size)
     }
 }
 
@@ -929,8 +970,9 @@ impl ExecuteStateful for StdMemD3 {
         let addr1 = addr1.as_u64();
         let addr2 = addr2.as_u64();
 
-        let old =
-            self.data[addr0 as usize][addr1 as usize][addr2 as usize].clone();
+        let real_addr = self.calc_addr(addr0, addr1, addr2);
+
+        let old = self.data[real_addr as usize].clone();
         //not sure if this could lead to errors (Some(old)) is borrow?
         // only write to memory if write_en is 1
         if write_en.as_u64() == 1 {
@@ -977,8 +1019,9 @@ impl ExecuteStateful for StdMemD3 {
         let addr1 = addr1.as_u64();
         let addr2 = addr2.as_u64();
 
-        let old =
-            self.data[addr0 as usize][addr1 as usize][addr2 as usize].clone();
+        let real_addr = self.calc_addr(addr0, addr1, addr2);
+
+        let old = self.data[real_addr as usize].clone();
         vec![
             (ir::Id::from("read_data"), old.into()),
             (ir::Id::from("done"), Value::zeroes(1).into()),
@@ -987,7 +1030,9 @@ impl ExecuteStateful for StdMemD3 {
 
     fn commit_updates(&mut self) {
         if let Some((addr0, addr1, addr2, val)) = self.update.take() {
-            self.data[addr0 as usize][addr1 as usize][addr2 as usize] = val;
+            let real_addr = self.calc_addr(addr0, addr1, addr2);
+
+            self.data[real_addr as usize] = val;
         }
     }
 
@@ -1004,9 +1049,15 @@ impl Serialize for StdMemD3 {
         let mem = self
             .data
             .iter()
+            .chunks((self.d2_size * self.d1_size) as usize)
+            .into_iter()
             .map(|x| {
-                x.iter()
-                    .map(|y| y.iter().map(|z| z.as_u64()).collect::<Vec<_>>())
+                x.into_iter()
+                    .chunks(self.d1_size as usize)
+                    .into_iter()
+                    .map(|y| {
+                        y.into_iter().map(|z| z.as_u64()).collect::<Vec<_>>()
+                    })
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
@@ -1047,7 +1098,7 @@ pub struct StdMemD4 {
     d1_idx_size: u64,
     d2_idx_size: u64,
     d3_idx_size: u64,
-    data: Vec<Vec<Vec<Vec<Value>>>>,
+    data: Vec<Value>,
     update: Option<(u64, u64, u64, u64, Value)>,
 }
 
@@ -1068,17 +1119,10 @@ impl StdMemD4 {
         d2_idx_size: u64,
         d3_idx_size: u64,
     ) -> StdMemD4 {
-        let data =
-            vec![
-                vec![
-                    vec![
-                        vec![Value::zeroes(width as usize); d3_size as usize];
-                        d2_size as usize
-                    ];
-                    d1_size as usize
-                ];
-                d0_size as usize
-            ];
+        let data = vec![
+            Value::zeroes(width as usize);
+            (d0_size * d1_size * d2_size * d3_size) as usize
+        ];
         StdMemD4 {
             width,
             d0_size,
@@ -1092,6 +1136,26 @@ impl StdMemD4 {
             data,
             update: None,
         }
+    }
+
+    pub fn initialize_memory(&mut self, vals: &[Value]) {
+        assert_eq!(
+            (self.d0_size * self.d1_size * self.d2_size * self.d3_size)
+                as usize,
+            vals.len()
+        );
+
+        for (idx, val) in vals.iter().enumerate() {
+            assert_eq!(val.len(), self.width as usize);
+            self.data[idx] = val.clone()
+        }
+    }
+
+    #[inline]
+    fn calc_addr(&self, addr0: u64, addr1: u64, addr2: u64, addr3: u64) -> u64 {
+        addr3
+            + self.d3_size
+                * (addr2 + self.d2_size * (addr1 + addr0 * self.d1_size))
     }
 }
 
@@ -1159,10 +1223,10 @@ impl ExecuteStateful for StdMemD4 {
         let addr2 = addr2.as_u64();
         let addr3 = addr3.as_u64();
 
-        let old = self.data[addr0 as usize][addr1 as usize][addr2 as usize]
-            [addr3 as usize]
-            .clone(); //not sure if this could lead to errors (Some(old)) is borrow?
-                      // only write to memory if write_en is 1
+        let real_addr = self.calc_addr(addr0, addr1, addr2, addr3);
+
+        let old = self.data[real_addr as usize].clone(); //not sure if this could lead to errors (Some(old)) is borrow?
+                                                         // only write to memory if write_en is 1
         if write_en.as_u64() == 1 {
             self.update = Some((addr0, addr1, addr2, addr3, (*input).clone()));
 
@@ -1208,10 +1272,9 @@ impl ExecuteStateful for StdMemD4 {
         let addr1 = addr1.as_u64();
         let addr2 = addr2.as_u64();
         let addr3 = addr3.as_u64();
+        let real_addr = self.calc_addr(addr0, addr1, addr2, addr3);
 
-        let old = self.data[addr0 as usize][addr1 as usize][addr2 as usize]
-            [addr3 as usize]
-            .clone();
+        let old = self.data[real_addr as usize].clone();
 
         vec![
             (ir::Id::from("read_data"), old.into()),
@@ -1221,8 +1284,8 @@ impl ExecuteStateful for StdMemD4 {
 
     fn commit_updates(&mut self) {
         if let Some((addr0, addr1, addr2, addr3, val)) = self.update.take() {
-            self.data[addr0 as usize][addr1 as usize][addr2 as usize]
-                [addr3 as usize] = val;
+            let real_addr = self.calc_addr(addr0, addr1, addr2, addr3);
+            self.data[real_addr as usize] = val;
         }
     }
 
@@ -1239,12 +1302,18 @@ impl Serialize for StdMemD4 {
         let mem = self
             .data
             .iter()
+            .chunks((self.d3_size * self.d2_size * self.d1_size) as usize)
+            .into_iter()
             .map(|x| {
-                x.iter()
+                x.into_iter()
+                    .chunks((self.d2_size * self.d1_size) as usize)
+                    .into_iter()
                     .map(|y| {
-                        y.iter()
+                        y.into_iter()
+                            .chunks(self.d1_size as usize)
+                            .into_iter()
                             .map(|z| {
-                                z.iter()
+                                z.into_iter()
                                     .map(|val| val.as_u64())
                                     .collect::<Vec<_>>()
                             })

--- a/interp/src/primitives.rs
+++ b/interp/src/primitives.rs
@@ -692,7 +692,7 @@ impl StdMemD2 {
 
     #[inline]
     fn calc_addr(&self, addr0: u64, addr1: u64) -> u64 {
-        addr1 + addr0 * self.d1_size
+        addr0 * self.d1_size + addr1
     }
 }
 
@@ -908,7 +908,7 @@ impl StdMemD3 {
 
     #[inline]
     fn calc_addr(&self, addr0: u64, addr1: u64, addr2: u64) -> u64 {
-        addr2 + self.d2_size * (addr1 + addr0 * self.d1_size)
+        self.d2_size * (addr0 * self.d1_size + addr1) + addr2
     }
 }
 
@@ -1153,9 +1153,8 @@ impl StdMemD4 {
 
     #[inline]
     fn calc_addr(&self, addr0: u64, addr1: u64, addr2: u64, addr3: u64) -> u64 {
-        addr3
-            + self.d3_size
-                * (addr2 + self.d2_size * (addr1 + addr0 * self.d1_size))
+        self.d3_size * (self.d2_size * (addr0 * self.d1_size + addr1) + addr2)
+            + addr3
     }
 }
 

--- a/interp/src/utils.rs
+++ b/interp/src/utils.rs
@@ -1,7 +1,13 @@
 use crate::values::{OutputValue, PulseValue, TimeLockedValue, Value};
-use calyx::ir::{Assignment, Cell, Port, RRC};
+use calyx::errors::Error;
+use calyx::ir::{Assignment, Cell, Id, Port, RRC};
+use serde::Deserialize;
+use serde_json;
+use std::collections::HashMap;
+use std::fs;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
+use std::path::PathBuf;
 pub(super) struct PortRef(RRC<Port>);
 
 impl Deref for PortRef {
@@ -177,5 +183,38 @@ impl From<RRC<Cell>> for CellRef {
 impl From<&RRC<Cell>> for CellRef {
     fn from(input: &RRC<Cell>) -> Self {
         Self(input.clone())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub struct MemoryMap(HashMap<Id, Vec<Value>>);
+
+impl MemoryMap {
+    pub fn inflate_map(path: &Option<PathBuf>) -> Result<Option<Self>, Error> {
+        if let Some(path) = path {
+            let v = fs::read(path)?;
+            let file_contents = std::str::from_utf8(&v)?;
+            let map: MemoryMap = serde_json::from_str(file_contents).unwrap();
+            return Ok(Some(map));
+        }
+
+        Ok(None)
+    }
+}
+
+impl Deref for MemoryMap {
+    type Target = HashMap<Id, Vec<Value>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+use std::ops::DerefMut;
+
+impl DerefMut for MemoryMap {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }

--- a/interp/src/utils.rs
+++ b/interp/src/utils.rs
@@ -2,7 +2,6 @@ use crate::values::{OutputValue, PulseValue, TimeLockedValue, Value};
 use calyx::errors::Error;
 use calyx::ir::{Assignment, Cell, Id, Port, RRC};
 use serde::Deserialize;
-use serde_json;
 use std::collections::HashMap;
 use std::fs;
 use std::hash::{Hash, Hasher};

--- a/interp/src/values.rs
+++ b/interp/src/values.rs
@@ -1,4 +1,5 @@
 use bitvec::prelude::*;
+use serde::de::{self, Deserialize, Visitor};
 use std::convert::TryInto;
 
 // Lsb0 means [10010] gives 0 at index 0, 1 at index 1, 0 at index 2, etc
@@ -507,5 +508,41 @@ impl OutputValue {
             OutputValue::LockedValue(v) => v.do_tick(),
             OutputValue::PulseValue(v) => v.do_tick(),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for Value {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct BitVecVisitor;
+
+        impl<'de> Visitor<'de> for BitVecVisitor {
+            type Value = BitVec<Lsb0, u64>;
+
+            fn expecting(
+                &self,
+                formatter: &mut std::fmt::Formatter,
+            ) -> std::fmt::Result {
+                formatter.write_str("Expected bitstring")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let mut vec = BitVec::<Lsb0, u64>::new();
+                let s = String::from(value);
+                for c in s.chars() {
+                    let bit: bool = c.to_digit(2).unwrap() == 1;
+                    vec.insert(0, bit)
+                }
+                Ok(vec)
+            }
+        }
+
+        let val = deserializer.deserialize_str(BitVecVisitor)?;
+        Ok(crate::values::Value { vec: val })
     }
 }

--- a/interp/tests/while.futil.data
+++ b/interp/tests/while.futil.data
@@ -1,0 +1,12 @@
+{
+  "i": {
+    "data": [
+      147
+    ],
+    "format": {
+      "numeric_type": "bitnum",
+      "is_signed": false,
+      "width": 32
+    }
+  }
+}


### PR DESCRIPTION
An attempt to close #560.

Major changes include:

***fud support for invoking the interpreter***
  try `fud e --to interpreter-out ...`

***fud support for passing data files to the interpreter***
  try `fud exec --to interpreter-out tests/while.futil -s interpreter.data tests/while.futil.data `

***Interpreter can now take and initialize memories based on the data marshaled from fud***

***memories are now a flat vec with row-major ordering indexing***

***NEW SERIALIZATION CRIMES***

Anyway, this still needs a bit of work, mainly in the writing tests department. But also someone please check my work wrt the row-major ordering calculations because I don't know that I did them correctly.

Also there's a bug in `tests/while.futil` for the interpreter since the addr0 of the memory is never set and the cond group doesn't assign to it while reading. The solution would be to give the initial value of a memory's read_data port the value of the zero index, or we could just decide this program is bad and should feel bad?

Anyway, my brain feels like spaghetti, so I'm going to stop writing words.