### PR TITLE
Define `ir::Rewriter`

### DIFF
--- a/calyx/src/analysis/reaching_defns.rs
+++ b/calyx/src/analysis/reaching_defns.rs
@@ -173,7 +173,7 @@ impl ReachingDefinitionAnalysis {
     /// which can be ignored if one is not rewriting values
     /// **NOTE**: Assumes that each group appears at only one place in the control
     /// structure.
-    pub fn new(_comp: &ir::Component, control: &ir::Control) -> Self {
+    pub fn new(control: &ir::Control) -> Self {
         let initial_set = DefSet::default();
         let mut analysis = ReachingDefinitionAnalysis::default();
         let mut counter: u64 = 0;

--- a/calyx/src/ir/mod.rs
+++ b/calyx/src/ir/mod.rs
@@ -18,6 +18,7 @@ mod id;
 mod primitives;
 mod printer;
 mod reserved_names;
+mod rewriter;
 mod structure;
 
 // Re-export types at the module level.
@@ -32,6 +33,7 @@ pub use id::Id;
 pub use primitives::{PortDef, Primitive, Width};
 pub use printer::Printer;
 pub use reserved_names::RESERVED_NAMES;
+pub use rewriter::Rewriter;
 pub use structure::{
     Assignment, Binding, Cell, CellIterator, CellType, CloneName, CombGroup,
     Direction, GetName, Group, Port, PortIterator, PortParent,

--- a/calyx/src/ir/mod.rs
+++ b/calyx/src/ir/mod.rs
@@ -30,7 +30,7 @@ pub use control::{Control, Empty, Enable, If, Invoke, Par, Seq, While};
 pub use guard::Guard;
 pub use id::Id;
 pub use primitives::{PortDef, Primitive, Width};
-pub use printer::IRPrinter;
+pub use printer::Printer;
 pub use reserved_names::RESERVED_NAMES;
 pub use structure::{
     Assignment, Binding, Cell, CellIterator, CellType, CloneName, CombGroup,

--- a/calyx/src/ir/printer.rs
+++ b/calyx/src/ir/printer.rs
@@ -9,9 +9,9 @@ use std::path::Path;
 use std::rc::Rc;
 
 /// Printer for the IR.
-pub struct IRPrinter;
+pub struct Printer;
 
-impl IRPrinter {
+impl Printer {
     /// Format attributes of the form `@static(1)`.
     /// Returns the empty string if the `attrs` is empty.
     fn format_at_attributes(attrs: &ir::Attributes) -> String {

--- a/calyx/src/ir/rewriter.rs
+++ b/calyx/src/ir/rewriter.rs
@@ -1,0 +1,105 @@
+use crate::ir::{self, RRC};
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// IR Rewriter. Defines methods to rewrite various parts of the IR using
+/// rewrite maps.
+pub struct Rewriter;
+
+/// Map to rewrite cell uses. Maps name of the old cell to the new [ir::Cell]
+/// instance.
+pub type CellRewriteMap = HashMap<ir::Id, RRC<ir::Cell>>;
+
+/// Map to rewrite port uses. Maps the canonical name of an old port (generated using
+/// [ir::Port::canonical]) to the new [ir::Port] instance.
+pub type PortRewriteMap = HashMap<(ir::Id, ir::Id), RRC<ir::Port>>;
+
+impl Rewriter {
+    /// Get [ir::Port] with the same name as `port` from `cell`.
+    fn get_port(port: &RRC<ir::Port>, cell: &RRC<ir::Cell>) -> RRC<ir::Port> {
+        Rc::clone(&cell.borrow().get(&port.borrow().name))
+    }
+
+    /// Return a port rewrite if it is defeind in the set of rewrites.
+    fn get_port_rewrite(
+        rewrites: &CellRewriteMap,
+        port: &RRC<ir::Port>,
+    ) -> Option<RRC<ir::Port>> {
+        let rewrite =
+            if let ir::PortParent::Cell(cell_wref) = &port.borrow().parent {
+                let cell_ref = cell_wref.upgrade();
+                let cell_name = cell_ref.borrow();
+                rewrites.get(cell_name.name())
+            } else {
+                None
+            };
+        rewrite.map(|new_cell| Self::get_port(port, new_cell))
+    }
+
+    /// Rewrite reads and writes from `cell` in the given assingments to
+    /// the same ports on `new_cell`.
+    ///
+    /// For example, given with `cell = a` and `new_cell = b`
+    /// ```
+    /// a.in = a.done ? a.out;
+    /// ```
+    /// is rewritten to
+    /// ```
+    /// b.in = b.done ? b.out;
+    /// ```
+    #[inline]
+    pub fn rename_cell_use(
+        rewrites: &CellRewriteMap,
+        assign: &mut ir::Assignment,
+    ) {
+        if let Some(new_port) = Self::get_port_rewrite(rewrites, &assign.src) {
+            assign.src = new_port;
+        }
+        if let Some(new_port) = Self::get_port_rewrite(rewrites, &assign.dst) {
+            assign.dst = new_port;
+        }
+        assign.guard.for_each(&|port| {
+            Self::get_port_rewrite(rewrites, &port).map(ir::Guard::port)
+        });
+    }
+
+    /// Convinience wrapper around [Self::rename_cell_use] that operates
+    /// over given set of assignments.
+    pub fn rename_cell_uses(
+        rewrites: &CellRewriteMap,
+        assigns: &mut Vec<ir::Assignment>,
+    ) {
+        for assign in assigns {
+            Self::rename_cell_use(rewrites, assign)
+        }
+    }
+
+    /// Rename uses of specific ports if they are defined within `rewrites`
+    /// to the mapped port.
+    /// Uses [ir::Port::canonical] values as the key.
+    #[inline]
+    pub fn rename_port_use(
+        rewrites: &PortRewriteMap,
+        assign: &mut ir::Assignment,
+    ) {
+        let new_src = rewrites
+            .get(&assign.src.borrow().canonical())
+            .map(Rc::clone);
+        if let Some(src) = new_src {
+            assign.src = src;
+        }
+
+        let new_dst = rewrites
+            .get(&assign.dst.borrow().canonical())
+            .map(Rc::clone);
+        if let Some(dst) = new_dst {
+            assign.dst = dst;
+        }
+
+        assign.guard.for_each(&|port| {
+            rewrites
+                .get(&port.borrow().canonical())
+                .map(|p| ir::Guard::port(Rc::clone(p)))
+        });
+    }
+}

--- a/calyx/src/passes/register_unsharing.rs
+++ b/calyx/src/passes/register_unsharing.rs
@@ -3,7 +3,7 @@ use crate::analysis::reaching_defns::{
 };
 use crate::ir::traversal::{Action, Named, VisResult, Visitor};
 use crate::ir::{self, Builder, Cell, CloneName, LibrarySignatures, RRC};
-use std::{collections::HashMap, rc::Rc};
+use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct RegisterUnsharing {
@@ -18,7 +18,7 @@ impl Named for RegisterUnsharing {
     }
 
     fn description() -> &'static str {
-        "Split apart shared values into separate regsters"
+        "Split apart shared values into separate registers"
     }
 }
 
@@ -55,8 +55,7 @@ impl Bookkeeper {
             })
             .collect();
 
-        let analysis =
-            ReachingDefinitionAnalysis::new(comp, &comp.control.borrow());
+        let analysis = ReachingDefinitionAnalysis::new(&comp.control.borrow());
 
         let invoke_map = HashMap::new();
 
@@ -195,35 +194,14 @@ impl Visitor for RegisterUnsharing {
 
             // only do rewrites if there is actually rewriting to do
             if let Some(rename_vec) = vec_array {
-                replace_invoke_ports(invoke, rename_vec);
+                ir::Rewriter::rewrite_invoke(
+                    invoke,
+                    rename_vec,
+                    &HashMap::new(),
+                );
             }
         }
 
         Ok(Action::Continue)
-    }
-}
-
-fn replace_invoke_ports(
-    invoke: &mut ir::Invoke,
-    rewrites: &HashMap<ir::Id, RRC<ir::Cell>>,
-) {
-    let get_port =
-        |port: &RRC<ir::Port>, cell: &RRC<ir::Cell>| -> RRC<ir::Port> {
-            Rc::clone(&cell.borrow().get(&port.borrow().name))
-        };
-
-    for (_, port) in invoke.inputs.iter_mut().chain(invoke.outputs.iter_mut()) {
-        let rewrite =
-            if let ir::PortParent::Cell(cell_wref) = &port.borrow().parent {
-                let cell_ref = cell_wref.upgrade();
-                let parent = cell_ref.borrow();
-                rewrites.get(parent.name())
-            } else {
-                None
-            };
-
-        if let Some(cell) = rewrite {
-            *port = get_port(port, cell)
-        }
     }
 }

--- a/calyx/src/passes/register_unsharing.rs
+++ b/calyx/src/passes/register_unsharing.rs
@@ -141,7 +141,7 @@ impl Bookkeeper {
         for (grp, rename_cells) in grp_map {
             let group = builder.component.find_group(grp).unwrap();
             let mut group_ref = group.borrow_mut();
-            ir::Builder::rename_port_uses(
+            ir::Rewriter::rename_cell_uses(
                 &rename_cells,
                 &mut group_ref.assignments,
             )

--- a/calyx/src/passes/sharing_components.rs
+++ b/calyx/src/passes/sharing_components.rs
@@ -182,120 +182,13 @@ impl<T: ShareComponents> Visitor for T {
         ir::Rewriter::rename_cell_uses(&coloring, &mut assigns);
         builder.component.continuous_assignments = assigns;
 
-        self.set_rewrites(coloring);
+        ir::Rewriter::rewrite_control(
+            &mut *comp.control.borrow_mut(),
+            &coloring,
+            &HashMap::new(),
+            &HashMap::new(),
+        );
 
-        Ok(Action::Continue)
-    }
-
-    fn start_if(
-        &mut self,
-        s: &mut ir::If,
-        _comp: &mut ir::Component,
-        _sigs: &ir::LibrarySignatures,
-        _comps: &[ir::Component],
-    ) -> VisResult {
-        let cond_port = &s.port;
-
-        // XXX(sam), is just having a single cell -> cell map for
-        // rewrites sufficient. or do you need cell, group_id -> cell
-
-        let parent = if let ir::PortParent::Cell(cell_wref) =
-            &cond_port.borrow().parent
-        {
-            Some(cell_wref.upgrade())
-        } else {
-            None
-        };
-
-        if let Some(cell) = parent {
-            // find rewrite for conditional port cell
-            let rewrite = self.get_rewrites().get(cell.borrow().name());
-            if let Some(new_cell) = rewrite {
-                let new_port = new_cell.borrow().get(&cond_port.borrow().name);
-                s.port = new_port;
-            }
-        };
-
-        Ok(Action::Continue)
-    }
-
-    // Rewrite the name of the cond port if this group was re-written.
-    fn start_while(
-        &mut self,
-        s: &mut ir::While,
-        _comp: &mut ir::Component,
-        _sigs: &ir::LibrarySignatures,
-        _comps: &[ir::Component],
-    ) -> VisResult {
-        let cond_port = &s.port;
-        // Check if the cell associated with the port was rewritten for the cond
-        // group.
-        let parent = if let ir::PortParent::Cell(cell_wref) =
-            &cond_port.borrow().parent
-        {
-            Some(cell_wref.upgrade())
-        } else {
-            None
-        };
-
-        if let Some(cell) = parent {
-            // find rewrite for conditional port cell
-            let rewrite = self.get_rewrites().get(cell.borrow().name());
-            if let Some(new_cell) = rewrite {
-                let new_port = new_cell.borrow().get(&cond_port.borrow().name);
-                s.port = new_port;
-            }
-        };
-
-        Ok(Action::Continue)
-    }
-
-    fn invoke(
-        &mut self,
-        s: &mut ir::Invoke,
-        _comp: &mut ir::Component,
-        _sigs: &ir::LibrarySignatures,
-        _comps: &[ir::Component],
-    ) -> VisResult {
-        // rename inputs
-        for (_id, src) in &s.inputs {
-            let parent =
-                if let ir::PortParent::Cell(cell_wref) = &src.borrow().parent {
-                    Some(cell_wref.upgrade())
-                } else {
-                    None
-                };
-
-            if let Some(cell) = parent {
-                // find rewrite for conditional port cell
-                let rewrite = self.get_rewrites().get(cell.borrow().name());
-                if let Some(new_cell) = rewrite {
-                    let new_port = new_cell.borrow().get(&src.borrow().name);
-                    *src.borrow_mut() = new_port.borrow().clone();
-                }
-            };
-        }
-
-        // rename outputs
-        for (_id, dest) in &s.outputs {
-            let parent = if let ir::PortParent::Cell(cell_wref) =
-                &dest.borrow().parent
-            {
-                Some(cell_wref.upgrade())
-            } else {
-                None
-            };
-
-            if let Some(cell) = parent {
-                // find rewrite for conditional port cell
-                let rewrite = self.get_rewrites().get(cell.borrow().name());
-                if let Some(new_cell) = rewrite {
-                    let new_port = new_cell.borrow().get(&dest.borrow().name);
-                    *dest.borrow_mut() = new_port.borrow().clone();
-                }
-            };
-        }
-
-        Ok(Action::Continue)
+        Ok(Action::Stop)
     }
 }

--- a/calyx/src/passes/sharing_components.rs
+++ b/calyx/src/passes/sharing_components.rs
@@ -173,13 +173,13 @@ impl<T: ShareComponents> Visitor for T {
         for group_ref in builder.component.groups.iter() {
             let mut group = group_ref.borrow_mut();
             let mut assigns: Vec<_> = group.assignments.drain(..).collect();
-            ir::Builder::rename_port_uses(&coloring, &mut assigns);
+            ir::Rewriter::rename_cell_uses(&coloring, &mut assigns);
             group.assignments = assigns;
         }
 
         let mut assigns: Vec<_> =
             builder.component.continuous_assignments.drain(..).collect();
-        ir::Builder::rename_port_uses(&coloring, &mut assigns);
+        ir::Rewriter::rename_cell_uses(&coloring, &mut assigns);
         builder.component.continuous_assignments = assigns;
 
         self.set_rewrites(coloring);

--- a/calyx/src/passes/top_down_compile_control.rs
+++ b/calyx/src/passes/top_down_compile_control.rs
@@ -11,7 +11,7 @@ use crate::{
         LibrarySignatures, RRC,
     },
 };
-use ir::IRPrinter;
+use ir::Printer;
 use itertools::Itertools;
 use petgraph::graph::DiGraph;
 use std::collections::HashMap;
@@ -198,7 +198,7 @@ impl Schedule {
             .for_each(|(state, assigns)| {
                 writeln!(out, "{}:", state).unwrap();
                 assigns.iter().for_each(|assign| {
-                    IRPrinter::write_assignment(assign, 2, out).unwrap();
+                    Printer::write_assignment(assign, 2, out).unwrap();
                     writeln!(out).unwrap();
                 })
             });
@@ -208,7 +208,7 @@ impl Schedule {
             .iter()
             .sorted_by(|(k1, _, _), (k2, _, _)| k1.cmp(k2))
             .for_each(|(i, f, g)| {
-                writeln!(out, "  ({}, {}): {}", i, f, IRPrinter::guard_str(g))
+                writeln!(out, "  ({}, {}): {}", i, f, Printer::guard_str(g))
                     .unwrap();
             });
     }

--- a/interp/src/utils.rs
+++ b/interp/src/utils.rs
@@ -138,7 +138,7 @@ impl<T> AsRaw<T> for &RRC<T> {
 
 pub fn assignment_to_string(assignment: &ir::Assignment) -> String {
     let mut str = vec![];
-    ir::IRPrinter::write_assignment(assignment, 0, &mut str)
+    ir::Printer::write_assignment(assignment, 0, &mut str)
         .expect("Write Failed");
     String::from_utf8(str).expect("Found invalid UTF-8")
 }

--- a/src/backend/mlir.rs
+++ b/src/backend/mlir.rs
@@ -1,5 +1,5 @@
 use calyx::errors::Error;
-use calyx::ir::{GetAttributes, IRPrinter};
+use calyx::ir::GetAttributes;
 
 use crate::ir::{self, RRC};
 use std::collections::HashMap;
@@ -264,7 +264,7 @@ impl MlirBackend {
         } else if matches!(&*assign.guard, ir::Guard::True) {
             /* Print nothing */
         } else {
-            panic!("Failed to compile guard: {}.\nFirst run the `lower-guards` pass. If you did, report this as an issue.", IRPrinter::guard_str(&*assign.guard));
+            panic!("Failed to compile guard: {}.\nFirst run the `lower-guards` pass. If you did, report this as an issue.", ir::Printer::guard_str(&*assign.guard));
         }
         write!(f, "{}", Self::get_port_access(&assign.src.borrow()),)?;
         write!(f, " : i{}", assign.src.borrow().width)

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -190,7 +190,7 @@ impl Opts {
             }
             BackendOpt::Calyx => {
                 for (path, prims) in context.lib.externs() {
-                    ir::IRPrinter::write_extern(
+                    ir::Printer::write_extern(
                         (
                             &path,
                             &prims.into_iter().map(|(_, v)| v).collect_vec(),
@@ -199,7 +199,7 @@ impl Opts {
                     )?;
                 }
                 for comp in &context.components {
-                    ir::IRPrinter::write_component(
+                    ir::Printer::write_component(
                         comp,
                         &mut self.output.get_write(),
                     )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn main() -> CalyxResult<()> {
         let out = &mut opts.output.get_write();
         if opts.compile_mode == CompileMode::Project {
             for (path, prims) in ctx.lib.externs() {
-                ir::IRPrinter::write_extern(
+                ir::Printer::write_extern(
                     (&path, &prims.into_iter().map(|(_, v)| v).collect_vec()),
                     out,
                 )?;
@@ -63,7 +63,7 @@ fn main() -> CalyxResult<()> {
             }
         }
         for comp in &ctx.components {
-            ir::IRPrinter::write_component(comp, out)?;
+            ir::Printer::write_component(comp, out)?;
             writeln!(out)?
         }
         Ok(())

--- a/tests/errors/insufficient-params.expect
+++ b/tests/errors/insufficient-params.expect
@@ -1,5 +1,5 @@
 ---CODE---
 101
 ---STDERR---
-thread 'main' panicked at 'Failed to add primitive.: Invalid parameter binding for primitive `std_fp_div_pipe`. Requires 3 parameters but provided with 1.', calyx/src/ir/builder.rs:168:14
+thread 'main' panicked at 'Failed to add primitive.: Invalid parameter binding for primitive `std_fp_div_pipe`. Requires 3 parameters but provided with 1.', calyx/src/ir/builder.rs:167:14
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/errors/mismatch-widths.expect
+++ b/tests/errors/mismatch-widths.expect
@@ -1,5 +1,5 @@
 ---CODE---
 101
 ---STDERR---
-thread 'main' panicked at 'Invalid assignment. `x.out' and `add.left' have different widths', calyx/src/ir/builder.rs:204:9
+thread 'main' panicked at 'Invalid assignment. `x.out' and `add.left' have different widths', calyx/src/ir/builder.rs:229:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/errors/mismatch-widths.expect
+++ b/tests/errors/mismatch-widths.expect
@@ -1,5 +1,5 @@
 ---CODE---
 101
 ---STDERR---
-thread 'main' panicked at 'Invalid assignment. `x.out' and `add.left' have different widths', calyx/src/ir/builder.rs:229:9
+thread 'main' panicked at 'Invalid assignment. `x.out' and `add.left' have different widths', calyx/src/ir/builder.rs:203:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/web/rust/src/lib.rs
+++ b/web/rust/src/lib.rs
@@ -43,7 +43,7 @@ fn compile(
 
     let mut buffer: Vec<u8> = vec![];
     for comp in &rep.components {
-        ir::IRPrinter::write_component(comp, &mut buffer)?;
+        ir::Printer::write_component(comp, &mut buffer)?;
     }
     Ok(String::from_utf8(buffer).unwrap())
 }


### PR DESCRIPTION
Separate out the rewrite methods defined on `ir::Builder` into a new struct add more rewrite methods that are generally useful when working with passes that modify/rename parts of components.
