### PR TITLE
Patch out-of-bounds memory on durbin

### DIFF
--- a/interp/src/primitives/stateful.rs
+++ b/interp/src/primitives/stateful.rs
@@ -481,7 +481,7 @@ impl Primitive for StdMemD1 {
                 "write_en" => assert_eq!(v.len(), 1),
                 "addr0" => {
                     assert!(v.as_u64() < self.size);
-                    assert_eq!(v.len() as u64, self.size, "std_mem_d1: addr0 is not same width ({}) as idx_size ({})", v.len(), self.idx_size)
+                    assert_eq!(v.len() as u64, self.idx_size, "std_mem_d1: addr0 is not same width ({}) as idx_size ({})", v.len(), self.idx_size)
                 }
                 p => unreachable!("Unknown port: {}", p),
             }

--- a/interp/src/primitives/stateful.rs
+++ b/interp/src/primitives/stateful.rs
@@ -508,7 +508,7 @@ impl Primitive for StdMemD1 {
         //else, empty vector return
         vec![(
             ir::Id::from("read_data"),
-            if addr0 < self.idx_size {
+            if addr0 < self.size {
                 self.data[addr0 as usize].clone()
             } else {
                 Value::zeroes(self.width as usize)


### PR DESCRIPTION
A simple patch which makes memories return zero when given an invalid index and raise an error if the clock ticks with an invalid index. This means that transient index changes during convergence won't cause spurious errors, but that lasting incorrect indices will appropriately raise an error.

I don't believe there was an issue open for the error, but please correct me if I'm wrong