### PR TITLE
Patch inifinite unroll bug

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -154,7 +154,7 @@ jobs:
         fud config global.futil_directory '/home/runner/work/calyx/calyx'
         fud config stages.dahlia.exec '/home/runner/work/calyx/calyx/dahlia/fuse'
         fud config stages.futil.exec "$(pwd)/target/debug/futil"
-        fud config
+        fud config stages.interpreter.exec "$(pwd)/target/debug/interp"
 
     - name: Run benchmarks
       run: |
@@ -164,3 +164,5 @@ jobs:
         runt -i Correctness -d
         # Run the unrolled benchmarks
         runt -i Unrolled -d
+        # Run the interpreter benchmarks
+        runt -i Interpreter

--- a/interp/src/interpreter/interpret_component.rs
+++ b/interp/src/interpreter/interpret_component.rs
@@ -15,7 +15,7 @@ pub fn interpret_component(
     env: InterpreterState,
 ) -> InterpreterResult<InterpreterState> {
     let ctrl: &ir::Control = &comp.control.borrow();
-    if let ir::Control::Empty(_) = ctrl {
+    if super::utils::control_is_empty(ctrl) {
         interp_cont(&comp.continuous_assignments, env, comp)
     } else {
         interpret_control(

--- a/interp/src/interpreter/interpret_component.rs
+++ b/interp/src/interpreter/interpret_component.rs
@@ -1,6 +1,7 @@
 //! Inteprets a component.
 
 use super::interpret_control::interpret_control;
+use super::interpret_group::interp_cont;
 use crate::environment::InterpreterState;
 use crate::errors::InterpreterResult;
 use calyx::ir;
@@ -13,10 +14,15 @@ pub fn interpret_component(
     comp: &ir::Component,
     env: InterpreterState,
 ) -> InterpreterResult<InterpreterState> {
-    interpret_control(
-        &comp.control.borrow(),
-        &comp.continuous_assignments,
-        env,
-        comp,
-    )
+    let ctrl: &ir::Control = &comp.control.borrow();
+    if let ir::Control::Empty(_) = ctrl {
+        interp_cont(&comp.continuous_assignments, env, comp)
+    } else {
+        interpret_control(
+            &comp.control.borrow(),
+            &comp.continuous_assignments,
+            env,
+            comp,
+        )
+    }
 }

--- a/interp/src/interpreter/interpret_control.rs
+++ b/interp/src/interpreter/interpret_control.rs
@@ -1,7 +1,7 @@
 //! Inteprets a control in a component.
 
 use super::interpret_group::{
-    finish_comb_group_interpretation, finish_group_interpretation, interp_cont,
+    finish_comb_group_interpretation, finish_group_interpretation,
     interpret_comb_group, interpret_group,
 };
 use crate::environment::InterpreterState;
@@ -186,10 +186,9 @@ fn eval_enable(
 #[allow(clippy::unnecessary_wraps)]
 fn eval_empty(
     _e: &ir::Empty,
-    continuous_assignments: &[ir::Assignment],
-    mut env: InterpreterState,
-    comp: &ir::Component,
+    _continuous_assignments: &[ir::Assignment],
+    env: InterpreterState,
+    _comp: &ir::Component,
 ) -> InterpreterResult<InterpreterState> {
-    env = interp_cont(continuous_assignments, env, comp)?;
     Ok(env)
 }


### PR DESCRIPTION
Closes #649.

Fixes a silly bug causing incorrect behavior on empty groups when running through the normal interpreter pass.

The unrolled ones now crash due to multiple-par writes, as anticipated.

~Note: may wish to use the `control_is_empty` function from the stepper utils rather than only matching a top level empty.~ done