### PR TITLE
Dyanmically check for unique drivers

### DIFF
--- a/calyx/src/backend/verilog.rs
+++ b/calyx/src/backend/verilog.rs
@@ -201,8 +201,8 @@ fn emit_component(comp: &ir::Component, synthesis_mode: bool) -> v::Module {
             .or_insert((Rc::clone(&asgn.dst), vec![asgn]));
     }
 
-    // Build a top-level always_ff block to contain verilator checks for assignments
-    let mut checks = v::ParallelProcess::new_always_ff();
+    // Build a top-level always block to contain verilator checks for assignments
+    let mut checks = v::ParallelProcess::new_always_comb();
 
     map.values()
         .sorted_by_key(|(port, _)| port.borrow().canonical())
@@ -302,7 +302,7 @@ fn emit_guard_disjoint_check(
     // Generated error message
     let (cell, port) = dst_ref.borrow().canonical();
     let err = v::Sequential::new_error(&format!(
-        "Multiple assignment to port {}.{}",
+        "Multiple assignment to port `{}.{}'.",
         cell, port
     ));
     check.add_seq(err);

--- a/runt.toml
+++ b/runt.toml
@@ -65,7 +65,7 @@ fud exec -s verilog.data {}.data \
 """
 
 [[tests]]
-name = "tcam testing"
+name = "[frontend] tcam testing"
 paths = [
   "tests/correctness/tcam/*.futil"
 ]
@@ -88,7 +88,7 @@ fud exec -s verilog.cycle_limit 500 \
 """
 
 [[tests]]
-name = "systolic array correctness"
+name = "[frontend] systolic array correctness"
 paths = [ "tests/correctness/systolic/*.systolic" ]
 cmd = """
 fud e --from systolic --to vcd_json \
@@ -101,7 +101,7 @@ fud e --from systolic --to vcd_json \
 """
 
 [[tests]]
-name = "NTT pipeline correctness"
+name = "[frontend] NTT pipeline correctness"
 paths = [ "tests/correctness/ntt-pipeline/*.txt" ]
 cmd = """
 python3 frontends/ntt-pipeline/gen-ntt-pipeline.py {} > {}.futil; \
@@ -119,14 +119,14 @@ rm {}.futil;
 """
 
 [[tests]]
-name = "mrxl correctness"
+name = "[frontend] mrxl correctness"
 paths = [ "frontends/mrxl/test/*.mrxl" ]
 cmd = """
 fud e -q {} --from mrxl --to dat -s verilog.data {}.data | jq .memories
 """
 
 [[tests]]
-name = "relay correctness"
+name = "[frontend] relay correctness"
 paths = ["tests/correctness/relay/*.relay"]
 cmd = """
 fud e -q {} --from relay --to dat -s verilog.data {}.data | jq .memories
@@ -144,7 +144,7 @@ flags=$(head -n 1 {} | cut -c 3-)
 
 ##### Frontend Tests #####
 [[tests]]
-name = "dahlia frontend"
+name = "[frontend] dahlia"
 paths = [ "tests/frontend/dahlia/*.fuse" ]
 cmd = """
 fud e {} --to futil -q \
@@ -153,14 +153,14 @@ fud e {} --to futil -q \
 """
 
 [[tests]]
-name = "systolic array frontend"
+name = "[frontend] systolic array"
 paths = [ "tests/frontend/systolic/array-*.systolic" ]
 cmd = """
 ./frontends/systolic-lang/gen-systolic.py {}
 """
 
 [[tests]]
-name = "NTT pipeline frontend generation"
+name = "[frontend] NTT pipeline generation"
 paths = [ "tests/frontend/ntt-pipeline/*.txt" ]
 cmd = """
 python3 frontends/ntt-pipeline/gen-ntt-pipeline.py {}
@@ -168,12 +168,12 @@ python3 frontends/ntt-pipeline/gen-ntt-pipeline.py {}
 
 
 [[tests]]
-name = "relay frontend"
+name = "[frontend] relay"
 paths = ["tests/frontend/relay/*.relay"]
 cmd = "python3 frontends/relay/relay_visitor.py {}"
 
 [[tests]]
-name = "exp frontend"
+name = "[frontend] exp"
 paths = ["tests/frontend/exp/*.txt"]
 cmd = "python3 calyx-py/calyx/gen_exp.py {}"
 

--- a/runt.toml
+++ b/runt.toml
@@ -34,6 +34,19 @@ cmd = """
 ./target/debug/futil {} -p well-formed -p papercut -p synthesis-papercut
 """
 
+## Tests errors that occur at runtime
+[[tests]]
+name = "[core] runtime errors"
+paths = [
+  "tests/errors/runtime/*.futil"
+]
+cmd = """
+fud exec -s futil.exec './target/debug/futil' \
+         -s verilog.cycle_limit 500 \
+         {} --to dat -q | \
+         grep '%Error' | sed 's/%Error: [^:]*:[^:]*:/%Error:/'
+"""
+
 ##### Correctness Tests #####
 ## Tests that ensure that individual control
 ## constructs have correct behavior when compiled.

--- a/tests/backend/verilog/memory-with-external-attribute.expect
+++ b/tests/backend/verilog/memory-with-external-attribute.expect
@@ -423,4 +423,5 @@ module main (
      1'b1 ? clk : 1'd0;
     assign m1_clk =
      1'b1 ? clk : 1'd0;
+    
 endmodule

--- a/tests/errors/runtime/multiple-drivers.expect
+++ b/tests/errors/runtime/multiple-drivers.expect
@@ -1,0 +1,2 @@
+[5] %Error: Assertion failed in TOP.main: Multiple assignment to port `r.in'.
+%Error: Verilog $stop

--- a/tests/errors/runtime/multiple-drivers.futil
+++ b/tests/errors/runtime/multiple-drivers.futil
@@ -1,0 +1,21 @@
+import "primitives/core.futil";
+component main() -> () {
+  cells {
+    r = std_reg(32);
+  }
+  wires {
+    group one {
+      r.in = 32'd0;
+      r.write_en = 1'd1;
+      one[done] = r.done;
+    }
+    group two {
+      r.in = 32'd2;
+      r.write_en = 1'd1;
+      two[done] = r.done;
+    }
+  }
+  control {
+    par { one; two; }
+  }
+}


### PR DESCRIPTION
#614 remains blocked on https://github.com/verilator/verilator/issues/3088 and I don't want to try to fix the bug in the Verilator source code.

This PR uses the transformation Verilator performs to add a dynamic check that ensure that each port has a unique driver. The generated code looks something like this:
```
always_comb begin
	if(~$onehot0({fsm_out != 1'd1 & go, fsm_out == 1'd1})) begin
		$error("Multiple assignment to port fsm.in");
	end
end
```

Closes #614.
