### PR TITLE
Deprecate `std_const` primitive

### DIFF
--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -244,7 +244,19 @@ fn add_cell(cell: ast::Cell, sig_ctx: &SigCtx, builder: &mut Builder) {
     let proto_name = &cell.prototype.name;
 
     let res = if sig_ctx.lib.find_primitive(proto_name).is_some() {
-        builder.add_primitive(cell.name, proto_name, &cell.prototype.params)
+        // Intern `std_const`
+        if proto_name == "std_const" {
+            let params = cell.prototype.params;
+            let width = *params
+                .get(0)
+                .unwrap_or_else(|| panic!("std_const missing WIDTH parameter"));
+            let value = *params
+                .get(1)
+                .unwrap_or_else(|| panic!("std_const missing VALUE parameter"));
+            builder.add_constant(value, width)
+        } else {
+            builder.add_primitive(cell.name, proto_name, &cell.prototype.params)
+        }
     } else {
         // Validator ensures that if the protoype is not a primitive, it
         // is a component.


### PR DESCRIPTION
Instead of actually removing `std_const` from the language, this PR is attempting to make `const0 = std_const(32, 1)` special syntax that immediately gets parsed into a constant by the frontend.

The benefit of doing this is that frontends that rely on `std_const` (Dahlia), don't need to be reimplemented to generate sized constants instead.