### PR TITLE
Annotations for specifying that signals should be used together

### DIFF
--- a/calyx/src/analysis/graph.rs
+++ b/calyx/src/analysis/graph.rs
@@ -1,4 +1,4 @@
-use crate::ir::{self, Id, RRC};
+use crate::ir::{self, Id, PortIterator, RRC};
 use petgraph::{
     algo,
     graph::{DiGraph, NodeIndex},
@@ -315,29 +315,5 @@ impl ToString for GraphAnalysis {
             .expect("Failed to write to ScheduleConflicts string");
         }
         out
-    }
-}
-
-/// An iterator over ports. Wraps generic iterators
-/// over ports to allow functions to build and return
-/// port iterators in different ways.
-pub struct PortIterator<'a> {
-    port_iter: Box<dyn Iterator<Item = RRC<ir::Port>> + 'a>,
-}
-
-impl PortIterator<'_> {
-    /// Returns an empty iterator over ports.
-    fn empty() -> Self {
-        PortIterator {
-            port_iter: Box::new(vec![].into_iter()),
-        }
-    }
-}
-
-impl Iterator for PortIterator<'_> {
-    type Item = RRC<ir::Port>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.port_iter.next()
     }
 }

--- a/calyx/src/analysis/live_range_analysis.rs
+++ b/calyx/src/analysis/live_range_analysis.rs
@@ -243,7 +243,6 @@ impl LiveRangeAnalysis {
         // add global reads to every point
         let global_reads: Prop =
             ReadWriteSet::read_set(&comp.continuous_assignments)
-                .into_iter()
                 .filter(|c| c.borrow().type_name() == Some(&"std_reg".into()))
                 .map(|c| c.clone_name())
                 .collect::<HashSet<_>>()
@@ -310,7 +309,6 @@ impl LiveRangeAnalysis {
 
             // calculate reads, but ignore `variable`. we've already dealt with that
             let reads: HashSet<_> = ReadWriteSet::read_set(&assignments)
-                .into_iter()
                 .filter(|c| c.borrow().type_name() == Some(&"std_reg".into()))
                 .map(|c| c.clone_name())
                 .collect();
@@ -321,7 +319,6 @@ impl LiveRangeAnalysis {
             (reads.into(), writes.into())
         } else {
             let reads: HashSet<_> = ReadWriteSet::read_set(&group.assignments)
-                .into_iter()
                 .filter(|c| c.borrow().type_name() == Some(&"std_reg".into()))
                 .map(|c| c.clone_name())
                 .collect();
@@ -335,7 +332,6 @@ impl LiveRangeAnalysis {
                 .collect::<Vec<_>>();
 
             let writes: HashSet<_> = ReadWriteSet::write_set(&assignments)
-                .into_iter()
                 .filter(|c| c.borrow().type_name() == Some(&"std_reg".into()))
                 .map(|c| c.clone_name())
                 .collect();

--- a/calyx/src/analysis/variable_detection.rs
+++ b/calyx/src/analysis/variable_detection.rs
@@ -16,7 +16,6 @@ impl VariableDetection {
         let group = group_ref.borrow();
 
         let writes = ReadWriteSet::write_set(&group.assignments)
-            .into_iter()
             .filter(|cell| cell.borrow().type_name() == Some(&"std_reg".into()))
             .collect::<Vec<_>>();
 

--- a/calyx/src/ir/mod.rs
+++ b/calyx/src/ir/mod.rs
@@ -31,8 +31,8 @@ pub use id::Id;
 pub use primitives::{PortDef, Primitive, Width};
 pub use printer::IRPrinter;
 pub use structure::{
-    Assignment, Binding, Cell, CellType, CloneName, Direction, GetName, Group,
-    Port, PortParent,
+    Assignment, Binding, Cell, CellIterator, CellType, CloneName, Direction,
+    GetName, Group, Port, PortIterator, PortParent,
 };
 
 /// Visitor to traverse a control program.

--- a/calyx/src/ir/primitives.rs
+++ b/calyx/src/ir/primitives.rs
@@ -58,6 +58,17 @@ impl Primitive {
 
         Ok((bindings.into_iter().collect(), ports))
     }
+
+    /// Return all ports that have the attribute `attr`.
+    pub fn find_all_with_attr<S>(&self, attr: S) -> Vec<&PortDef>
+    where
+        S: AsRef<str>,
+    {
+        self.signature
+            .iter()
+            .filter(|&g| g.attributes.has(attr.as_ref()))
+            .collect()
+    }
 }
 
 /// Definition of a port.

--- a/calyx/src/ir/structure.rs
+++ b/calyx/src/ir/structure.rs
@@ -91,6 +91,29 @@ impl PartialEq for Port {
 
 impl Eq for Port {}
 
+/// Wraps generic iterators over ports to allow functions to build and return port iterators in
+/// different ways.
+pub struct PortIterator<'a> {
+    pub port_iter: Box<dyn Iterator<Item = RRC<Port>> + 'a>,
+}
+
+impl PortIterator<'_> {
+    /// Returns an empty iterator over ports.
+    pub fn empty() -> Self {
+        PortIterator {
+            port_iter: Box::new(vec![].into_iter()),
+        }
+    }
+}
+
+impl Iterator for PortIterator<'_> {
+    type Item = RRC<Port>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.port_iter.next()
+    }
+}
+
 /// Alias for bindings
 pub type Binding = SmallVec<[(Id, u64); 5]>;
 
@@ -248,6 +271,19 @@ impl Cell {
     /// Grants immutable access to the name of this cell.
     pub fn name(&self) -> &Id {
         &self.name
+    }
+}
+
+/// Generic wrapper for iterators that return [RRC] of [ir::Cell].
+pub struct CellIterator<'a> {
+    pub port_iter: Box<dyn Iterator<Item = RRC<Cell>> + 'a>,
+}
+
+impl Iterator for CellIterator<'_> {
+    type Item = RRC<Cell>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.port_iter.next()
     }
 }
 

--- a/calyx/src/ir/traversal/visitor.rs
+++ b/calyx/src/ir/traversal/visitor.rs
@@ -56,12 +56,14 @@ where
 /// For most passes that don't need to use, this is just going to use the
 /// default() method.
 pub trait ConstructVisitor {
-    fn from(_ctx: &ir::Context) -> Self;
+    fn from(_ctx: &ir::Context) -> CalyxResult<Self>
+    where
+        Self: Sized;
 }
 
 impl<T: Default + Sized + Visitor> ConstructVisitor for T {
-    fn from(_ctx: &ir::Context) -> Self {
-        T::default()
+    fn from(_ctx: &ir::Context) -> CalyxResult<Self> {
+        Ok(T::default())
     }
 }
 
@@ -152,7 +154,7 @@ pub trait Visitor {
     where
         Self: ConstructVisitor + Sized,
     {
-        let mut visitor = Self::from(&*context);
+        let mut visitor = Self::from(&*context)?;
         visitor.do_pass(context)?;
         Ok(visitor)
     }

--- a/calyx/src/passes/dead_cell_removal.rs
+++ b/calyx/src/passes/dead_cell_removal.rs
@@ -55,7 +55,6 @@ impl Visitor for DeadCellRemoval {
         for group in comp.groups.iter() {
             self.used_cells.extend(
                 &mut analysis::ReadWriteSet::uses(&group.borrow().assignments)
-                    .into_iter()
                     .map(|c| c.clone_name()),
             )
         }
@@ -63,7 +62,6 @@ impl Visitor for DeadCellRemoval {
         // All cells used in continuous assignments.
         self.used_cells.extend(
             &mut analysis::ReadWriteSet::uses(&comp.continuous_assignments)
-                .into_iter()
                 .map(|c| c.clone_name()),
         );
 

--- a/calyx/src/passes/infer_static_timing.rs
+++ b/calyx/src/passes/infer_static_timing.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::analysis::{GraphAnalysis, ReadWriteSet};
-use crate::errors::Error;
+use crate::errors::{CalyxResult, Error};
 use crate::ir::traversal::{
     Action, ConstructVisitor, Named, VisResult, Visitor,
 };
@@ -29,7 +29,7 @@ pub struct InferStaticTiming {
 // Override constructor to build latency_data information from the primitives
 // library.
 impl ConstructVisitor for InferStaticTiming {
-    fn from(ctx: &ir::Context) -> Self {
+    fn from(ctx: &ir::Context) -> CalyxResult<Self> {
         let mut latency_data = HashMap::new();
         // XXX(rachit): This is unneccesarily rebuilt for every component
         // Build latency data by traversing primitive cells
@@ -50,10 +50,10 @@ impl ConstructVisitor for InferStaticTiming {
                 }
             }
         }
-        InferStaticTiming {
+        Ok(InferStaticTiming {
             latency_data,
             comp_latency: HashMap::new(),
-        }
+        })
     }
 }
 

--- a/calyx/src/passes/resource_sharing.rs
+++ b/calyx/src/passes/resource_sharing.rs
@@ -1,5 +1,6 @@
 use super::sharing_components::ShareComponents;
 use crate::analysis;
+use crate::errors::CalyxResult;
 use crate::ir::{self, traversal::Named, CloneName, RRC};
 use ir::traversal::ConstructVisitor;
 use std::collections::{HashMap, HashSet};
@@ -28,7 +29,7 @@ impl Named for ResourceSharing {
 }
 
 impl ConstructVisitor for ResourceSharing {
-    fn from(ctx: &ir::Context) -> Self {
+    fn from(ctx: &ir::Context) -> CalyxResult<Self> {
         let mut shareable_components = HashSet::new();
         // add share=1 primitives to the shareable_components set
         for prim in ctx.lib.sigs.values() {
@@ -42,11 +43,11 @@ impl ConstructVisitor for ResourceSharing {
                 shareable_components.insert(comp.name.clone());
             }
         }
-        ResourceSharing {
+        Ok(ResourceSharing {
             used_cells_map: HashMap::new(),
             rewrites: Vec::new(),
             shareable_components,
-        }
+        })
     }
 }
 

--- a/calyx/src/passes/resource_sharing.rs
+++ b/calyx/src/passes/resource_sharing.rs
@@ -63,7 +63,6 @@ impl ShareComponents for ResourceSharing {
                 (
                     group.clone_name(),
                     analysis::ReadWriteSet::uses(&group.borrow().assignments)
-                        .into_iter()
                         .filter(|cell| self.cell_filter(&cell.borrow()))
                         .map(|cell| cell.clone_name())
                         .collect::<Vec<_>>(),

--- a/docs/lang/attributes.md
+++ b/docs/lang/attributes.md
@@ -74,7 +74,7 @@ across groups. This is used by the `-p resource-sharing` to decide which compone
 can be shared.
 
 ### `bound(n)`
-Used in `infer-static-timing` and `static-timing` when the number of iterations 
+Used in `infer-static-timing` and `static-timing` when the number of iterations
 of a `While` control is known statically, as indicated by `n`.
 
 ### `generated`
@@ -82,5 +82,41 @@ Added by [`ir::Builder`][builder] to denote that the cell was added by a pass.
 
 ### `clk`
 Marks the special clock signal inserted by the `clk-insertion` pass, which helps with lowering to RTL languages that require an explicit clock.
+
+### `write_together(n)`
+Used by the `papercut` pass.
+Defines a group `n` of signals that all must be driven together:
+```
+primitive std_mem_d2<"static"=1>[WIDTH, D0_SIZE, D1_SIZE, D0_IDX_SIZE, D1_IDX_SIZE](
+  @write_together(2) addr0: D0_IDX_SIZE,
+  @write_together(2) addr1: D1_IDX_SIZE,
+  @write_together(1) write_data: WIDTH,
+  @write_together(1) @go write_en: 1,
+  ...
+) -> (...);
+```
+
+This defines two groups.
+The first group requires that `write_en` and `write_data` signals together
+while the second requires that `addr0` and `addr1` are driven together.
+
+Note that `@write_together` specifications cannot encode implication of the
+form "if port `x` is driven then `y` should be driven".
+
+### `read_together(n)`
+Used by the `papercut` pass.
+Defines a group `n` in which when the read port is used then all the write
+ports must be driven as well.
+```
+primitive std_mem_d1<"static"=1>[WIDTH, SIZE, IDX_SIZE](
+  @read_together(1) addr0: IDX_SIZE, ...
+) -> (
+  @read_together(1) read_data: WIDTH, ...
+);
+```
+
+This requires that when `read_data` is used then `addr0` must be driven.
+Note that each group must have exactly one output port in it.
+
 
 [builder]: https://capra.cs.cornell.edu/docs/calyx/source/calyx/ir/struct.Builder.html

--- a/interp/tests/control/iteration/while.futil
+++ b/interp/tests/control/iteration/while.futil
@@ -9,6 +9,7 @@ component main() -> () {
 
   wires {
     group cond<"static"=0> { //how can something take 0 cycles?
+      i.addr0 = 1'd0;
       lt.left = i.read_data;
       lt.right = 32'd8;
       cond[done] = 1'b1;

--- a/primitives/binary_operators.futil
+++ b/primitives/binary_operators.futil
@@ -11,19 +11,26 @@ extern "binary_operators.sv" {
   primitive std_fp_mult_pipe[
     WIDTH, INT_WIDTH, FRAC_WIDTH
   ](
-    @clk(1) clk: 1, go: 1, left: WIDTH, right: WIDTH
+    @clk clk: 1,
+    @write_together(1) @go go: 1,
+    @write_together(1) left: WIDTH,
+    @write_together(1) right: WIDTH
   ) -> (
-    out: WIDTH, done: 1
+    out: WIDTH,
+    @done done: 1
   );
 
   primitive std_fp_div_pipe[
     WIDTH, INT_WIDTH, FRAC_WIDTH
   ](
-    @clk(1) clk: 1, go: 1, left: WIDTH, right: WIDTH
+    @clk clk: 1,
+    @write_together(1) @go go: 1,
+    @write_together(1) left: WIDTH,
+    @write_together(1) right: WIDTH
   ) -> (
     out_remainder: WIDTH,
     out_quotient: WIDTH,
-    done: 1
+    @done done: 1
   );
 
   primitive std_fp_gt<"share"=1>[
@@ -52,19 +59,26 @@ extern "binary_operators.sv" {
   primitive std_fp_smult_pipe[
     WIDTH, INT_WIDTH, FRAC_WIDTH
   ](
-    @clk(1) clk: 1, go: 1, left: WIDTH, right: WIDTH
+    @clk clk: 1,
+    @write_together(1) @go go: 1,
+    @write_together(1) left: WIDTH,
+    @write_together(1) right: WIDTH
   ) -> (
-    out: WIDTH, done: 1
+    out: WIDTH,
+    @done done: 1
   );
 
   primitive std_fp_sdiv_pipe[
     WIDTH, INT_WIDTH, FRAC_WIDTH
   ](
-    @clk(1) clk: 1, go: 1, left: WIDTH, right: WIDTH
+    @clk clk: 1,
+    @write_together(1) @go go: 1,
+    @write_together(1) left: WIDTH,
+    @write_together(1) right: WIDTH
   ) -> (
     out_remainder: WIDTH,
     out_quotient: WIDTH,
-    done: 1
+    @done done: 1
   );
 
   primitive std_fp_sgt<"share"=1>[
@@ -90,17 +104,24 @@ extern "binary_operators.sv" {
   /// since they're required for FSM encoding.
 
   primitive std_mult_pipe[WIDTH](
-    @clk(1) clk: 1, go: 1, left: WIDTH, right: WIDTH
+    @clk clk: 1,
+    @write_together(1) @go go: 1,
+    @write_together(1) left: WIDTH,
+    @write_together(1) right: WIDTH
   ) -> (
-    out: WIDTH, done: 1
+    out: WIDTH,
+    @done done: 1
   );
 
-  primitive std_div_pipe<"static"=3>[WIDTH](
-    left: WIDTH, right: WIDTH, @go(1) go: 1, @clk(1) clk: 1
+  primitive std_div_pipe[WIDTH](
+    @write_together(1) left: WIDTH,
+    @write_together(1) right: WIDTH,
+    @write_together(1) @go go: 1,
+    @clk clk: 1
   ) -> (
     out_quotient: WIDTH,
     out_remainder: WIDTH,
-    @done(1) done: 1
+    @done done: 1
   );
 
   /// =================== Signed, Bitnum =========================
@@ -108,17 +129,23 @@ extern "binary_operators.sv" {
   primitive std_ssub<"share"=1>[WIDTH](left: WIDTH, right: WIDTH) -> (out: WIDTH);
 
   primitive std_smult_pipe[WIDTH](
-    left: WIDTH, right: WIDTH, go: 1, @clk(1) clk: 1
+    @write_together(1) left: WIDTH,
+    @write_together(1) right: WIDTH,
+    @write_together(1) go: 1,
+    @clk clk: 1
   ) -> (
     out: WIDTH, done: 1
   );
 
   primitive std_sdiv_pipe[WIDTH](
-    @clk(1) clk: 1, @go(1) go: 1, left: WIDTH, right: WIDTH
+    @clk clk: 1,
+    @write_together(1) @go go: 1,
+    @write_together(1) left: WIDTH,
+    @write_together(1) right: WIDTH
   ) -> (
     out_quotient: WIDTH,
     out_remainder: WIDTH,
-    @done(1) done: 1
+    @done done: 1
   );
 
   primitive std_sgt<"share"=1>[WIDTH](left: WIDTH, right: WIDTH) -> (out: 1);

--- a/primitives/core.futil
+++ b/primitives/core.futil
@@ -25,34 +25,34 @@ extern "core.sv" {
 
   /// Memories
   primitive std_reg<"static"=1>[WIDTH](
-    in: WIDTH,
-    @go(1) write_en: 1,
-    @clk(1) clk: 1,
-    @reset(1) reset: 1
+    @write_together(1) in: WIDTH,
+    @write_together(1) @go write_en: 1,
+    @clk clk: 1,
+    @reset reset: 1
   ) -> (
     out: WIDTH,
-    @done(1) done: 1
+    @done done: 1
   );
 
   primitive std_mem_d1<"static"=1>[WIDTH, SIZE, IDX_SIZE](
-    addr0: IDX_SIZE,
-    write_data: WIDTH,
-    @go(1) write_en: 1,
-    @clk(1) clk: 1
+    @read_together(1) addr0: IDX_SIZE,
+    @write_together(1) write_data: WIDTH,
+    @write_together(1) @go write_en: 1,
+    @clk clk: 1
   ) -> (
-    read_data: WIDTH,
-    @done(1) done: 1
+    @read_together(1) read_data: WIDTH,
+    @done done: 1
   );
 
   primitive std_mem_d2<"static"=1>[WIDTH, D0_SIZE, D1_SIZE, D0_IDX_SIZE, D1_IDX_SIZE](
-    addr0: D0_IDX_SIZE,
-    addr1: D1_IDX_SIZE,
-    write_data: WIDTH,
-    @go(1) write_en: 1,
-    @clk(1) clk: 1
+    @read_together(1) @write_together(2) addr0: D0_IDX_SIZE,
+    @read_together(1) @write_together(2) addr1: D1_IDX_SIZE,
+    @write_together(1) write_data: WIDTH,
+    @write_together(1) @go write_en: 1,
+    @clk clk: 1
   ) -> (
-    read_data: WIDTH,
-    @done(1) done: 1
+    @read_together(1) read_data: WIDTH,
+    @done done: 1
   );
 
   primitive std_mem_d3<"static"=1>[
@@ -64,15 +64,15 @@ extern "core.sv" {
       D1_IDX_SIZE,
       D2_IDX_SIZE
   ] (
-    addr0: D0_IDX_SIZE,
-    addr1: D1_IDX_SIZE,
-    addr2: D2_IDX_SIZE,
-    write_data: WIDTH,
-    @go(1) write_en: 1,
-    @clk(1) clk: 1
+    @read_together(1) @write_together(2) addr0: D0_IDX_SIZE,
+    @read_together(1) @write_together(2) addr1: D1_IDX_SIZE,
+    @read_together(1) @write_together(2) addr2: D2_IDX_SIZE,
+    @write_together(1) write_data: WIDTH,
+    @write_together(1) @go write_en: 1,
+    @clk clk: 1
   ) -> (
-    read_data: WIDTH,
-    @done(1) done: 1
+    @read_together(1) read_data: WIDTH,
+    @done done: 1
   );
 
   primitive std_mem_d4<"static"=1>[
@@ -86,15 +86,15 @@ extern "core.sv" {
       D2_IDX_SIZE,
       D3_IDX_SIZE
   ] (
-    addr0: D0_IDX_SIZE,
-    addr1: D1_IDX_SIZE,
-    addr2: D2_IDX_SIZE,
-    addr3: D3_IDX_SIZE,
-    write_data: WIDTH,
-    @go(1) write_en: 1,
-    @clk(1) clk: 1
+    @read_together(1) @write_together(2) addr0: D0_IDX_SIZE,
+    @read_together(1) @write_together(2) addr1: D1_IDX_SIZE,
+    @read_together(1) @write_together(2) addr2: D2_IDX_SIZE,
+    @read_together(1) @write_together(2) addr3: D3_IDX_SIZE,
+    @write_together(1) write_data: WIDTH,
+    @write_together(1) @go write_en: 1,
+    @clk clk: 1
   ) -> (
-    read_data: WIDTH,
-    @done(1) done: 1
+    @read_together(1) read_data: WIDTH,
+    @done done: 1
   );
 }

--- a/primitives/math.futil
+++ b/primitives/math.futil
@@ -4,19 +4,24 @@ extern "math.sv" {
   primitive fp_sqrt[
     WIDTH, INT_WIDTH, FRAC_WIDTH
   ](
-    @clk(1) clk: 1, go: 1, in: WIDTH
+    @clk clk: 1,
+    @write_together(1) @go go: 1,
+    @write_together(1) in: WIDTH
   ) -> (
-    out: WIDTH, done: 1
+    out: WIDTH,
+    @done done: 1
   );
 
   primitive sqrt[
     WIDTH
   ](
-    @clk(1) clk: 1, go: 1, in: WIDTH
+    @clk clk: 1,
+    @write_together(1) @go go: 1,
+    @write_together(1) in: WIDTH
   ) -> (
-    out: WIDTH, done: 1
+    out: WIDTH,
+    @done done: 1
   );
-
 }
 
 // Computes the unsigned value b^e, where

--- a/tests/correctness/while.futil
+++ b/tests/correctness/while.futil
@@ -9,6 +9,7 @@ component main() -> () {
 
   wires {
     group cond<"static"=0> {
+      i.addr0 = 1'd0;
       lt.left = i.read_data;
       lt.right = 32'd8;
       cond[done] = 1'b1;

--- a/tests/errors/no-drive.expect
+++ b/tests/errors/no-drive.expect
@@ -4,4 +4,5 @@
 Error: 
 8 |    group no_drive {
   |          ^^^^^^^^ [Papercut] Required signal not driven inside the group.
-When driving the signal `r.in' the signal `r.write_en' must also be driven. The primitive type `std_reg' requires this invariant.
+When writing to the port `r.in', the ports [r.write_en] must also be written to.
+The primitive type `std_reg' requires this invariant.

--- a/tests/errors/papercut-no-done.expect
+++ b/tests/errors/papercut-no-done.expect
@@ -1,6 +1,6 @@
 ---CODE---
 1
 ---STDERR---
-Error: 
+Error: Malformed Structure: 
 8 |    group no_drive {
-  |          ^^^^^^^^ [Papercut] No writes to the `done' hole for group `no_drive'
+  |          ^^^^^^^^ No writes to the `done' hole for group `no_drive'

--- a/tests/errors/papercut-no-done.futil
+++ b/tests/errors/papercut-no-done.futil
@@ -1,4 +1,4 @@
-import "primitives/std.lib";
+import "primitives/core.futil";
 
 component main() -> () {
   cells {

--- a/tests/errors/papercut-read-missing-write.expect
+++ b/tests/errors/papercut-read-missing-write.expect
@@ -1,0 +1,8 @@
+---CODE---
+1
+---STDERR---
+Error: 
+10 |    group incr {
+   |          ^^^^ [Papercut] Required signal not driven inside the group.
+When read the port `mem.read_data', the ports [mem.addr0] must be written to.
+The primitive type `std_mem_d1' requires this invariant.

--- a/tests/errors/papercut-read-missing-write.futil
+++ b/tests/errors/papercut-read-missing-write.futil
@@ -1,0 +1,21 @@
+import "primitives/core.futil";
+
+component main() -> () {
+  cells {
+    mem = std_mem_d1(32, 1, 1);
+    add = std_add(32);
+    r = std_reg(32);
+  }
+  wires {
+    group incr {
+      add.left = mem.read_data;
+      add.right = 32'd1;
+      r.in = add.out;
+      r.write_en = 1'd1;
+      incr[done] = r.done;
+    }
+  }
+  control {
+    incr;
+  }
+}

--- a/tools/vim/futil/syntax/futil.vim
+++ b/tools/vim/futil/syntax/futil.vim
@@ -11,7 +11,8 @@ syn region futilString start=/\v"/ skip=/\v\\./ end=/\v("|$)/
 hi link futilString String
 
 " @ style attributes
-syn region futilAttr start=/\v\@[a-zA-Z_]+\(/ end=/\v\)/ contains=futilConstant
+syn match futilAttr '\v\@[a-zA-Z_]+' nextgroup=futilAttrVal
+syn region futilAttrVal start=/\v\(/ end=/\v\)/ contains=futilConstant
 hi link futilAttr String
 
 " Control statements
@@ -28,7 +29,7 @@ syn match futilBoundName '\v[_a-zA-Z]((\-+)?[_a-zA-Z0-9]+)*' contained nextgroup
 hi link futilBoundName Include
 
 " Parameters attached to primitives
-syn region futilParams start=/\v\[/  end=/\v\]/ contains=futilParam
+syn region futilParams start=/\v\[/  end=/\v\]/ contains=futilParam nextgroup=futilPorts skipwhite skipnl
 syn match futilParam '\v[_a-zA-Z]((\-+)?[_a-zA-Z0-9]+)*' contained
 hi link futilParam Type
 
@@ -41,6 +42,7 @@ hi link futilPortParam Type
 
 " Output ports come after the arrow
 syn match futilArrow '->' nextgroup=futilPorts skipwhite skipnl
+hi link futilArrow futilOperator
 
 
 " Highlight holes


### PR DESCRIPTION
Adds two new annotations:

- `@write_together(n)`: All signals in group `n` must be written to when any
   signal in group `n` is written to.
- `@read_together(n)`: When the *only* output signal associated with group `n` is read,
  input signals in group `n` must be written to.

Examples:

1. For `std_reg`, `.in` and `.write_en` are in the same `@write_together` group.
2. For `std_mem_d1`, `.read_data` and `.addr0` are in the same `@read_together` group.

Note that `@write_together` annotation creates a set so we can't specify something like
"when `.in` is used in `std_mem_d1` then `.addr0` should also be driven".
This is because it is not the case that `.in` should be driven when `.addr0` is driven.
