### PR TITLE
Update attribute documentation

### DIFF
--- a/docs/lang/attributes.md
+++ b/docs/lang/attributes.md
@@ -59,8 +59,11 @@ Can be attached to components, groups, and control statements. They indicate how
 many cycles a component, group, or control statement will take to run and are used
 by `-p static-timing` to generate more efficient control FSMs.
 
-### `go` and `done`
-Used by the `infer-static-timing` pass to configure which ports are used like
+### `go`, `done`, and `reset`
+These three ports are part of the interface to Calyx components.
+They are the mechanism for how an "outer" component invokes an "inner" cell that it contains.
+
+The `go` and `done` attributes are, in particular, used by the `infer-static-timing` pass to configure which ports are used like
 `go` and `done` signals.
 Along with the `static(n)` attribute, this allows the pass to calculate when
 a particular done signal of a primitive will be high.

--- a/docs/lang/attributes.md
+++ b/docs/lang/attributes.md
@@ -80,4 +80,7 @@ of a `While` control is known statically, as indicated by `n`.
 ### `generated`
 Added by [`ir::Builder`][builder] to denote that the cell was added by a pass.
 
+### `clk`
+Marks the special clock signal inserted by the `clk-insertion` pass, which helps with lowering to RTL languages that require an explicit clock.
+
 [builder]: https://capra.cs.cornell.edu/docs/calyx/source/calyx/ir/struct.Builder.html

--- a/docs/lang/attributes.md
+++ b/docs/lang/attributes.md
@@ -4,10 +4,16 @@ Calyx has an attribute system that allows information to be associated with
 every basic Calyx construct. This information can then be used to optimize the program
 or change how the program is compiled.
 
+Attributes can decorate lots of things in Calyx: components, groups, cells, ports, and control statements.
+The syntax looks like `name<"attr"=value>` for components and groups or `@attr(value)` for other constructs.
+Attributes always map keys to values.
+Because it's common to have a "Boolean" attribute that always maps to the value 1, the syntax `@attr` is a shorthand for `@attr(1)`.
+
 Here is the syntax for attributes in different parts of the AST:
+
 #### **Component and Port Attributes**
 ```
-component main<"static"=10>(@go(1) go: 1) -> (@done(1) done: 1) {
+component main<"static"=10>(@go go: 1) -> (@done done: 1) {
  ...
 }
 ```
@@ -15,7 +21,7 @@ component main<"static"=10>(@go(1) go: 1) -> (@done(1) done: 1) {
 #### **Cell Attributes**
 ```
 cells {
-  @external(1) mem = std_mem_d1(32, 8, 4);
+  @external mem = std_mem_d1(32, 8, 4);
   reg = std_reg(32);
   ...
 }
@@ -39,8 +45,8 @@ control {
 ```
 
 ## Meaning of Attributes
-### `external(1)`
-The `external(1)` attribute has meaning when it is attached to a cell.
+### `external`
+The `external` attribute has meaning when it is attached to a cell.
 It has two meanings:
 1. If the `externalize` pass is enabled, the cell is turned into an "external"
    cell by exposing all its ports through the current component and rewriting
@@ -53,13 +59,13 @@ Can be attached to components, groups, and control statements. They indicate how
 many cycles a component, group, or control statement will take to run and are used
 by `-p static-timing` to generate more efficient control FSMs.
 
-### `go(1)` and `done(1)`
+### `go` and `done`
 Used by the `infer-static-timing` pass to configure which ports are used like
 `go` and `done` signals.
 Along with the `static(n)` attribute, this allows the pass to calculate when
 a particular done signal of a primitive will be high.
 
-### `share(1)`
+### `share`
 Can be attached to a component and indicates that a component can be shared
 across groups. This is used by the `-p resource-sharing` to decide which components
 can be shared.


### PR DESCRIPTION
This adds a few things:

* Use the shorthand `@attr` syntax introduced in #566, where appropriate.
* Document the `@reset` attribute added in #579. Also, slightly expand the discussion of the role of it, `@go`, and `@done`, although this topic probably needs a deep discussion of its own someday.
* Document the `@clk` attribute (tersely).