### PR TITLE
upgrade runt version

### DIFF
--- a/interp/runt.toml
+++ b/interp/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.2.8"
+ver = "0.3.1"
 
 # Check basic functionality of the interpreter
 [[tests]]

--- a/runt.toml
+++ b/runt.toml
@@ -1,4 +1,4 @@
-ver = "0.2.8"
+ver = "0.3.1"
 
 ##### Compilation Tests ######
 ## Test each pass in isolation. Gets the pass flags from a comment on the first line of the file


### PR DESCRIPTION
New version of runt (0.3.1) is out! You'll have to run `cargo install runt`
to get the latest version.

Please report any problems to: https://github.com/rachitnigam/runt/issues/new
