### PR TITLE
Remove an accidental dependency for fud

### DIFF
--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -4,9 +4,7 @@ import simplejson as sjson
 import numpy as np
 from fud.stages.verilator.numeric_types import FixedPoint, Bitnum
 from fud.errors import InvalidNumericType
-from fud.stages.verilator.json_to_dat import parse_fp_widths
-from calyx.utils import float_to_fixed_point
-
+from fud.stages.verilator.json_to_dat import parse_fp_widths, float_to_fixed
 
 from ..utils import shell, TmpDir
 
@@ -135,7 +133,7 @@ def convert_to_json(output_dir, data, round_float_to_fixed):
                 if round_float_to_fixed:
                     # Only round if it is not already representable.
                     fractional_width = width - int_width
-                    x = float_to_fixed_point(float(x), fractional_width)
+                    x = float_to_fixed(float(x), fractional_width)
                     x = str(x)
                     return FixedPoint(x, **shape[k]).bit_string(with_prefix)
                 else:

--- a/fud/fud/stages/verilator/json_to_dat.py
+++ b/fud/fud/stages/verilator/json_to_dat.py
@@ -3,7 +3,14 @@ import numpy as np
 from .numeric_types import FixedPoint, Bitnum
 from pathlib import Path
 from fud.errors import InvalidNumericType, Malformed
-from calyx.utils import float_to_fixed_point
+
+
+def float_to_fixed(value: float, N: int) -> float:
+    """Round a float to a new float that could be represented with N
+    fractional bits in a fixed-point representation.
+    """
+    w = 2 << (N - 1)
+    return round(value * w) / float(w)
 
 
 def parse_dat(path, args):
@@ -113,7 +120,7 @@ def convert2dat(output_dir, data, extension, round_float_to_fixed):
                 if round_float_to_fixed:
                     # Only round if it is not already representable.
                     fractional_width = width - int_width
-                    x = float_to_fixed_point(float(x), fractional_width)
+                    x = float_to_fixed(float(x), fractional_width)
                     x = str(x)
                     return FixedPoint(x, **shape[k]).hex_string(with_prefix)
                 else:


### PR DESCRIPTION
At some point, fud started using a float-to-fixed conversion utility from the calyx-py library. I think this was a mistake because calyx-py is really just for Calyx code generators (frontends); it's not, like, a general-purpose library for all things Calyx. And because this dependency was undeclared, it meant that someone following our setup instructions would end up with a "broken" fud and would need to go back and install calyx-py as well.

This duplicates that utility function, which removes the accidental dependency. I think it's not too much of a sin to copy & paste the code because it's so little code. I also thought the original docstring was somewhat inaccurate, so I tried a slightly better one.