### PR TITLE
Expand interpreter docs

### DIFF
--- a/docs/fud/examples.md
+++ b/docs/fud/examples.md
@@ -57,3 +57,16 @@ fud exec \
   -s verilog.data examples/dahlia/dot-product.fuse.data
 ```
 
+**Interpreting Calyx.**
+In addition to Verilator, fud can execute Calyx programs using the experimental [interpreter](../interpreter.md).
+
+```bash
+# Execute a Calyx program without compiling it,
+# producing a JSON snapshot of the final state.
+# === Calyx:   tests/correctness/while.futil
+# === data:    tests/correctness/while.futil.data
+fud exec \
+  tests/correctness/while.futil \
+  -s interpreter.data tests/correctness/while.futil.data \
+  --to interpreter-out
+```

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -2,11 +2,44 @@
 
 The experimental Calyx interpreter resides in the `interp/` directory of the
 repository.
+The interpreter supports all Calyx programs---from high-level programs that
+make heavy use of control operators, to fully lowered Calyx programs.
+(RTL simulation, in contrast, only supports execution of fully lowered programs.)
 
-In order to run an example program, run:
-```
-cd interp/ && cargo run interp/tests/add_feeding.futil
-```
+There are two ways to use the interpreter: you can directly invoke it, or you can use [fud][].
 
-The interpreter supports all Calyx programs--from high-level programs that make
-heavy use of control operators, to fully lowered Calyx programs.
+## Basic Use
+
+To run an example program, try:
+
+    cd interp && cargo run tests/control/if.futil
+
+You can see the available command-line options by typing `cargo run -- --help`.
+
+## Interpreting via fud
+
+The interpreter is available as a stage in [fud][], which lets you provide standard JSON data files as input and easily execute passes on the input Calyx program before interpretation.
+
+You'll want to build the interpreter first:
+
+    cd interp && cargo build
+
+Here's how to run a Calyx program:
+
+    fud e --to interpreter-out interp/tests/control/if.futil
+
+To provide input data, set the `interpreter.data` variable, like so:
+
+    fud e --to interpreter-out \
+        -s interpreter.data tests/correctness/while.futil.data \
+        tests/correctness/while.futil
+
+By default, fud will not transform the Calyx code before feeding it to the interpreter.
+To run passes before the interpreter, use the `futil.flags` variable in conjunction with the `-p` flag.
+For example, to fully lower the Calyx program before interpreting it:
+
+    fud e --to interpreter-out \
+        -s futil.flags '-p all' \
+        interp/tests/control/if.futil
+
+[fud]: fud/index.md


### PR DESCRIPTION
This just expands the docs a little to show how to use the interpreter via fud. The examples are based on @EclecticGriffin's commands from #583. (Basically, I just tried all this out myself and recorded how I figured out how to do it.)