### PR TITLE
Add CLI flag to disable asserts in verilog backend

### DIFF
--- a/benches/component-sharing.rs
+++ b/benches/component-sharing.rs
@@ -26,8 +26,7 @@ fn resource_sharing_bench(c: &mut Criterion) {
                         )
                         .unwrap();
 
-                        ir::from_ast::ast_to_ir(namespace, false, false)
-                            .unwrap()
+                        ir::from_ast::ast_to_ir(namespace, false).unwrap()
                     },
                     |mut rep: ir::Context| {
                         passes::ResourceSharing::do_pass_default(&mut rep)

--- a/benches/component-sharing.rs
+++ b/benches/component-sharing.rs
@@ -26,7 +26,7 @@ fn resource_sharing_bench(c: &mut Criterion) {
                         )
                         .unwrap();
 
-                        ir::from_ast::ast_to_ir(namespace, false).unwrap()
+                        ir::from_ast::ast_to_ir(namespace, false, true).unwrap()
                     },
                     |mut rep: ir::Context| {
                         passes::ResourceSharing::do_pass_default(&mut rep)

--- a/calyx/src/ir/context.rs
+++ b/calyx/src/ir/context.rs
@@ -51,8 +51,6 @@ pub struct Context {
     pub components: Vec<Component>,
     /// Library definitions imported by the program.
     pub lib: LibrarySignatures,
-    /// Enable debug mode logging.
-    pub debug_mode: bool,
     /// Enables synthesis mode.
     pub synthesis_mode: bool,
     /// Original import statements.

--- a/calyx/src/ir/context.rs
+++ b/calyx/src/ir/context.rs
@@ -53,6 +53,8 @@ pub struct Context {
     pub lib: LibrarySignatures,
     /// Enables synthesis mode.
     pub synthesis_mode: bool,
+    /// Enables verification checks.
+    pub enable_verification: bool,
     /// Original import statements.
     pub imports: Vec<String>,
 }

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -92,6 +92,7 @@ fn extend_signature(sig: &mut Vec<PortDef>) {
 pub fn ast_to_ir(
     mut namespace: ast::NamespaceDef,
     synthesis_mode: bool,
+    enable_verification: bool,
 ) -> CalyxResult<Context> {
     let mut all_names: HashSet<&Id> = HashSet::with_capacity(
         namespace.components.len() + namespace.externs.len(),
@@ -139,6 +140,7 @@ pub fn ast_to_ir(
         components: comps,
         lib: sig_ctx.lib,
         imports: namespace.imports,
+        enable_verification,
         synthesis_mode,
     })
 }

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -91,7 +91,6 @@ fn extend_signature(sig: &mut Vec<PortDef>) {
 /// Construct an IR representation using a parsed AST and command line options.
 pub fn ast_to_ir(
     mut namespace: ast::NamespaceDef,
-    debug_mode: bool,
     synthesis_mode: bool,
 ) -> CalyxResult<Context> {
     let mut all_names: HashSet<&Id> = HashSet::with_capacity(
@@ -140,7 +139,6 @@ pub fn ast_to_ir(
         components: comps,
         lib: sig_ctx.lib,
         imports: namespace.imports,
-        debug_mode,
         synthesis_mode,
     })
 }

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -82,7 +82,7 @@ fn main() -> InterpreterResult<()> {
 
     // Construct IR
     let namespace = frontend::NamespaceDef::new(&opts.file, &opts.lib_path)?;
-    let ir = ir::from_ast::ast_to_ir(namespace, false, false)?;
+    let ir = ir::from_ast::ast_to_ir(namespace, false)?;
     let ctx = ir::RRC::new(RefCell::new(ir));
     let pm = PassManager::default_passes()?;
 

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -82,7 +82,7 @@ fn main() -> InterpreterResult<()> {
 
     // Construct IR
     let namespace = frontend::NamespaceDef::new(&opts.file, &opts.lib_path)?;
-    let ir = ir::from_ast::ast_to_ir(namespace, false)?;
+    let ir = ir::from_ast::ast_to_ir(namespace, false, false)?;
     let ctx = ir::RRC::new(RefCell::new(ir));
     let pm = PassManager::default_passes()?;
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -25,10 +25,6 @@ pub struct Opts {
     #[argh(option, short = 'l', default = "Path::new(\".\").into()")]
     pub lib_path: PathBuf,
 
-    /// enable debug mode output
-    #[argh(switch, long = "debug")]
-    pub enable_debug: bool,
-
     /// enable synthesis mode
     #[argh(switch, long = "synthesis")]
     pub enable_synthesis: bool,

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -29,6 +29,10 @@ pub struct Opts {
     #[argh(switch, long = "synthesis")]
     pub enable_synthesis: bool,
 
+    /// disable verification checks emitted by backends
+    #[argh(switch)]
+    pub disable_verify: bool,
+
     /// select a backend
     #[argh(option, short = 'b', default = "BackendOpt::default()")]
     pub backend: BackendOpt,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,11 @@ fn main() -> CalyxResult<()> {
     let namespace = frontend::NamespaceDef::new(&opts.file, &opts.lib_path)?;
 
     // Build the IR representation
-    let mut rep = ir::from_ast::ast_to_ir(namespace, opts.enable_synthesis)?;
+    let mut rep = ir::from_ast::ast_to_ir(
+        namespace,
+        opts.enable_synthesis,
+        !opts.disable_verify,
+    )?;
 
     // Run all passes specified by the command line
     pm.execute_plan(&mut rep, &opts.pass, &opts.disable_pass)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,11 +20,7 @@ fn main() -> CalyxResult<()> {
     let namespace = frontend::NamespaceDef::new(&opts.file, &opts.lib_path)?;
 
     // Build the IR representation
-    let mut rep = ir::from_ast::ast_to_ir(
-        namespace,
-        opts.enable_debug,
-        opts.enable_synthesis,
-    )?;
+    let mut rep = ir::from_ast::ast_to_ir(namespace, opts.enable_synthesis)?;
 
     // Run all passes specified by the command line
     pm.execute_plan(&mut rep, &opts.pass, &opts.disable_pass)?;


### PR DESCRIPTION
This is stopgap measure to get master to be green again for now. A long-term solution would require fixing the Dahlia frontend to generate code that doesn't fail the asserts in the generated Verilog.
