### PR TITLE
[fud] Fix return type of `interpret` stage.

### DIFF
--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -130,6 +130,7 @@ def run_fud(args, config):
                 data.data = utils.profile_stages(
                     "stage", [ed for ed in path], overall_durations, args.csv
                 )
+                data.typ = SourceType.String
             else:
                 # Otherwise, gather profiling data for each stage and steps provided.
                 def gather_profiling_data(stage, steps):
@@ -160,6 +161,7 @@ def run_fud(args, config):
                     gather_profiling_data(stage, steps)
                     for stage, steps in profiled_stages.items()
                 )
+                data.typ = SourceType.String
 
         # output the data or profiling information.
         if args.output_file is not None:

--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -125,12 +125,13 @@ def run_fud(args, config):
         sp.stop()
 
         if args.profiled_stages is not None:
+            # Overwrite previous data type.
+            data.typ = SourceType.String
             if args.profiled_stages == []:
                 # No stages provided; collect overall stage durations.
                 data.data = utils.profile_stages(
                     "stage", [ed for ed in path], overall_durations, args.csv
                 )
-                data.typ = SourceType.String
             else:
                 # Otherwise, gather profiling data for each stage and steps provided.
                 def gather_profiling_data(stage, steps):
@@ -161,7 +162,6 @@ def run_fud(args, config):
                     gather_profiling_data(stage, steps)
                     for stage, steps in profiled_stages.items()
                 )
-                data.typ = SourceType.String
 
         # output the data or profiling information.
         if args.output_file is not None:

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -100,7 +100,7 @@ class InterpreterStage(Stage):
         @self.step()
         def interpret(
             target: SourceType.Path, tmpdir: SourceType.Directory
-        ) -> SourceType.String:
+        ) -> SourceType.Stream:
             """
             Invoke the interpreter
             """

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -100,7 +100,7 @@ class InterpreterStage(Stage):
         @self.step()
         def interpret(
             target: SourceType.Path, tmpdir: SourceType.Directory
-        ) -> SourceType.Stream:
+        ) -> SourceType.String:
             """
             Invoke the interpreter
             """


### PR DESCRIPTION
After execution, Fud is looking for a SourceType.String, not SourceType.Stream.