### PR TITLE
Use `argh` instead of `structopt` for parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 build = false
 
 [dependencies]
-structopt = "~0.3"
 calyx = { path = "calyx" }
 pest = "2.0"
 itertools = "0.9.0"
 atty = "0.2.14"
+argh = "0.1"
 
 [workspace]
 members = ["calyx", "interp"]

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -10,13 +10,13 @@ doctest = false # Don't run doc tests
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-structopt = "~0.3"
 calyx = { path = "../calyx" }
 bitvec = "0.22.3"
 smallvec = "1.6.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 itertools = "0.10.1"
+argh = "0.1.5"
 
 [dependencies.serde_with]
 version = "1.6.4"

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -5,38 +5,46 @@ use calyx::{
     utils::OutputFile,
 };
 
+use argh::FromArgs;
 use interp::environment;
 use interp::interpreter::interpret_component;
-use std::cell::RefCell;
 use std::path::PathBuf;
-use structopt::StructOpt;
+use std::{cell::RefCell, path::Path};
 
-/// CLI Options
-#[derive(Debug, StructOpt)]
-#[structopt(name = "interpreter", about = "interpreter CLI")]
+#[derive(FromArgs)]
+/// The Calyx Interpreter
 pub struct Opts {
-    /// Input file
-    #[structopt(parse(from_os_str))]
+    /// input file
+    #[argh(positional, from_str_fn(read_path))]
     pub file: Option<PathBuf>,
 
-    /// Output file, default is stdout
-    #[structopt(short = "o", long = "output", default_value)]
+    /// output file, default is stdout
+    #[argh(
+        option,
+        short = 'o',
+        long = "output",
+        default = "OutputFile::default()"
+    )]
     pub output: OutputFile,
 
-    /// Path to the primitives library
-    #[structopt(long, short, default_value = "..")]
+    /// path to the primitives library
+    #[argh(option, short = 'l', default = "Path::new(\"..\").into()")]
     pub lib_path: PathBuf,
 
-    /// Path to optional datafile used to initialze memories. If it is not
+    /// path to optional datafile used to initialze memories. If it is not
     /// provided memories will be initialzed with zeros
-    #[structopt(long = "data", short = "d", parse(from_os_str))]
+    #[argh(option, long = "data", short = 'd', from_str_fn(read_path))]
     pub data_file: Option<PathBuf>,
+}
+
+fn read_path(path: &str) -> Result<PathBuf, String> {
+    Ok(Path::new(path).into())
 }
 
 //first half of this is tests
 /// Interpret a group from a Calyx program
 fn main() -> CalyxResult<()> {
-    let opts = Opts::from_args();
+    let opts: Opts = argh::from_env();
 
     // Construct IR
     let namespace = frontend::NamespaceDef::new(&opts.file, &opts.lib_path)?;

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -126,8 +126,7 @@ impl ToString for BackendOpt {
             Self::Verilog => "verilog",
             Self::Xilinx => "xilinx",
             Self::XilinxXml => "xilinx-xml",
-            Self::Calyx => "futil",
-            // Self::Dot => "dot",
+            Self::Calyx => "calyx",
             Self::None => "none",
         }
         .to_string()

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -164,4 +164,16 @@ impl Opts {
             BackendOpt::None => Ok(()),
         }
     }
+
+    /// Get the current set of options from the command line invocation.
+    pub fn get_opts() -> Opts {
+        let mut opts: Opts = argh::from_env();
+
+        // argh doesn't allow us to specify a default for this so we fill it
+        // in manually.
+        if opts.pass.is_empty() {
+            opts.pass = vec!["all".into()];
+        }
+        opts
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ fn main() -> CalyxResult<()> {
     let pm = PassManager::default_passes()?;
 
     // parse the command line arguments into Opts struct
-    let opts: Opts = argh::from_env();
+    let opts = Opts::get_opts();
 
     // list all the avaliable pass options when flag --list-passes is enabled
     if opts.list_passes {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,12 @@ mod cmdline;
 
 use calyx::{errors::CalyxResult, frontend, ir, pass_manager::PassManager};
 use cmdline::Opts;
-use structopt::StructOpt;
 
 fn main() -> CalyxResult<()> {
     let pm = PassManager::default_passes()?;
 
     // parse the command line arguments into Opts struct
-    let opts: Opts = Opts::from_args();
+    let opts: Opts = argh::from_env();
 
     // list all the avaliable pass options when flag --list-passes is enabled
     if opts.list_passes {


### PR DESCRIPTION
This removes 18 dependencies from the build of the compiler.
