### PR TITLE
[Interpreter/CIDR] Fix help typos and improve error message

### DIFF
--- a/calyx/src/passes/simplify_guards.rs
+++ b/calyx/src/passes/simplify_guards.rs
@@ -116,7 +116,7 @@ fn simplify_guard(guard: ir::Guard) -> ir::Guard {
                 })
                 .fold(ir::Guard::True, |acc, x| acc & x)
         })
-        .fold1(ir::Guard::or)
+        .reduce(ir::Guard::or)
         .unwrap();
 
     let common_guard = common

--- a/calyx/src/passes/simplify_guards.rs
+++ b/calyx/src/passes/simplify_guards.rs
@@ -5,7 +5,6 @@ use crate::ir::{
 };
 use boolean_expression::Expr;
 use ir::traversal::{Action, VisResult};
-use itertools::Itertools;
 
 impl From<ir::Guard> for Expr<ir::Guard> {
     fn from(guard: ir::Guard) -> Self {

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 itertools = "0.10.1"
 argh = "0.1.5"
-rustyline = "9.0.0"
+rustyline = "=9.0.0"
 fraction = { version = "0.9.0", features = ["with-serde-support"] }
 thiserror = "1.0.26"
 lazy_static = "1.4.0"

--- a/interp/src/configuration.rs
+++ b/interp/src/configuration.rs
@@ -18,6 +18,8 @@ pub struct Config {
     /// suppresses warning printing
     pub quiet: bool,
 }
+
+#[allow(clippy::derivable_impls)]
 impl Default for Config {
     fn default() -> Self {
         Self {

--- a/interp/src/configuration.rs
+++ b/interp/src/configuration.rs
@@ -19,7 +19,7 @@ pub struct Config {
     pub quiet: bool,
 }
 
-#[allow(clippy::derivable_impls)]
+// #[allow(clippy::derivable_impls)]
 impl Default for Config {
     fn default() -> Self {
         Self {

--- a/interp/src/debugger/commands.rs
+++ b/interp/src/debugger/commands.rs
@@ -80,17 +80,17 @@ impl Command {
 impl Command {
     fn help_string() -> Vec<(Vec<&'static str>, &'static str)> {
         vec![
-            (vec!["Step", "S"], "Advance the execution by a step"),
-            (vec!["Step-over", "S"], "Advance the execution over a given group"),
-            (vec!["Continue", "C"], "Continue until the program finishes executing or hits a breakpoint"),
+            (vec!["Step", "s"], "Advance the execution by a step"),
+            (vec!["Step-over"], "Advance the execution over a given group"),
+            (vec!["Continue", "c"], "Continue until the program finishes executing or hits a breakpoint"),
             (vec!["Display"], "Display the full state"),
-            (vec!["Print", "P"], "Print target value"),
+            (vec!["Print", "p"], "Print target value"),
             (vec!["Print-state"], "Print the internal state of the target cell"),
             (vec!["Watch"], "Watch a given group with a print statement"),
             (vec!["Help", "h"], "Print this message"),
-            (vec!["Break", "Br"], "Create a breakpoint"),
-            (vec!["Info break"], "List all breakpoints"),
-            (vec!["Delete","Del"], "Delete target breakpoint"),
+            (vec!["Break", "br"], "Create a breakpoint"),
+            (vec!["Info break", "ib"], "List all breakpoints"),
+            (vec!["Delete","del"], "Delete target breakpoint"),
             (vec!["Enable"], "Enable target breakpoint"),
             (vec!["Disable"], "Disable target breakpoint"),
             (vec!["Exit"], "Exit the debugger")

--- a/interp/src/errors.rs
+++ b/interp/src/errors.rs
@@ -97,8 +97,12 @@ pub enum InterpreterError {
     #[error("the interpreter attempted to exit a phantom group before it finished. This should never happen, please report it")]
     InvalidGroupExitUnnamed,
 
-    #[error("invalid memory access. Given index ({}) but memory has dimension ({})", access.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(", "), dims.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(", "))]
-    InvalidMemoryAccess { access: Vec<u64>, dims: Vec<u64> },
+    #[error("invalid memory access to memory {}. Given index ({}) but memory has dimension ({})", name, access.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(", "), dims.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(", "))]
+    InvalidMemoryAccess {
+        access: Vec<u64>,
+        dims: Vec<u64>,
+        name: Id,
+    },
 
     // TODO (Griffin): Make this error message better please
     #[error("Computation has under/overflowed its bounds")]

--- a/interp/src/primitives/stateful.rs
+++ b/interp/src/primitives/stateful.rs
@@ -576,6 +576,7 @@ impl Primitive for StdMemD1 {
             }
 
             return Err(InterpreterError::InvalidMemoryAccess {
+                name: self.full_name.clone(),
                 access: vec![self.last_index],
                 dims: vec![self.size],
             });
@@ -831,6 +832,7 @@ impl Primitive for StdMemD2 {
                 }
             }
             return Err(InterpreterError::InvalidMemoryAccess {
+                name: self.full_name.clone(),
                 access: vec![self.last_idx.0, self.last_idx.1],
                 dims: vec![self.d0_size, self.d1_size],
             });
@@ -1109,6 +1111,7 @@ impl Primitive for StdMemD3 {
                 }
             }
             return Err(InterpreterError::InvalidMemoryAccess {
+                name: self.full_name.clone(),
                 access: vec![self.last_idx.0, self.last_idx.1, self.last_idx.2],
                 dims: vec![self.d0_size, self.d1_size, self.d2_size],
             });
@@ -1424,6 +1427,7 @@ impl Primitive for StdMemD4 {
             }
 
             return Err(InterpreterError::InvalidMemoryAccess {
+                name: self.full_name.clone(),
                 access: vec![
                     self.last_idx.0,
                     self.last_idx.1,


### PR DESCRIPTION
Teeny PR which fixes a few typos in the CIDR help message and adds the name of the memory to the memory out of bounds index error.