### PR TITLE
[Interpreter] Logging rework with Slog

### DIFF
--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -28,6 +28,8 @@ pest = "2.1.3"
 pest_derive = "2.1.0"
 pest_consume = "1.1.1"
 
+slog-term = "2.8.0"
+slog-async = "2.7.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -28,6 +28,7 @@ pest = "2.1.3"
 pest_derive = "2.1.0"
 pest_consume = "1.1.1"
 
+slog = "2.7.0"
 slog-term = "2.8.0"
 slog-async = "2.7.0"
 

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -20,8 +20,6 @@ argh = "0.1.5"
 rustyline = "9.0.0"
 fraction = { version = "0.9.0", features = ["with-serde-support"] }
 thiserror = "1.0.26"
-log = { version = "0.4.14", features = ["std"]}
-stderrlog = "0.5.1"
 lazy_static = "1.4.0"
 ibig = { version= "0.3.4", features = ["serde"] }
 pest = "2.1.3"

--- a/interp/src/configuration.rs
+++ b/interp/src/configuration.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub error_on_overflow: bool,
     /// permits "sloppy" interpretation with parallel blocks
     pub allow_par_conflicts: bool,
+    /// suppresses warning printing
+    pub quiet: bool,
 }
 impl Default for Config {
     fn default() -> Self {
@@ -22,6 +24,7 @@ impl Default for Config {
             allow_invalid_memory_access: false,
             error_on_overflow: false,
             allow_par_conflicts: false,
+            quiet: false,
         }
     }
 }

--- a/interp/src/lib.rs
+++ b/interp/src/lib.rs
@@ -2,16 +2,14 @@ pub mod interpreter;
 pub mod primitives;
 pub use utils::MemoryMap;
 mod configuration;
-
 pub mod debugger;
 pub mod errors;
 pub mod interpreter_ir;
+pub mod logging;
 mod macros;
 mod structures;
-
-pub use structures::{environment, stk_env, values};
-
 mod tests;
 mod utils;
 
 pub use configuration::SETTINGS;
+pub use structures::{environment, stk_env, values};

--- a/interp/src/logging.rs
+++ b/interp/src/logging.rs
@@ -7,7 +7,9 @@ pub(crate) use slog::{debug, error, info, o, trace, warn, Logger};
 use slog::{Drain, Level};
 
 lazy_static! {
-    /// Global root logger. Note should be initialized after SETTINGS
+    /// Global root logger. Note should be initialized after SETTINGS to ensure
+    /// warning suppression, if desired. Directly using the root logger is not
+    /// recommended unless a sublogger is unavailable (see [new_sublogger]).
     pub static ref ROOT_LOGGER: Logger = {
         let decorator = slog_term::TermDecorator::new().stderr().build();
         let drain = slog_term::FullFormat::new(decorator).build();
@@ -24,6 +26,9 @@ lazy_static! {
     };
 }
 
+/// Utility method for creating subloggers for components/primitives/etc. This
+/// is the prefered method for getting a logger. Initializes the source key with
+/// the supplied name.
 pub fn new_sublogger<S: AsRef<str>>(source_name: S) -> Logger {
     ROOT_LOGGER.new(o!("source" => String::from(source_name.as_ref())))
 }

--- a/interp/src/logging.rs
+++ b/interp/src/logging.rs
@@ -1,0 +1,23 @@
+use lazy_static::*;
+
+// re-export for convenience
+pub use slog::{debug, error, info, trace, warn};
+use slog::{o, Drain, Level, Logger};
+
+lazy_static! {
+    /// Global root logger. Note should be initialized after SETTINGS
+    pub static ref ROOT_LOGGER: Logger = {
+        let decorator = slog_term::TermDecorator::new().stderr().build();
+        let drain = slog_term::FullFormat::new(decorator).build();
+        let filter_level = if crate::configuration::SETTINGS.read().unwrap().quiet {
+            Level::Error
+        } else {
+            Level::Trace
+        };
+        let drain = drain.filter_level(filter_level).fuse();
+
+        let drain = slog_async::Async::new(drain).build().fuse();
+
+        slog::Logger::root(drain, o!())
+    };
+}

--- a/interp/src/logging.rs
+++ b/interp/src/logging.rs
@@ -1,8 +1,10 @@
 use lazy_static::*;
 
 // re-export for convenience
-pub use slog::{debug, error, info, trace, warn};
-use slog::{o, Drain, Level, Logger};
+#[allow(unused_imports)]
+pub(crate) use slog::{debug, error, info, o, trace, warn, Logger};
+
+use slog::{Drain, Level};
 
 lazy_static! {
     /// Global root logger. Note should be initialized after SETTINGS
@@ -20,4 +22,8 @@ lazy_static! {
 
         slog::Logger::root(drain, o!())
     };
+}
+
+pub fn new_sublogger<S: AsRef<str>>(source_name: S) -> Logger {
+    ROOT_LOGGER.new(o!("source" => String::from(source_name.as_ref())))
 }

--- a/interp/src/logging.rs
+++ b/interp/src/logging.rs
@@ -1,8 +1,9 @@
 use lazy_static::*;
 
 // re-export for convenience
+pub use slog::Logger;
 #[allow(unused_imports)]
-pub(crate) use slog::{debug, error, info, o, trace, warn, Logger};
+pub(crate) use slog::{debug, error, info, o, trace, warn};
 
 use slog::{Drain, Level};
 

--- a/interp/src/macros.rs
+++ b/interp/src/macros.rs
@@ -150,7 +150,7 @@ macro_rules! comb_primitive {
                         .$port
                         .expect(&format!("No value for port: {}", $crate::in_fix!($port)).to_string()) ),+,
                     &self.logger,
-                    self.get_full_name(),
+                    $crate::primitives::Named::get_full_name(self),
                 )?;
 
                 return Ok(vec![

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -8,7 +8,7 @@ use interp::{
 };
 
 use argh::FromArgs;
-use slog::{o, warn, Drain};
+use slog::warn;
 use std::{
     path::{Path, PathBuf},
     rc::Rc,

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -97,7 +97,6 @@ fn print_res(
     }
 }
 
-//first half of this is tests
 /// Interpret a group from a Calyx program
 fn main() -> InterpreterResult<()> {
     let opts: Opts = argh::from_env();

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -1,15 +1,18 @@
-use crate::environment::InterpreterState;
-use argh::FromArgs;
 use calyx::{frontend, ir, pass_manager::PassManager, utils::OutputFile};
-use interp::debugger::Debugger;
-use interp::environment;
-use interp::errors::{InterpreterError, InterpreterResult};
-use interp::interpreter::interpret_component;
-use interp::interpreter_ir as iir;
+use interp::{
+    debugger::Debugger,
+    environment::InterpreterState,
+    errors::{InterpreterError, InterpreterResult},
+    interpreter::interpret_component,
+    interpreter_ir as iir,
+};
+
+use argh::FromArgs;
 use log::warn;
-use std::path::Path;
-use std::path::PathBuf;
-use std::rc::Rc;
+use std::{
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 #[derive(FromArgs)]
 /// The Calyx Interpreter
 pub struct Opts {
@@ -151,11 +154,8 @@ fn main() -> InterpreterResult<()> {
 
     let mems = interp::MemoryMap::inflate_map(&opts.data_file)?;
 
-    let env = environment::InterpreterState::init_top_level(
-        &components,
-        main_component,
-        &mems,
-    );
+    let env =
+        InterpreterState::init_top_level(&components, main_component, &mems);
     let res = match opts.comm.unwrap_or(Command::Interpret(CommandInterpret {}))
     {
         Command::Interpret(_) => interpret_component(main_component, env?),

--- a/interp/src/primitives/stateful.rs
+++ b/interp/src/primitives/stateful.rs
@@ -74,8 +74,17 @@ impl<const SIGNED: bool> Primitive for StdMultPipe<SIGNED> {
             } else if overflow {
                 warn!(
                     self.logger,
-                    "Computation has under/overflowed in multiplier ({})",
-                    self.get_full_name()
+                    "Computation under/overflowed ({} -> {})",
+                    if SIGNED {
+                        format!("{}", left.as_signed() * right.as_signed())
+                    } else {
+                        format!("{}", left.as_unsigned() * right.as_unsigned())
+                    },
+                    if SIGNED {
+                        format!("{}", value.as_signed())
+                    } else {
+                        format!("{}", value.as_unsigned())
+                    }
                 );
             }
 

--- a/interp/src/structures/stk_env.rs
+++ b/interp/src/structures/stk_env.rs
@@ -838,7 +838,10 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
                         if crate::SETTINGS.read().unwrap().allow_par_conflicts
                             && prev == v
                         {
-                            log::warn!("Allowing parallel conflict")
+                            crate::logging::warn!(
+                                crate::logging::ROOT_LOGGER,
+                                "Allowing parallel conflict"
+                            )
                         } else {
                             return Err(CollisionError(k, prev, v));
                         }


### PR DESCRIPTION
Another simple quality of life PR which revamps the logging infrastructure to use `slog` instead of `log`. The most salient difference is that any logging message coming from a primitive will have the source of the primitive included by default, rather than needing to specially format the message to contain it.

```
Dec 01 17:29:17.708 WARN Computation over/underflow: -78056.9766248 to -12520.9766387, source: main.e.pow1.mul
Dec 01 17:29:17.710 WARN Computation over/underflow: 85627.1313813 to 20091.1313781, source: main.e.pow1.mul
```