### PR TITLE
[Interpreter] Verification bypass

### DIFF
--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -34,6 +34,11 @@ pub struct Opts {
     #[argh(option, long = "data", short = 'd', from_str_fn(read_path))]
     pub data_file: Option<PathBuf>,
 
+    #[argh(switch, short = 'n', long = "no-verification")]
+    /// flag to bypass verification checks before running the program
+    /// note: the interpreter will not behave correctly on malformed input
+    skip_verification: bool,
+
     #[argh(subcommand)]
     comm: Option<Command>,
 }
@@ -87,7 +92,9 @@ fn main() -> InterpreterResult<()> {
     let ctx = ir::RRC::new(RefCell::new(ir));
     let pm = PassManager::default_passes()?;
 
-    pm.execute_plan(&mut ctx.borrow_mut(), &["validate".to_string()], &[])?;
+    if !opts.skip_verification {
+        pm.execute_plan(&mut ctx.borrow_mut(), &["validate".to_string()], &[])?;
+    }
 
     let ctx_ref: &ir::Context = &ctx.borrow();
     let components = ctx_ref.components.iter();


### PR DESCRIPTION
A tiny patch to add a bypass flag for the interpreter to avoid running the verification checks. This is to avoid errors thrown by when there are unused groups and shouldn't be used for code which is produced by people rather than by the compiler.

Adds `-n` or `--no-verification` to the interpreter.

May be useful for @yn224 