### PR TITLE
Fud support for the interactive debugger

### DIFF
--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -31,9 +31,7 @@ DEFAULT_CONFIGURATION = {
             "flags": None,
             "data": None,
             "round_float_to_fixed": True,
-            "debugger": {
-                "flags": None
-            }
+            "debugger": {"flags": None},
         },
         "dahlia": {
             "exec": "dahlia",

--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -31,6 +31,9 @@ DEFAULT_CONFIGURATION = {
             "flags": None,
             "data": None,
             "round_float_to_fixed": True,
+            "debugger": {
+                "flags": None
+            }
         },
         "dahlia": {
             "exec": "dahlia",

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -101,7 +101,11 @@ def run_fud(args, config):
         for ed in path:
             sp.start_stage(f"{ed.stage.name} → {ed.stage.target_stage}")
             try:
-                result = ed.stage.run(data, sp)
+                if getattr(ed.stage, '_no_spinner', False):
+                    sp.stop()
+                    result = ed.stage.run(data, None)
+                else:
+                    result = ed.stage.run(data, sp)
                 data = result
                 sp.end_stage()
             except errors.StepFailure as e:
@@ -118,5 +122,5 @@ def run_fud(args, config):
             else:
                 with Path(args.output_file).open("wb") as f:
                     f.write(data.convert_to(SourceType.Bytes).data)
-        else:
+        elif data is not None:
             print(data.convert_to(SourceType.String).data)

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -101,7 +101,7 @@ def run_fud(args, config):
         for ed in path:
             sp.start_stage(f"{ed.stage.name} → {ed.stage.target_stage}")
             try:
-                if getattr(ed.stage, '_no_spinner', False):
+                if getattr(ed.stage, "_no_spinner", False):
                     sp.stop()
                     result = ed.stage.run(data, None)
                 else:

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -101,7 +101,7 @@ def run_fud(args, config):
         for ed in path:
             sp.start_stage(f"{ed.stage.name} → {ed.stage.target_stage}")
             try:
-                if getattr(ed.stage, "_no_spinner", False):
+                if ed.stage._no_spinner:
                     sp.stop()
                     result = ed.stage.run(data, None)
                 else:
@@ -122,5 +122,5 @@ def run_fud(args, config):
             else:
                 with Path(args.output_file).open("wb") as f:
                     f.write(data.convert_to(SourceType.Bytes).data)
-        elif data is not None:
+        elif data:
             print(data.convert_to(SourceType.String).data)

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -145,7 +145,9 @@ def register_stages(registry, cfg):
 
     # Interpreter
     registry.register(interpreter.InterpreterStage(cfg, "", "", "Run the interpreter"))
-    registry.register(interpreter.InterpreterStage.debugger(cfg, "", "", "Run the debugger"))
+    registry.register(
+        interpreter.InterpreterStage.debugger(cfg, "", "", "Run the debugger")
+    )
     # register external stages
     register_external_stages(cfg, registry)
 

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -144,8 +144,8 @@ def register_stages(registry, cfg):
     registry.register(xilinx.HwExecutionStage(cfg))
 
     # Interpreter
-    registry.register(interpreter.InterpreterStage(cfg, "", "Run the interpreter"))
-
+    registry.register(interpreter.InterpreterStage(cfg, "", "", "Run the interpreter"))
+    registry.register(interpreter.InterpreterStage.debugger(cfg, "", "", "Run the debugger"))
     # register external stages
     register_external_stages(cfg, registry)
 

--- a/fud/fud/stages/__init__.py
+++ b/fud/fud/stages/__init__.py
@@ -133,6 +133,7 @@ class Stage:
             self.cmd = None
         self.description = description
         self.steps = []
+        self._no_spinner = False
 
     def setup(self):
         self.hollow_input_data = Source(None, self.input_type)

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -53,22 +53,21 @@ class InterpreterStage(Stage):
 
     def _define_steps(self, input_data):
 
-        cmd = " ".join(
-            [
-                self.cmd,
-                self.flags,
-                unwrap_or(self.config["stages", self.name, "flags"], ""),
-                "-l",
-                self.config["global", "futil_directory"],
-                "--data {data_file}" if self.data_path else "",
-                "{target}",
-                "debug" if self.target_stage == _DEBUGGER_TARGET else "",
-                self.debugger_flags if self.target_stage == _DEBUGGER_TARGET else "",
-                unwrap_or(self.config["stages", self.name, "debugger", "flags"], "")
-                if self.target_stage == _DEBUGGER_TARGET
-                else "",
-            ]
-        )
+        cmd = [
+            self.cmd,
+            self.flags,
+            unwrap_or(self.config["stages", self.name, "flags"], ""),
+            "-l",
+            self.config["global", "futil_directory"],
+            "--data" if self.data_path else "",
+            "{data_file}" if self.data_path else "",
+            "{target}",
+            "debug" if self.target_stage == _DEBUGGER_TARGET else "",
+            self.debugger_flags if self.target_stage == _DEBUGGER_TARGET else "",
+            unwrap_or(self.config["stages", self.name, "debugger", "flags"], "")
+            if self.target_stage == _DEBUGGER_TARGET
+            else "",
+        ]
 
         @self.step()
         def mktmp() -> SourceType.Directory:
@@ -101,9 +100,11 @@ class InterpreterStage(Stage):
             Invoke the interpreter
             """
 
-            command = cmd.format(
-                data_file=Path(tmpdir.name) / _FILE_NAME, target=str(target)
-            )
+            command = [
+                x.format(data_file=Path(tmpdir.name) / _FILE_NAME, target=str(target))
+                for x in cmd
+                if x
+            ]
 
             if self.target_stage == _DEBUGGER_TARGET:
                 return transparent_shell(command)

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -5,7 +5,6 @@ import numpy as np
 from fud.stages.verilator.numeric_types import FixedPoint, Bitnum
 from fud.errors import InvalidNumericType
 from fud.stages.verilator.json_to_dat import parse_fp_widths, float_to_fixed
-from sys import stdin
 from ..utils import shell, TmpDir, unwrap_or, transparent_shell
 
 # A local constant used only within this file largely for organizational
@@ -111,9 +110,7 @@ class InterpreterStage(Stage):
         result = interpret(input_data, tmpdir)
         cleanup(tmpdir)
 
-        if self.target_stage == _DEBUGGER_TARGET:
-            return
-        else:
+        if self.target_stage != _DEBUGGER_TARGET:
             return result
 
 

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -16,11 +16,26 @@ _DEBUGGER_TARGET = "debugger"
 class InterpreterStage(Stage):
     @classmethod
     def debugger(cls, config, interp_flags, debug_flags, desc):
-        self = cls(config, interp_flags, debug_flags, desc, output_name=_DEBUGGER_TARGET, output_type=None)
+        self = cls(
+            config,
+            interp_flags,
+            debug_flags,
+            desc,
+            output_name=_DEBUGGER_TARGET,
+            output_type=None,
+        )
         self._no_spinner = True
         return self
 
-    def __init__(self, config, flags, debugger_flags, desc, output_type=SourceType.Stream, output_name="interpreter-out"):
+    def __init__(
+        self,
+        config,
+        flags,
+        debugger_flags,
+        desc,
+        output_type=SourceType.Stream,
+        output_name="interpreter-out",
+    ):
         super().__init__(
             "interpreter",
             output_name,
@@ -49,7 +64,9 @@ class InterpreterStage(Stage):
                 "{target}",
                 "debug" if self.target_stage == _DEBUGGER_TARGET else "",
                 self.debugger_flags if self.target_stage == _DEBUGGER_TARGET else "",
-                unwrap_or(self.config["stages", self.name, "debugger", "flags"], "") if self.target_stage == _DEBUGGER_TARGET else "",
+                unwrap_or(self.config["stages", self.name, "debugger", "flags"], "")
+                if self.target_stage == _DEBUGGER_TARGET
+                else "",
             ]
         )
 
@@ -84,7 +101,9 @@ class InterpreterStage(Stage):
             Invoke the interpreter
             """
 
-            command = cmd.format(data_file=Path(tmpdir.name) / _FILE_NAME, target=str(target))
+            command = cmd.format(
+                data_file=Path(tmpdir.name) / _FILE_NAME, target=str(target)
+            )
 
             if self.target_stage == _DEBUGGER_TARGET:
                 return transparent_shell(command)

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -194,16 +194,13 @@ def shell(cmd, stdin=None, stdout_as_debug=False):
     return stdout
 
 
-def transparent_shell(cmd, stdout_as_debug=False):
+def transparent_shell(cmd):
     """
     Runs `cmd` in the shell. Does not capture output or input. Does nothing
     fancy and returns nothing
     """
     if isinstance(cmd, list):
         cmd = " ".join(cmd)
-
-    if stdout_as_debug:
-        cmd += ">&2"
 
     assert isinstance(cmd, str)
 

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -192,3 +192,24 @@ def shell(cmd, stdin=None, stdout_as_debug=False):
         else:
             raise errors.StepFailure(cmd, "No stdout captured.", "No stderr captured.")
     return stdout
+
+def transparent_shell(cmd, stdout_as_debug=False):
+    """
+    Runs `cmd` in the shell. Does not capture output or input. Does nothing
+    fancy and returns nothing
+    """
+    if isinstance(cmd, list):
+        cmd = " ".join(cmd)
+
+    if stdout_as_debug:
+        cmd += ">&2"
+
+    assert isinstance(cmd, str)
+
+    log.debug(cmd)
+
+    proc = subprocess.Popen(
+        cmd, shell=True, env=os.environ
+    )
+
+    proc.wait()

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -193,6 +193,7 @@ def shell(cmd, stdin=None, stdout_as_debug=False):
             raise errors.StepFailure(cmd, "No stdout captured.", "No stderr captured.")
     return stdout
 
+
 def transparent_shell(cmd, stdout_as_debug=False):
     """
     Runs `cmd` in the shell. Does not capture output or input. Does nothing
@@ -208,8 +209,6 @@ def transparent_shell(cmd, stdout_as_debug=False):
 
     log.debug(cmd)
 
-    proc = subprocess.Popen(
-        cmd, shell=True, env=os.environ
-    )
+    proc = subprocess.Popen(cmd, shell=True, env=os.environ)
 
     proc.wait()

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -206,6 +206,6 @@ def transparent_shell(cmd):
 
     log.debug(cmd)
 
-    proc = subprocess.Popen(cmd, shell=True, env=os.environ)
+    proc = subprocess.Popen(cmd, env=os.environ)
 
     proc.wait()

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -199,10 +199,10 @@ def transparent_shell(cmd):
     Runs `cmd` in the shell. Does not capture output or input. Does nothing
     fancy and returns nothing
     """
-    if isinstance(cmd, list):
-        cmd = " ".join(cmd)
+    if isinstance(cmd, str):
+        cmd = cmd.split()
 
-    assert isinstance(cmd, str)
+    assert isinstance(cmd, list)
 
     log.debug(cmd)
 


### PR DESCRIPTION
A small hack to enable `fud` to work with the interactive debugger. This was complicated slightly by the need to use standard input & output directly which is a bit different from fud's normal behavior.

The end result is that now you can use `--to debugger` to get the interactive debugger and use `-s interpreter.debugger.flags` to pass flags directly to the debugger. It is an alternate stage of the interpreter and so plugs into the same places that the interpreter does.

Given that this is more than a bit hacky, I'd appreciate some eyes on it.