### PR TITLE
[Interpreter] Make div/mult primitives only compute on cycle change

### DIFF
--- a/interp/src/primitives/prim_utils.rs
+++ b/interp/src/primitives/prim_utils.rs
@@ -1,5 +1,6 @@
 use crate::values::Value;
 use calyx::ir;
+use std::collections::VecDeque;
 
 pub(super) fn get_param<S>(params: &ir::Binding, target: S) -> Option<u64>
 where
@@ -35,4 +36,28 @@ where
     S: AsRef<str>,
 {
     get_input(inputs, target).unwrap()
+}
+
+/// A shift buffer of a fixed size
+pub struct ShiftBuffer<T, const N: usize> {
+    buffer: VecDeque<Option<T>>,
+}
+
+impl<T, const N: usize> Default for ShiftBuffer<T, N> {
+    fn default() -> Self {
+        let mut buffer = VecDeque::with_capacity(N);
+        for _ in 0..N {
+            buffer.push_front(None)
+        }
+        Self { buffer }
+    }
+}
+
+impl<T, const N: usize> ShiftBuffer<T, N> {
+    /// Shifts an element on to the front of the buffer and returns the element
+    /// on the end of the buffer.
+    pub fn shift(&mut self, element: Option<T>) -> Option<T> {
+        self.buffer.push_front(element);
+        self.buffer.pop_back().flatten()
+    }
 }

--- a/interp/src/primitives/prim_utils.rs
+++ b/interp/src/primitives/prim_utils.rs
@@ -62,4 +62,13 @@ impl<T, const N: usize> ShiftBuffer<T, N> {
         // this call
         self.buffer.pop_back().unwrap()
     }
+
+    /// Removes all instantiated elements in the buffer and replaces them with
+    /// empty slots
+    pub fn reset(&mut self) {
+        self.buffer.clear();
+        for _ in 0..N {
+            self.buffer.push_front(None)
+        }
+    }
 }

--- a/interp/src/primitives/prim_utils.rs
+++ b/interp/src/primitives/prim_utils.rs
@@ -58,6 +58,8 @@ impl<T, const N: usize> ShiftBuffer<T, N> {
     /// on the end of the buffer.
     pub fn shift(&mut self, element: Option<T>) -> Option<T> {
         self.buffer.push_front(element);
-        self.buffer.pop_back().flatten()
+        // this is safe as the buffer will always have N + 1 elements before
+        // this call
+        self.buffer.pop_back().unwrap()
     }
 }


### PR DESCRIPTION
A simple PR which rearranges the computation for div and mult primitives. Previously they computed a value during the stabilization loop, this changes it so that the mult/div value is only computed when time advances. This saves a bit of work as the computation is no longer performed every trip around the stabilization loop though is useful primarially because it reduces spurious warnings and only prints one warning per cycle for overflow/div-by-zero. Of course, since each takes three cycles we still will raise a warning three times under stable input, but this at least cuts down on the noise somewhat.

Also adds proper warnings for div-by-zero.

Also adds a small shift buffer struct which has a fixed length to cut down on the asserts.