### PR TITLE
Make systolic array output one dimensional

### DIFF
--- a/tests/frontend/systolic/array-1.expect
+++ b/tests/frontend/systolic/array-1.expect
@@ -8,7 +8,7 @@ component main() -> () {
     l0_idx = std_reg(2);
     l0_add = std_add(2);
     @external(1) l0 = std_mem_d1(32, 3, 2);
-    @external(1) out_mem = std_mem_d2(32, 1, 1, 1, 1);
+    @external(1) out_mem = std_mem_d1(32, 1, 1);
     pe_0_0 = mac_pe();
     top_0_0 = std_reg(32);
     left_0_0 = std_reg(32);
@@ -52,7 +52,6 @@ component main() -> () {
     }
     group pe_0_0_out_write {
       out_mem.addr0 = 1'd0;
-      out_mem.addr1 = 1'd0;
       out_mem.write_data = pe_0_0.out;
       out_mem.write_en = 1'd1;
       pe_0_0_out_write[done] = out_mem.done;

--- a/tests/frontend/systolic/array-2.expect
+++ b/tests/frontend/systolic/array-2.expect
@@ -14,7 +14,7 @@ component main() -> () {
     l1_idx = std_reg(2);
     l1_add = std_add(2);
     @external(1) l1 = std_mem_d1(32, 3, 2);
-    @external(1) out_mem = std_mem_d2(32, 2, 2, 2, 2);
+    @external(1) out_mem = std_mem_d1(32, 4, 3);
     pe_0_0 = mac_pe();
     top_0_0 = std_reg(32);
     left_0_0 = std_reg(32);
@@ -112,8 +112,7 @@ component main() -> () {
       pe_0_0_down_move[done] = top_1_0.done;
     }
     group pe_0_0_out_write {
-      out_mem.addr0 = 2'd0;
-      out_mem.addr1 = 2'd0;
+      out_mem.addr0 = 3'd0;
       out_mem.write_data = pe_0_0.out;
       out_mem.write_en = 1'd1;
       pe_0_0_out_write[done] = out_mem.done;
@@ -124,8 +123,7 @@ component main() -> () {
       pe_0_1_down_move[done] = top_1_1.done;
     }
     group pe_0_1_out_write {
-      out_mem.addr0 = 2'd0;
-      out_mem.addr1 = 2'd1;
+      out_mem.addr0 = 3'd1;
       out_mem.write_data = pe_0_1.out;
       out_mem.write_en = 1'd1;
       pe_0_1_out_write[done] = out_mem.done;
@@ -136,15 +134,13 @@ component main() -> () {
       pe_1_0_right_move[done] = left_1_1.done;
     }
     group pe_1_0_out_write {
-      out_mem.addr0 = 2'd1;
-      out_mem.addr1 = 2'd0;
+      out_mem.addr0 = 3'd2;
       out_mem.write_data = pe_1_0.out;
       out_mem.write_en = 1'd1;
       pe_1_0_out_write[done] = out_mem.done;
     }
     group pe_1_1_out_write {
-      out_mem.addr0 = 2'd1;
-      out_mem.addr1 = 2'd1;
+      out_mem.addr0 = 3'd3;
       out_mem.write_data = pe_1_1.out;
       out_mem.write_en = 1'd1;
       pe_1_1_out_write[done] = out_mem.done;

--- a/tests/frontend/systolic/array-3.expect
+++ b/tests/frontend/systolic/array-3.expect
@@ -20,7 +20,7 @@ component main() -> () {
     l2_idx = std_reg(2);
     l2_add = std_add(2);
     @external(1) l2 = std_mem_d1(32, 3, 2);
-    @external(1) out_mem = std_mem_d2(32, 3, 3, 2, 2);
+    @external(1) out_mem = std_mem_d1(32, 9, 4);
     pe_0_0 = mac_pe();
     top_0_0 = std_reg(32);
     left_0_0 = std_reg(32);
@@ -169,8 +169,7 @@ component main() -> () {
       pe_0_0_down_move[done] = top_1_0.done;
     }
     group pe_0_0_out_write {
-      out_mem.addr0 = 2'd0;
-      out_mem.addr1 = 2'd0;
+      out_mem.addr0 = 4'd0;
       out_mem.write_data = pe_0_0.out;
       out_mem.write_en = 1'd1;
       pe_0_0_out_write[done] = out_mem.done;
@@ -186,8 +185,7 @@ component main() -> () {
       pe_0_1_down_move[done] = top_1_1.done;
     }
     group pe_0_1_out_write {
-      out_mem.addr0 = 2'd0;
-      out_mem.addr1 = 2'd1;
+      out_mem.addr0 = 4'd1;
       out_mem.write_data = pe_0_1.out;
       out_mem.write_en = 1'd1;
       pe_0_1_out_write[done] = out_mem.done;
@@ -198,8 +196,7 @@ component main() -> () {
       pe_0_2_down_move[done] = top_1_2.done;
     }
     group pe_0_2_out_write {
-      out_mem.addr0 = 2'd0;
-      out_mem.addr1 = 2'd2;
+      out_mem.addr0 = 4'd2;
       out_mem.write_data = pe_0_2.out;
       out_mem.write_en = 1'd1;
       pe_0_2_out_write[done] = out_mem.done;
@@ -215,8 +212,7 @@ component main() -> () {
       pe_1_0_down_move[done] = top_2_0.done;
     }
     group pe_1_0_out_write {
-      out_mem.addr0 = 2'd1;
-      out_mem.addr1 = 2'd0;
+      out_mem.addr0 = 4'd3;
       out_mem.write_data = pe_1_0.out;
       out_mem.write_en = 1'd1;
       pe_1_0_out_write[done] = out_mem.done;
@@ -232,8 +228,7 @@ component main() -> () {
       pe_1_1_down_move[done] = top_2_1.done;
     }
     group pe_1_1_out_write {
-      out_mem.addr0 = 2'd1;
-      out_mem.addr1 = 2'd1;
+      out_mem.addr0 = 4'd4;
       out_mem.write_data = pe_1_1.out;
       out_mem.write_en = 1'd1;
       pe_1_1_out_write[done] = out_mem.done;
@@ -244,8 +239,7 @@ component main() -> () {
       pe_1_2_down_move[done] = top_2_2.done;
     }
     group pe_1_2_out_write {
-      out_mem.addr0 = 2'd1;
-      out_mem.addr1 = 2'd2;
+      out_mem.addr0 = 4'd5;
       out_mem.write_data = pe_1_2.out;
       out_mem.write_en = 1'd1;
       pe_1_2_out_write[done] = out_mem.done;
@@ -256,8 +250,7 @@ component main() -> () {
       pe_2_0_right_move[done] = left_2_1.done;
     }
     group pe_2_0_out_write {
-      out_mem.addr0 = 2'd2;
-      out_mem.addr1 = 2'd0;
+      out_mem.addr0 = 4'd6;
       out_mem.write_data = pe_2_0.out;
       out_mem.write_en = 1'd1;
       pe_2_0_out_write[done] = out_mem.done;
@@ -268,15 +261,13 @@ component main() -> () {
       pe_2_1_right_move[done] = left_2_2.done;
     }
     group pe_2_1_out_write {
-      out_mem.addr0 = 2'd2;
-      out_mem.addr1 = 2'd1;
+      out_mem.addr0 = 4'd7;
       out_mem.write_data = pe_2_1.out;
       out_mem.write_en = 1'd1;
       pe_2_1_out_write[done] = out_mem.done;
     }
     group pe_2_2_out_write {
-      out_mem.addr0 = 2'd2;
-      out_mem.addr1 = 2'd2;
+      out_mem.addr0 = 4'd8;
       out_mem.write_data = pe_2_2.out;
       out_mem.write_en = 1'd1;
       pe_2_2_out_write[done] = out_mem.done;


### PR DESCRIPTION
Mostly for convenience of simulation with the symbolic evaluator and because I didn't see a good reason to keep the output to be two dimensional.
