### PR TITLE
[NFC] Cleanup profiling.

### DIFF
--- a/fud/fud/stages/__init__.py
+++ b/fud/fud/stages/__init__.py
@@ -230,7 +230,7 @@ class Stage:
     def _define_steps(self, input_data):
         pass
 
-    def run(self, input_data, args, sp=None):
+    def run(self, input_data, sp=None):
         assert isinstance(input_data, Source)
 
         # fill in input_data

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -250,3 +250,16 @@ def profiling_csv(stage, phases, durations):
     return "\n".join(
         [f"{stage},{p.name},{round(t, 3)}" for (p, t) in zip(phases, durations)]
     )
+
+
+def profile_stages(stage, phases, durations, is_csv):
+    """
+    Returns either a human-readable or CSV format profiling information,
+    depending on `is_csv`.
+    """
+    kwargs = {
+        "stage": stage,
+        "phases": phases,
+        "durations": durations,
+    }
+    return profiling_csv(**kwargs) if is_csv else profiling_dump(**kwargs)


### PR DESCRIPTION
Remove `args` from run(), since it is no longer used, and a few other small changes. Semantics remain the same.