### PR TITLE
Make the error message for incorrect memory initialization more useful

### DIFF
--- a/interp/src/environment.rs
+++ b/interp/src/environment.rs
@@ -112,7 +112,7 @@ impl<'outer> InterpreterState<'outer> {
                     .and_then(|x| cell_name.and_then(|name| x.get(name)));
 
                 if let Some(vals) = init {
-                    prim.initialize_memory(vals);
+                    prim.initialize_memory(vals).unwrap();
                 }
                 prim
             }
@@ -124,7 +124,7 @@ impl<'outer> InterpreterState<'outer> {
                     .and_then(|x| cell_name.and_then(|name| x.get(name)));
 
                 if let Some(vals) = init {
-                    prim.initialize_memory(vals);
+                    prim.initialize_memory(vals).unwrap();
                 }
                 prim
             }
@@ -136,7 +136,7 @@ impl<'outer> InterpreterState<'outer> {
                     .and_then(|x| cell_name.and_then(|name| x.get(name)));
 
                 if let Some(vals) = init {
-                    prim.initialize_memory(vals);
+                    prim.initialize_memory(vals).unwrap();
                 }
                 prim
             }
@@ -148,7 +148,7 @@ impl<'outer> InterpreterState<'outer> {
                     .and_then(|x| cell_name.and_then(|name| x.get(name)));
 
                 if let Some(vals) = init {
-                    prim.initialize_memory(vals);
+                    prim.initialize_memory(vals).unwrap();
                 }
                 prim
             }

--- a/interp/src/errors.rs
+++ b/interp/src/errors.rs
@@ -70,6 +70,15 @@ pub enum InterpreterError {
     InvalidIfState,
     #[error("invalid internal while state. This should never happen, please report it")]
     InvalidWhileState,
+
+    #[error("{mem_dim} Memory given initialization data with invalid dimension.
+    When flattened, expected {expected} entries, but the memory was supplied with {given} entries instead.
+    Please ensure that the dimensions of your input memories match their initalization data in the supplied data file")]
+    IncorrectMemorySize {
+        mem_dim: String,
+        expected: u64,
+        given: usize,
+    },
 }
 
 impl InterpreterError {

--- a/interp/src/primitives/stateful.rs
+++ b/interp/src/primitives/stateful.rs
@@ -431,7 +431,6 @@ impl StdMemD1 {
         &mut self,
         vals: &[Value],
     ) -> InterpreterResult<()> {
-        assert_eq!(self.size as usize, vals.len());
         if self.size as usize != vals.len() {
             return Err(InterpreterError::IncorrectMemorySize {
                 mem_dim: "1D".into(),

--- a/interp/src/primitives/stateful.rs
+++ b/interp/src/primitives/stateful.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
 use super::{Primitive, Serializeable};
+use crate::errors::{InterpreterError, InterpreterResult};
 use crate::utils::construct_bindings;
 use crate::values::Value;
 use calyx::ir;
@@ -426,13 +427,25 @@ impl StdMemD1 {
         }
     }
 
-    pub fn initialize_memory(&mut self, vals: &[Value]) {
+    pub fn initialize_memory(
+        &mut self,
+        vals: &[Value],
+    ) -> InterpreterResult<()> {
         assert_eq!(self.size as usize, vals.len());
+        if self.size as usize != vals.len() {
+            return Err(InterpreterError::IncorrectMemorySize {
+                mem_dim: "1D".into(),
+                expected: self.size,
+                given: vals.len(),
+            });
+        }
 
         for (idx, val) in vals.iter().enumerate() {
             assert_eq!(val.len(), self.width as usize);
             self.data[idx] = val.clone()
         }
+
+        Ok(())
     }
 }
 
@@ -633,13 +646,23 @@ impl StdMemD2 {
         }
     }
 
-    pub fn initialize_memory(&mut self, vals: &[Value]) {
-        assert_eq!((self.d0_size * self.d1_size) as usize, vals.len());
+    pub fn initialize_memory(
+        &mut self,
+        vals: &[Value],
+    ) -> InterpreterResult<()> {
+        if (self.d0_size * self.d1_size) as usize != vals.len() {
+            return Err(InterpreterError::IncorrectMemorySize {
+                mem_dim: "2D".into(),
+                expected: self.d0_size * self.d1_size,
+                given: vals.len(),
+            });
+        }
 
         for (idx, val) in vals.iter().enumerate() {
             assert_eq!(val.len(), self.width as usize);
             self.data[idx] = val.clone()
         }
+        Ok(())
     }
 
     #[inline]
@@ -860,16 +883,23 @@ impl StdMemD3 {
         }
     }
 
-    pub fn initialize_memory(&mut self, vals: &[Value]) {
-        assert_eq!(
-            (self.d0_size * self.d1_size * self.d2_size) as usize,
-            vals.len()
-        );
+    pub fn initialize_memory(
+        &mut self,
+        vals: &[Value],
+    ) -> InterpreterResult<()> {
+        if (self.d0_size * self.d1_size * self.d2_size) as usize != vals.len() {
+            return Err(InterpreterError::IncorrectMemorySize {
+                mem_dim: "3D".into(),
+                expected: self.d0_size * self.d1_size * self.d2_size,
+                given: vals.len(),
+            });
+        }
 
         for (idx, val) in vals.iter().enumerate() {
             assert_eq!(val.len(), self.width as usize);
             self.data[idx] = val.clone()
         }
+        Ok(())
     }
 
     #[inline]
@@ -1128,17 +1158,29 @@ impl StdMemD4 {
         }
     }
 
-    pub fn initialize_memory(&mut self, vals: &[Value]) {
-        assert_eq!(
-            (self.d0_size * self.d1_size * self.d2_size * self.d3_size)
-                as usize,
-            vals.len()
-        );
+    pub fn initialize_memory(
+        &mut self,
+        vals: &[Value],
+    ) -> InterpreterResult<()> {
+        if (self.d0_size * self.d1_size * self.d2_size * self.d3_size) as usize
+            != vals.len()
+        {
+            return Err(InterpreterError::IncorrectMemorySize {
+                mem_dim: "4D".into(),
+                expected: self.d0_size
+                    * self.d1_size
+                    * self.d2_size
+                    * self.d3_size,
+                given: vals.len(),
+            });
+        }
 
         for (idx, val) in vals.iter().enumerate() {
             assert_eq!(val.len(), self.width as usize);
             self.data[idx] = val.clone()
         }
+
+        Ok(())
     }
 
     #[inline]


### PR DESCRIPTION
A small patch which closes #675.

Currently just unwraps the error so it will still cause a panic, but the message should be more useful going forward.