### PR TITLE
[fud] Add CSV and normal profiling flags.

### DIFF
--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -127,16 +127,13 @@ def run_fud(args, config):
                 exit(-1)
         sp.stop()
 
-        # DO NOT SUBMIT: Throw error if the stage for profiling is not found in this set of paths.
-
-        # Profiling information.
         if is_profiling_run:
             # Whether this should output data in CSV format.
             is_csv = any(a == "csv" for a in profiled_stages)
             # If no stages provided, print overall profiling information for the stages.
             if not profiled_stages or (len(profiled_stages) == 1 and is_csv):
                 kwargs = {
-                    "stage": "Stage",
+                    "stage": "stage",
                     "phases": [ed for ed in path],
                     "durations": overall_durations,
                 }
@@ -164,7 +161,7 @@ def run_fud(args, config):
                     )
 
                 data.data = "\n".join(
-                    (gather_profiling_data(stage) for stage in profiled_stages)
+                    gather_profiling_data(stage) for stage in profiled_stages
                 )
 
         # output the data or profiling information.

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -135,7 +135,7 @@ def run_fud(args, config):
             )
 
         if args.output_file is not None:
-            if args.profile is not None:
+            if args.profile:
                 with Path(args.output_file).open("wb") as f:
                     f.write(str.encode(data))
             elif data.typ == SourceType.Directory:

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -137,6 +137,7 @@ def run_fud(args, config):
                 SourceType.String,
             )
 
+        # output the data or profiling information from the file step.
         if args.output_file is not None:
             if data.typ == SourceType.Directory:
                 shutil.move(data.data.name, args.output_file)

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -121,7 +121,6 @@ def run_fud(args, config):
             durations.append(time.time() - begin)
         sp.stop()
 
-        is_profiling = any(a is not None for a in (args.profiling, args.profiling_csv))
         # The case where overall stage times want to be printed.
         if args.profiling == "all":
             data = utils.profiling_information(
@@ -130,6 +129,7 @@ def run_fud(args, config):
         if args.profiling_csv == "all":
             data = utils.profiling_csv("overall", [ed for ed in path], durations)
 
+        is_profiling = any(a is not None for a in (args.profiling, args.profiling_csv))
         if args.output_file is not None:
             if is_profiling:
                 with Path(args.output_file).open("wb") as f:

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -128,20 +128,20 @@ def run_fud(args, config):
                 "phases": [ed for ed in path],
                 "durations": durations,
             }
-            data = (
-                utils.profiling_csv(**kwargs)
-                if any(a == "csv" for a in args.profile)
-                else utils.profiling_information(**kwargs)
+            data = Source(
+                (
+                    utils.profiling_csv(**kwargs)
+                    if any(a == "csv" for a in args.profile)
+                    else utils.profiling_information(**kwargs)
+                ),
+                SourceType.String,
             )
 
         if args.output_file is not None:
-            if args.profile:
-                with Path(args.output_file).open("wb") as f:
-                    f.write(str.encode(data))
-            elif data.typ == SourceType.Directory:
+            if data.typ == SourceType.Directory:
                 shutil.move(data.data.name, args.output_file)
             else:
                 with Path(args.output_file).open("wb") as f:
                     f.write(data.convert_to(SourceType.Bytes).data)
         elif data:
-            print(data if args.profile else data.convert_to(SourceType.String).data)
+            print(data.convert_to(SourceType.String).data)

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -119,6 +119,7 @@ def run_fud(args, config):
                 print(e)
                 exit(-1)
             durations.append(time.time() - begin)
+        sp.stop()
 
         is_profiling = any(a is not None for a in (args.profiling, args.profiling_csv))
         # The case where overall stage times want to be printed.
@@ -129,7 +130,6 @@ def run_fud(args, config):
         if args.profiling_csv == "all":
             data = utils.profiling_csv("overall", [ed for ed in path], durations)
 
-        sp.stop()
         if args.output_file is not None:
             if is_profiling:
                 with Path(args.output_file).open("wb") as f:

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -122,16 +122,20 @@ def run_fud(args, config):
         sp.stop()
 
         # The case where overall stage times want to be printed.
-        if args.profiling == "all":
-            data = utils.profiling_information(
-                "overall", [ed for ed in path], durations
+        if any(a == "all" for a in args.profile):
+            kwargs = {
+                "stage": "overall",
+                "phases": [ed for ed in path],
+                "durations": durations,
+            }
+            data = (
+                utils.profiling_csv(**kwargs)
+                if any(a == "csv" for a in args.profile)
+                else utils.profiling_information(**kwargs)
             )
-        if args.profiling_csv == "all":
-            data = utils.profiling_csv("overall", [ed for ed in path], durations)
 
-        is_profiling = any(a is not None for a in (args.profiling, args.profiling_csv))
         if args.output_file is not None:
-            if is_profiling:
+            if args.profile is not None:
                 with Path(args.output_file).open("wb") as f:
                     f.write(str.encode(data))
             elif data.typ == SourceType.Directory:
@@ -139,7 +143,5 @@ def run_fud(args, config):
             else:
                 with Path(args.output_file).open("wb") as f:
                     f.write(data.convert_to(SourceType.Bytes).data)
-        elif is_profiling:
-            print(data)
         elif data:
-            print(data.convert_to(SourceType.String).data)
+            print(data if args.profile else data.convert_to(SourceType.String).data)

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -140,7 +140,7 @@ def run_fud(args, config):
                 data.data = (
                     utils.profiling_csv(**kwargs)
                     if is_csv
-                    else utils.profiling_information(**kwargs)
+                    else utils.profiling_dump(**kwargs)
                 )
             else:
                 # Otherwise, gather profiling data for each stage provided.
@@ -157,7 +157,7 @@ def run_fud(args, config):
                     return (
                         utils.profiling_csv(**kwargs)
                         if is_csv
-                        else utils.profiling_information(**kwargs)
+                        else utils.profiling_dump(**kwargs)
                     )
 
                 data.data = "\n".join(

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -102,8 +102,7 @@ def run_fud(args, config):
         overall_durations = []
 
         # tracks profiling information requested by the flag.
-        steps = {}
-        step_durations = {}
+        collected_profiling_stages = {}
 
         # run all the stages
         for ed in path:
@@ -120,8 +119,7 @@ def run_fud(args, config):
                 sp.end_stage()
                 # Collect profiling information.
                 if is_profiling_run and ed.name in profiled_stages:
-                    steps[ed.name] = [s for s in ed.steps]
-                    step_durations[ed.name] = ed.durations
+                    collected_profiling_stages[ed.name] = ed
 
             except errors.StepFailure as e:
                 sp.fail()
@@ -152,12 +150,12 @@ def run_fud(args, config):
                 def gather_profiling_data(stage):
                     if stage == "csv":
                         return ""
-                    if stage not in steps:
+                    if stage not in collected_profiling_stages:
                         raise errors.UndefinedStage(stage)
                     kwargs = {
                         "stage": stage,
-                        "phases": steps[stage],
-                        "durations": step_durations[stage],
+                        "phases": [s for s in collected_profiling_stages[stage].steps],
+                        "durations": collected_profiling_stages[stage].durations,
                     }
                     return (
                         utils.profiling_csv(**kwargs)

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -302,6 +302,18 @@ def main():
 
 
 def config_run(parser):
+    parser.add_argument(
+        "-p",
+        "--dump_prof",
+        help="Dumps profile information for <stage>. If you want overall stage times, use `all`",
+        dest="profiling",
+    )
+    parser.add_argument(
+        "-p-csv",
+        "--dump_prof_csv",
+        help="Dumps profile information in CSV format for <stage>",
+        dest="profiling_csv",
+    )
     parser.add_argument("--from", dest="source", help="Name of the start stage")
     parser.add_argument("--to", dest="dest", help="Name of the final stage")
     parser.add_argument(
@@ -312,7 +324,7 @@ def config_run(parser):
         help="Names of intermediate stages (repeatable option)",
     )
     parser.add_argument(
-        "-o", dest="output_file", help="Name of the outpfule file (default: STDOUT)"
+        "-o", dest="output_file", help="Name of the output file (default: STDOUT)"
     )
     parser.add_argument(
         "-s",

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -306,7 +306,6 @@ def config_run(parser):
         "-pr",
         "--dump_prof",
         nargs="+",
-        default=[],
         help="Dumps profile information for <stage>. "
         + "If you want overall stage times, use `all`. "
         + "If you want CSV format, use `csv` as an additional argument",

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -306,6 +306,7 @@ def config_run(parser):
         "-pr",
         "--dump_prof",
         nargs="+",
+        default=[],
         help="Dumps profile information for <stage>. If you want overall stage times, use `all`. If you want CSV format, use `csv` as an additional argument",
         dest="profile",
     )

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -305,11 +305,12 @@ def config_run(parser):
     parser.add_argument(
         "-pr",
         "--dump_prof",
-        nargs="+",
+        nargs="*",
+        default=[],
         help="Dumps profile information for <stage>. "
-        + "If you want overall stage times, use `all`. "
-        + "If you want CSV format, use `csv` as an additional argument",
-        dest="profile",
+        + "If no stages provided, dumps the overall profiling information for this run."
+        + "If you want CSV format, include `csv` as an argument",
+        dest="profiled_stages",
     )
     parser.add_argument("--from", dest="source", help="Name of the start stage")
     parser.add_argument("--to", dest="dest", help="Name of the final stage")

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -303,13 +303,13 @@ def main():
 
 def config_run(parser):
     parser.add_argument(
-        "-p",
+        "-pr",
         "--dump_prof",
         help="Dumps profile information for <stage>. If you want overall stage times, use `all`",
         dest="profiling",
     )
     parser.add_argument(
-        "-p-csv",
+        "-pr-csv",
         "--dump_prof_csv",
         help="Dumps profile information in CSV format for <stage>",
         dest="profiling_csv",

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -305,14 +305,9 @@ def config_run(parser):
     parser.add_argument(
         "-pr",
         "--dump_prof",
-        help="Dumps profile information for <stage>. If you want overall stage times, use `all`",
-        dest="profiling",
-    )
-    parser.add_argument(
-        "-pr-csv",
-        "--dump_prof_csv",
-        help="Dumps profile information in CSV format for <stage>",
-        dest="profiling_csv",
+        nargs="+",
+        help="Dumps profile information for <stage>. If you want overall stage times, use `all`. If you want CSV format, use `csv` as an additional argument",
+        dest="profile",
     )
     parser.add_argument("--from", dest="source", help="Name of the start stage")
     parser.add_argument("--to", dest="dest", help="Name of the final stage")

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -306,7 +306,6 @@ def config_run(parser):
         "-pr",
         "--dump_prof",
         nargs="*",
-        default=[],
         help="Dumps profile information for <stage>. "
         + "If no stages provided, dumps the overall profiling information for this run."
         + "If you want CSV format, include `csv` as an argument",

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -307,7 +307,9 @@ def config_run(parser):
         "--dump_prof",
         nargs="+",
         default=[],
-        help="Dumps profile information for <stage>. If you want overall stage times, use `all`. If you want CSV format, use `csv` as an additional argument",
+        help="Dumps profile information for <stage>. "
+        + "If you want overall stage times, use `all`. "
+        + "If you want CSV format, use `csv` as an additional argument",
         dest="profile",
     )
     parser.add_argument("--from", dest="source", help="Name of the start stage")

--- a/fud/fud/stages/__init__.py
+++ b/fud/fud/stages/__init__.py
@@ -232,8 +232,6 @@ class Stage:
 
     def run(self, input_data, args, sp=None):
         assert isinstance(input_data, Source)
-        # tracks the approximate time elapsed to run each step in this stage.
-        durations = []
 
         # fill in input_data
         self.hollow_input_data.data = input_data.convert_to(self.input_type).data

--- a/fud/fud/stages/__init__.py
+++ b/fud/fud/stages/__init__.py
@@ -9,7 +9,7 @@ from io import IOBase
 from pathlib import Path
 
 from ..utils import Conversions as conv
-from ..utils import Directory, is_debug, print_profiling_information
+from ..utils import Directory, is_debug, profiling_information, profiling_csv
 
 
 class SourceType(Enum):
@@ -229,7 +229,7 @@ class Stage:
     def _define_steps(self, input_data):
         pass
 
-    def run(self, input_data, sp=None):
+    def run(self, input_data, args, sp=None):
         assert isinstance(input_data, Source)
         # tracks the approximate time elapsed to run each step in this stage.
         durations = []
@@ -247,8 +247,10 @@ class Stage:
                 sp.end_step()
             durations.append(time.time() - begin)
 
-        if is_debug():
-            print_profiling_information(self.name, self.steps, durations)
+        if self.name == args.profiling:
+            return profiling_information(self.name, self.steps, durations)
+        if self.name == args.profiling_csv:
+            return profiling_csv(self.name, self.steps, durations)
 
         return self.final_output
 

--- a/fud/fud/stages/__init__.py
+++ b/fud/fud/stages/__init__.py
@@ -9,7 +9,7 @@ from io import IOBase
 from pathlib import Path
 
 from ..utils import Conversions as conv
-from ..utils import Directory, is_debug, profiling_information, profiling_csv
+from ..utils import Directory, is_debug
 
 
 class SourceType(Enum):

--- a/fud/fud/stages/__init__.py
+++ b/fud/fud/stages/__init__.py
@@ -249,10 +249,13 @@ class Stage:
 
         if any(a == self.name for a in args.profile):
             kwargs = {"stage": self.name, "phases": self.steps, "durations": durations}
-            return (
-                profiling_csv(**kwargs)
-                if any(a == "csv" for a in args.profile)
-                else profiling_information(**kwargs)
+            return Source(
+                (
+                    profiling_csv(**kwargs)
+                    if any(a == "csv" for a in args.profile)
+                    else profiling_information(**kwargs)
+                ),
+                SourceType.String,
             )
 
         return self.final_output

--- a/fud/fud/stages/__init__.py
+++ b/fud/fud/stages/__init__.py
@@ -149,6 +149,7 @@ class Stage:
 
         self.description = description
         self.steps = []
+        self.durations = []
         self._no_spinner = False
 
     def setup(self):
@@ -239,24 +240,14 @@ class Stage:
 
         # run all the steps
         for step in self.steps:
-            begin = time.time()
+
             if sp is not None:
                 sp.start_step(step.name)
+            begin = time.time()
             step()
+            self.durations.append(time.time() - begin)
             if sp is not None:
                 sp.end_step()
-            durations.append(time.time() - begin)
-
-        if any(a == self.name for a in args.profile):
-            kwargs = {"stage": self.name, "phases": self.steps, "durations": durations}
-            return Source(
-                (
-                    profiling_csv(**kwargs)
-                    if any(a == "csv" for a in args.profile)
-                    else profiling_information(**kwargs)
-                ),
-                SourceType.String,
-            )
 
         return self.final_output
 

--- a/fud/fud/stages/__init__.py
+++ b/fud/fud/stages/__init__.py
@@ -247,10 +247,13 @@ class Stage:
                 sp.end_step()
             durations.append(time.time() - begin)
 
-        if self.name == args.profiling:
-            return profiling_information(self.name, self.steps, durations)
-        if self.name == args.profiling_csv:
-            return profiling_csv(self.name, self.steps, durations)
+        if any(a == self.name for a in args.profile):
+            kwargs = {"stage": self.name, "phases": self.steps, "durations": durations}
+            return (
+                profiling_csv(**kwargs)
+                if any(a == "csv" for a in args.profile)
+                else profiling_information(**kwargs)
+            )
 
         return self.final_output
 

--- a/fud/fud/stages/verilator/stage.py
+++ b/fud/fud/stages/verilator/stage.py
@@ -160,10 +160,6 @@ class VerilatorStage(Stage):
             json_to_dat(tmpdir, Source(Path(self.data_path), SourceType.Path))
         compile_with_verilator(input_data, tmpdir)
         stdout = simulate(tmpdir)
-        result = None
-        if self.vcd:
-            result = output_vcd(tmpdir)
-        else:
-            result = output_json(stdout, tmpdir)
+        result = output_vcd(tmpdir) if self.vcd else output_json(stdout, tmpdir)
         cleanup(tmpdir)
         return result

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -227,10 +227,9 @@ def profiling_information(stage, phases, durations):
         # Return a string containing `s` followed by max(32 - len(s), 1) spaces.
         return "".join((s, max(32 - len(s), 1) * " "))
 
-    msg = f"{name_and_space(stage)}elapsed time (s)\n"
-    for p, t in zip(phases, durations):
-        msg += f"{name_and_space(p.name)}{round(t, 3)}\n"
-    return msg
+    return f"{name_and_space(stage)}elapsed time (s)\n" + "\n".join(
+        f"{name_and_space(p.name)}{round(t, 3)}" for p, t in zip(phases, durations)
+    )
 
 
 def profiling_csv(stage, phases, durations):

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -217,7 +217,7 @@ def transparent_shell(cmd):
     proc.wait()
 
 
-def profiling_information(stage, phases, durations):
+def profiling_dump(stage, phases, durations):
     """
     Returns time elapsed during each stage or step of the fud execution.
     """
@@ -234,7 +234,7 @@ def profiling_information(stage, phases, durations):
 
 def profiling_csv(stage, phases, durations):
     """
-    Dumps the profiling information into a CSV.
+    Dumps the profiling information into a CSV format.
     For example, with
         stage:     `x`
         phases:    ['a', 'b', 'c']

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -217,15 +217,35 @@ def transparent_shell(cmd):
     proc.wait()
 
 
-def print_profiling_information(title, phases, durations):
+def profiling_information(title, phases, durations):
     """
-    Prints time elapsed during each stage or step of the fud execution.
+    Returns time elapsed during each stage or step of the fud execution.
     """
     assert all(hasattr(p, "name") for p in phases), "expected to have name attribute."
+    # Return a string containing `s` followed by max(32 - len(s), 1) spaces.
+    def name_and_space(s: str) -> str:
+        return "".join((s, max(32 - len(s), 1) * " "))
 
-    print(f"{title}              |          elapsed time (s)")
-    print("-------------------------------------------------")
-    for phase, elapsed_time in zip(phases, durations):
-        whitespace = max(32 - len(phase.name), 1) * " "
-        print(f"{phase.name}{whitespace}{round(elapsed_time, 3)}")
-    print("-------------------------------------------------")
+    msg = f"{name_and_space(title)}elapsed time (s)\n"
+    for p, t in zip(phases, durations):
+        msg += f"{name_and_space(p.name)}{round(t, 3)}\n"
+    return msg
+
+
+def profiling_csv(stage, steps, durations):
+    """
+    Dumps the profiling information into a CSV.
+    For example, with
+        stage:     `x`
+        steps:     ['a', 'b', 'c']
+        durations: [1.42, 2.0, 3.4445]
+    The output will be:
+    ```
+    x,a,1.42
+    x,b,2.0
+    x,c,3.444
+    ```
+    """
+    return "\n".join(
+        [f"{stage},{s.name},{round(t, 3)}" for (s, t) in zip(steps, durations)]
+    )

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -246,6 +246,7 @@ def profiling_csv(stage, phases, durations):
     x,c,3.444
     ```
     """
+    assert all(hasattr(p, "name") for p in phases), "expected to have name attribute."
     return "\n".join(
         [f"{stage},{p.name},{round(t, 3)}" for (p, t) in zip(phases, durations)]
     )

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -217,7 +217,7 @@ def transparent_shell(cmd):
     proc.wait()
 
 
-def profiling_information(title, phases, durations):
+def profiling_information(stage, phases, durations):
     """
     Returns time elapsed during each stage or step of the fud execution.
     """
@@ -226,18 +226,18 @@ def profiling_information(title, phases, durations):
     def name_and_space(s: str) -> str:
         return "".join((s, max(32 - len(s), 1) * " "))
 
-    msg = f"{name_and_space(title)}elapsed time (s)\n"
+    msg = f"{name_and_space(stage)}elapsed time (s)\n"
     for p, t in zip(phases, durations):
         msg += f"{name_and_space(p.name)}{round(t, 3)}\n"
     return msg
 
 
-def profiling_csv(stage, steps, durations):
+def profiling_csv(stage, phases, durations):
     """
     Dumps the profiling information into a CSV.
     For example, with
         stage:     `x`
-        steps:     ['a', 'b', 'c']
+        phases:    ['a', 'b', 'c']
         durations: [1.42, 2.0, 3.4445]
     The output will be:
     ```
@@ -247,5 +247,5 @@ def profiling_csv(stage, steps, durations):
     ```
     """
     return "\n".join(
-        [f"{stage},{s.name},{round(t, 3)}" for (s, t) in zip(steps, durations)]
+        [f"{stage},{p.name},{round(t, 3)}" for (p, t) in zip(phases, durations)]
     )

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -222,8 +222,9 @@ def profiling_information(stage, phases, durations):
     Returns time elapsed during each stage or step of the fud execution.
     """
     assert all(hasattr(p, "name") for p in phases), "expected to have name attribute."
-    # Return a string containing `s` followed by max(32 - len(s), 1) spaces.
+
     def name_and_space(s: str) -> str:
+        # Return a string containing `s` followed by max(32 - len(s), 1) spaces.
         return "".join((s, max(32 - len(s), 1) * " "))
 
     msg = f"{name_and_space(stage)}elapsed time (s)\n"


### PR DESCRIPTION
Some examples:

```bash
# fud e tests/correctness/seq.futil --to dat -s verilog.data tests/correctness/seq.futil.data \
# --through icarus-verilog -pr

stage                           elapsed time (s)
futil                           0.067
icarus-verilog                  0.24

```

```bash
# fud e tests/correctness/seq.futil --to dat -s verilog.data tests/correctness/seq.futil.data \
# --through icarus-verilog \
# -pr icarus-verilog futil 

icarus-verilog                  elapsed time (s)
mktmp                           0.0
json_to_dat                     0.002
compile_with_iverilog           0.025
simulate                        0.127
output_json                     0.003
cleanup                         0.001
futil                           elapsed time (s)
run_futil                       0.028

```

```bash
# fud e tests/correctness/seq.futil --to dat -s verilog.data tests/correctness/seq.futil.data \
# --through icarus-verilog \
# -pr csv futil icarus-verilog


futil,run_futil,0.029
icarus-verilog,mktmp,0.0
icarus-verilog,json_to_dat,0.002
icarus-verilog,compile_with_iverilog,0.024
icarus-verilog,simulate,0.128
icarus-verilog,output_json,0.003
icarus-verilog,cleanup,0.001
```

Allows file writes as well using the `-o` flag.

The CSV format is similar to the benchmark evaluation format, e.g. [here](https://github.com/cucapra/calyx-evaluation/blob/master/benchmarks/results.csv), where the "key(s)" are followed by the "value".
