### PR TITLE
Parse reserved names as is to generate error msgs

### DIFF
--- a/calyx/src/ir/component.rs
+++ b/calyx/src/ir/component.rs
@@ -2,7 +2,6 @@ use super::{
     Assignment, Attributes, Builder, Cell, CellType, CloneName, CombGroup,
     Control, Direction, GetName, Group, Id, RRC,
 };
-use crate::ir::RESERVED_NAMES;
 use crate::utils;
 use linked_hash_map::LinkedHashMap;
 use std::cell::RefCell;
@@ -58,7 +57,6 @@ impl Component {
         let prev_names: HashSet<_> = ports
             .iter()
             .map(|(name, _, _, _)| name.as_ref().to_string())
-            .chain(RESERVED_NAMES.iter().map(|s| s.to_string()))
             .collect();
 
         let this_sig = Builder::cell_from_signature(
@@ -84,6 +82,10 @@ impl Component {
             namegen: utils::NameGenerator::with_prev_defined_names(prev_names),
             attributes: Attributes::default(),
         }
+    }
+
+    pub(super) fn add_names(&mut self, names: HashSet<String>) {
+        self.namegen.add_names(names)
     }
 
     /// Return a reference to the group with `name` if present.

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -1,7 +1,7 @@
 use super::{
     Assignment, Attributes, BackendConf, Builder, CellType, Component, Context,
     Control, Direction, GetAttributes, Guard, Id, Invoke, LibrarySignatures,
-    Port, PortDef, Width, RRC,
+    Port, PortDef, Width, RESERVED_NAMES, RRC,
 };
 use crate::{
     errors::{CalyxResult, Error},
@@ -249,6 +249,11 @@ fn build_component(
     builder.component.control = control;
 
     ir_component.attributes = comp.attributes;
+
+    // Add reserved names to the component's namegenerator so future conflicts
+    // don't occur
+    ir_component
+        .add_names(RESERVED_NAMES.iter().map(|s| s.to_string()).collect());
 
     Ok(ir_component)
 }

--- a/calyx/src/utils/namegenerator.rs
+++ b/calyx/src/utils/namegenerator.rs
@@ -19,6 +19,11 @@ impl NameGenerator {
         }
     }
 
+    /// Add generated names
+    pub fn add_names(&mut self, names: HashSet<String>) {
+        self.generated_names.extend(names)
+    }
+
     /// Returns a new String that starts with `prefix`.
     /// For example:
     /// ```

--- a/tests/errors/reserved-name.expect
+++ b/tests/errors/reserved-name.expect
@@ -1,0 +1,6 @@
+---CODE---
+1
+---STDERR---
+Error: tests/errors/reserved-name.futil
+4 |    reg = std_reg(32);
+  |    ^^^ Use of reserved keyword: reg

--- a/tests/errors/reserved-name.futil
+++ b/tests/errors/reserved-name.futil
@@ -1,0 +1,10 @@
+import "primitives/core.futil";
+component main() -> () {
+  cells {
+    reg = std_reg(32);
+  }
+  wires {
+  }
+  control {
+  }
+}


### PR DESCRIPTION
The frontend was parsing `reg = std_reg(32)` as `reg0` because of the
namegenerator. This changes the frontend so that reserved names are
parsed as is
