### PR TITLE
[fud] Add step-based profiling.

### DIFF
--- a/docs/fud/index.md
+++ b/docs/fud/index.md
@@ -213,6 +213,21 @@ output_json                     0.003
 cleanup                         0.003
 ```
 
+If you want time elapsed for a single step, you can specify the given step, e.g.
+
+```bash
+  fud e examples/dahlia/dot-product.fuse --to dat \
+  -s verilog.data examples/dahlia/dot-product.fuse.data \
+  -pr verilog.simulate
+```
+
+will output:
+
+```
+verilog                         elapsed time (s)
+simulate                        0.161
+```
+
 Lastly, the `-csv` flag will provide the profiling information in CSV format.
 
 [frontends]: ./frontends/index.md

--- a/fud/fud/errors.py
+++ b/fud/fud/errors.py
@@ -103,6 +103,16 @@ class UndefinedStage(FudError):
         super().__init__(msg)
 
 
+class UndefinedSteps(FudError):
+    """
+    No steps with the defined name for the given stage.
+    """
+
+    def __init__(self, stage, steps):
+        msg = f"No step(s): {', '.join(steps)} defined for stage: {stage}"
+        super().__init__(msg)
+
+
 class MultiplePaths(FudError):
     """
     Multiple paths found to transform `src` to `dst`.

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -146,7 +146,9 @@ def run_fud(args, config):
                     profiled_steps = [
                         s for s in data.steps if steps == [] or s.name in steps
                     ]
-                    profiled_durations = [data.durations[s] for s in steps]
+                    # Gather all the step names that are being profiled.
+                    profiled_names = [s.name for s in profiled_steps]
+                    profiled_durations = [data.durations[s] for s in profiled_names]
                     return utils.profile_stages(
                         stage,
                         profiled_steps,

--- a/fud/fud/stages/__init__.py
+++ b/fud/fud/stages/__init__.py
@@ -149,8 +149,9 @@ class Stage:
 
         self.description = description
         self.steps = []
-        self.durations = []
         self._no_spinner = False
+        # Mapping from step name to its elapsed run time.
+        self.durations = {}
 
     def setup(self):
         """
@@ -243,7 +244,7 @@ class Stage:
                 sp.start_step(step.name)
             begin = time.time()
             step()
-            self.durations.append(time.time() - begin)
+            self.durations[step.name] = time.time() - begin
             if sp is not None:
                 sp.end_step()
 

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -217,6 +217,29 @@ def transparent_shell(cmd):
     proc.wait()
 
 
+def parse_profiling_input(args):
+    """
+    Returns a mapping from stage to steps from the `profiled_stages` argument.
+    For example, if the user passes in `-pr a.a1 a.a2 b.b1 c`, this will return:
+    {"a" : ["a1", "a2"], "b" : ["b1"], "c" : [] }
+    """
+    stages = {}
+    # Retrieve all stages.
+    for stage in args.profiled_stages:
+        if "." not in stage:
+            stages[stage] = []
+        else:
+            s, _ = stage.split(".")
+            stages[s] = []
+    # Append all steps.
+    for stage in args.profiled_stages:
+        if "." not in stage:
+            continue
+        _, step = stage.split(".")
+        stages[s].append(step)
+    return stages
+
+
 def profiling_dump(stage, phases, durations):
     """
     Returns time elapsed during each stage or step of the fud execution.

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -224,6 +224,8 @@ def parse_profiling_input(args):
     {"a" : ["a1", "a2"], "b" : ["b1"], "c" : [] }
     """
     stages = {}
+    if args.profiled_stages is None:
+        return stages
     # Retrieve all stages.
     for stage in args.profiled_stages:
         if "." not in stage:


### PR DESCRIPTION
Adds step-based profiling, e.g.

```bash
fud e examples/futil/memory-by-reference/memory-by-reference.futil --to dat \
-s verilog.data examples/futil/memory-by-reference/memory-by-reference.futil.data \
--through icarus-verilog \
-pr icarus-verilog.cleanup icarus-verilog.output_json -csv
```

will output:

```python
icarus-verilog,output_json,0.001
icarus-verilog,cleanup,0.002
```

All other profiling behavior remains the same, i.e. if you provide no steps, then all steps will be printed.