### PR TITLE
Merge guard comparison variants into one variant

### DIFF
--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -6,6 +6,7 @@ use super::{
 use crate::{
     errors::{CalyxResult, Error},
     frontend::{self, ast},
+    ir::PortComp,
     utils::NameGenerator,
 };
 use linked_hash_map::LinkedHashMap;
@@ -398,12 +399,36 @@ fn build_guard(guard: ast::GuardExpr, bd: &mut Builder) -> CalyxResult<Guard> {
         GE::Or(l, r) => Guard::or(build_guard(*l, bd)?, build_guard(*r, bd)?),
         GE::And(l, r) => Guard::and(build_guard(*l, bd)?, build_guard(*r, bd)?),
         GE::Not(g) => Guard::Not(into_box_guard(g, bd)?),
-        GE::Eq(l, r) => Guard::Eq(atom_to_port(l, bd)?, atom_to_port(r, bd)?),
-        GE::Neq(l, r) => Guard::Neq(atom_to_port(l, bd)?, atom_to_port(r, bd)?),
-        GE::Gt(l, r) => Guard::Gt(atom_to_port(l, bd)?, atom_to_port(r, bd)?),
-        GE::Lt(l, r) => Guard::Lt(atom_to_port(l, bd)?, atom_to_port(r, bd)?),
-        GE::Geq(l, r) => Guard::Geq(atom_to_port(l, bd)?, atom_to_port(r, bd)?),
-        GE::Leq(l, r) => Guard::Leq(atom_to_port(l, bd)?, atom_to_port(r, bd)?),
+        GE::Eq(l, r) => Guard::CompOp(
+            PortComp::Eq,
+            atom_to_port(l, bd)?,
+            atom_to_port(r, bd)?,
+        ),
+        GE::Neq(l, r) => Guard::CompOp(
+            PortComp::Neq,
+            atom_to_port(l, bd)?,
+            atom_to_port(r, bd)?,
+        ),
+        GE::Gt(l, r) => Guard::CompOp(
+            PortComp::Gt,
+            atom_to_port(l, bd)?,
+            atom_to_port(r, bd)?,
+        ),
+        GE::Lt(l, r) => Guard::CompOp(
+            PortComp::Lt,
+            atom_to_port(l, bd)?,
+            atom_to_port(r, bd)?,
+        ),
+        GE::Geq(l, r) => Guard::CompOp(
+            PortComp::Geq,
+            atom_to_port(l, bd)?,
+            atom_to_port(r, bd)?,
+        ),
+        GE::Leq(l, r) => Guard::CompOp(
+            PortComp::Leq,
+            atom_to_port(l, bd)?,
+            atom_to_port(r, bd)?,
+        ),
     })
 }
 

--- a/calyx/src/ir/guard.rs
+++ b/calyx/src/ir/guard.rs
@@ -4,7 +4,7 @@ use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
 use std::{cmp::Ordering, hash::Hash, rc::Rc};
 
 /// Comparison operations that can be performed between ports by [ir::Guard::Comp].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PortComp {
     /// p1 == p2
     Eq,
@@ -285,8 +285,9 @@ impl PartialEq for Guard {
             (Guard::Or(la, ra), Guard::Or(lb, rb))
             | (Guard::And(la, ra), Guard::And(lb, rb)) => la == lb && ra == rb,
             (Guard::CompOp(opa, la, ra), Guard::CompOp(opb, lb, rb)) => {
-                (la.borrow().get_parent_name(), &la.borrow().name)
-                    == (lb.borrow().get_parent_name(), &lb.borrow().name)
+                (opa == opb)
+                    && (la.borrow().get_parent_name(), &la.borrow().name)
+                        == (lb.borrow().get_parent_name(), &lb.borrow().name)
                     && (ra.borrow().get_parent_name(), &ra.borrow().name)
                         == (rb.borrow().get_parent_name(), &rb.borrow().name)
             }

--- a/calyx/src/ir/guard.rs
+++ b/calyx/src/ir/guard.rs
@@ -3,6 +3,23 @@ use std::mem;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
 use std::{cmp::Ordering, hash::Hash, rc::Rc};
 
+/// Comparison operations that can be performed between ports by [ir::Guard::Comp].
+#[derive(Debug, Clone)]
+pub enum PortComp {
+    /// p1 == p2
+    Eq,
+    /// p1 != p2
+    Neq,
+    /// p1 > p2
+    Gt,
+    /// p1 < p2
+    Lt,
+    /// p1 >= p2
+    Geq,
+    /// p1 <= p2
+    Leq,
+}
+
 /// An assignment guard which has pointers to the various ports from which it reads.
 #[derive(Debug, Clone)]
 pub enum Guard {
@@ -14,18 +31,8 @@ pub enum Guard {
     Not(Box<Guard>),
     /// The constant true
     True,
-    /// Represents `p1 == p2`.
-    Eq(RRC<Port>, RRC<Port>),
-    /// Represents `p1 != p2`.
-    Neq(RRC<Port>, RRC<Port>),
-    /// Represents `p1 > p2`.
-    Gt(RRC<Port>, RRC<Port>),
-    /// Represents `p1 < p2`.
-    Lt(RRC<Port>, RRC<Port>),
-    /// Represents `p1 >= p2`.
-    Geq(RRC<Port>, RRC<Port>),
-    /// Represents `p1 <= p2`.
-    Leq(RRC<Port>, RRC<Port>),
+    /// Comparison operator.
+    CompOp(PortComp, RRC<Port>, RRC<Port>),
     /// Uses the value on a port as the condition. Same as `p1 == true`
     Port(RRC<Port>),
 }
@@ -43,12 +50,7 @@ impl Hash for Guard {
                 l.hash(state);
                 r.hash(state)
             }
-            Guard::Eq(l, r)
-            | Guard::Neq(l, r)
-            | Guard::Gt(l, r)
-            | Guard::Lt(l, r)
-            | Guard::Geq(l, r)
-            | Guard::Leq(l, r) => {
+            Guard::CompOp(_, l, r) => {
                 l.borrow().name.hash(state);
                 l.borrow().get_parent_name().hash(state);
                 r.borrow().name.hash(state);
@@ -81,12 +83,7 @@ impl Guard {
             Guard::Not(inner) => {
                 inner.for_each(f);
             }
-            Guard::Eq(l, r)
-            | Guard::Neq(l, r)
-            | Guard::Gt(l, r)
-            | Guard::Lt(l, r)
-            | Guard::Geq(l, r)
-            | Guard::Leq(l, r) => {
+            Guard::CompOp(_, l, r) => {
                 match f(Rc::clone(l)) {
                     Some(Guard::Port(p)) => *l = p,
                     Some(_) => unreachable!(
@@ -120,12 +117,7 @@ impl Guard {
                 atoms.append(&mut r.all_ports());
                 atoms
             }
-            Guard::Eq(l, r)
-            | Guard::Neq(l, r)
-            | Guard::Gt(l, r)
-            | Guard::Lt(l, r)
-            | Guard::Leq(l, r)
-            | Guard::Geq(l, r) => {
+            Guard::CompOp(_, l, r) => {
                 vec![Rc::clone(l), Rc::clone(r)]
             }
             Guard::Not(g) => g.all_ports(),
@@ -159,12 +151,14 @@ impl Guard {
         match self {
             Guard::And(..) => "&".to_string(),
             Guard::Or(..) => "|".to_string(),
-            Guard::Eq(..) => "==".to_string(),
-            Guard::Neq(..) => "!=".to_string(),
-            Guard::Gt(..) => ">".to_string(),
-            Guard::Lt(..) => "<".to_string(),
-            Guard::Geq(..) => ">=".to_string(),
-            Guard::Leq(..) => "<=".to_string(),
+            Guard::CompOp(op, _, _) => match op {
+                PortComp::Eq => "==".to_string(),
+                PortComp::Neq => "!=".to_string(),
+                PortComp::Gt => ">".to_string(),
+                PortComp::Lt => "<".to_string(),
+                PortComp::Geq => ">=".to_string(),
+                PortComp::Leq => "<=".to_string(),
+            },
             Guard::Not(..) => "!".to_string(),
             Guard::Port(..) | Guard::True => {
                 panic!("No operator string for Guard::Port")
@@ -204,7 +198,9 @@ impl Guard {
 
     pub fn eq(self, other: Guard) -> Self {
         match (self, other) {
-            (Guard::Port(l), Guard::Port(r)) => Guard::Eq(l, r),
+            (Guard::Port(l), Guard::Port(r)) => {
+                Guard::CompOp(PortComp::Eq, l, r)
+            }
             (l, r) => {
                 unreachable!("Cannot build Guard::Eq using {:?} and {:?}", l, r)
             }
@@ -213,7 +209,9 @@ impl Guard {
 
     pub fn neq(self, other: Guard) -> Self {
         match (self, other) {
-            (Guard::Port(l), Guard::Port(r)) => Guard::Neq(l, r),
+            (Guard::Port(l), Guard::Port(r)) => {
+                Guard::CompOp(PortComp::Neq, l, r)
+            }
             (l, r) => {
                 unreachable!(
                     "Cannot build Guard::Neq using {:?} and {:?}",
@@ -225,7 +223,9 @@ impl Guard {
 
     pub fn le(self, other: Guard) -> Self {
         match (self, other) {
-            (Guard::Port(l), Guard::Port(r)) => Guard::Leq(l, r),
+            (Guard::Port(l), Guard::Port(r)) => {
+                Guard::CompOp(PortComp::Leq, l, r)
+            }
             (l, r) => {
                 unreachable!(
                     "Cannot build Guard::Leq using {:?} and {:?}",
@@ -237,7 +237,9 @@ impl Guard {
 
     pub fn lt(self, other: Guard) -> Self {
         match (self, other) {
-            (Guard::Port(l), Guard::Port(r)) => Guard::Lt(l, r),
+            (Guard::Port(l), Guard::Port(r)) => {
+                Guard::CompOp(PortComp::Lt, l, r)
+            }
             (l, r) => {
                 unreachable!("Cannot build Guard::Lt using {:?} and {:?}", l, r)
             }
@@ -246,7 +248,9 @@ impl Guard {
 
     pub fn ge(self, other: Guard) -> Self {
         match (self, other) {
-            (Guard::Port(l), Guard::Port(r)) => Guard::Geq(l, r),
+            (Guard::Port(l), Guard::Port(r)) => {
+                Guard::CompOp(PortComp::Geq, l, r)
+            }
             (l, r) => {
                 unreachable!(
                     "Cannot build Guard::Geq using {:?} and {:?}",
@@ -258,7 +262,9 @@ impl Guard {
 
     pub fn gt(self, other: Guard) -> Self {
         match (self, other) {
-            (Guard::Port(l), Guard::Port(r)) => Guard::Gt(l, r),
+            (Guard::Port(l), Guard::Port(r)) => {
+                Guard::CompOp(PortComp::Gt, l, r)
+            }
             (l, r) => {
                 unreachable!("Cannot build Guard::Gt using {:?} and {:?}", l, r)
             }
@@ -278,12 +284,7 @@ impl PartialEq for Guard {
         match (self, other) {
             (Guard::Or(la, ra), Guard::Or(lb, rb))
             | (Guard::And(la, ra), Guard::And(lb, rb)) => la == lb && ra == rb,
-            (Guard::Eq(la, ra), Guard::Eq(lb, rb))
-            | (Guard::Neq(la, ra), Guard::Neq(lb, rb))
-            | (Guard::Gt(la, ra), Guard::Gt(lb, rb))
-            | (Guard::Lt(la, ra), Guard::Lt(lb, rb))
-            | (Guard::Geq(la, ra), Guard::Geq(lb, rb))
-            | (Guard::Leq(la, ra), Guard::Leq(lb, rb)) => {
+            (Guard::CompOp(opa, la, ra), Guard::CompOp(opb, lb, rb)) => {
                 (la.borrow().get_parent_name(), &la.borrow().name)
                     == (lb.borrow().get_parent_name(), &lb.borrow().name)
                     && (ra.borrow().get_parent_name(), &ra.borrow().name)
@@ -316,12 +317,7 @@ impl Ord for Guard {
         match (self, other) {
             (Guard::Or(..), Guard::Or(..))
             | (Guard::And(..), Guard::And(..))
-            | (Guard::Eq(..), Guard::Eq(..))
-            | (Guard::Neq(..), Guard::Neq(..))
-            | (Guard::Gt(..), Guard::Gt(..))
-            | (Guard::Lt(..), Guard::Lt(..))
-            | (Guard::Geq(..), Guard::Geq(..))
-            | (Guard::Leq(..), Guard::Leq(..))
+            | (Guard::CompOp(..), Guard::CompOp(..))
             | (Guard::Not(..), Guard::Not(..))
             | (Guard::Port(..), Guard::Port(..))
             | (Guard::True, Guard::True) => Ordering::Equal,
@@ -329,18 +325,18 @@ impl Ord for Guard {
             (_, Guard::Or(..)) => Ordering::Less,
             (Guard::And(..), _) => Ordering::Greater,
             (_, Guard::And(..)) => Ordering::Less,
-            (Guard::Leq(..), _) => Ordering::Greater,
-            (_, Guard::Leq(..)) => Ordering::Less,
-            (Guard::Geq(..), _) => Ordering::Greater,
-            (_, Guard::Geq(..)) => Ordering::Less,
-            (Guard::Lt(..), _) => Ordering::Greater,
-            (_, Guard::Lt(..)) => Ordering::Less,
-            (Guard::Gt(..), _) => Ordering::Greater,
-            (_, Guard::Gt(..)) => Ordering::Less,
-            (Guard::Eq(..), _) => Ordering::Greater,
-            (_, Guard::Eq(..)) => Ordering::Less,
-            (Guard::Neq(..), _) => Ordering::Greater,
-            (_, Guard::Neq(..)) => Ordering::Less,
+            (Guard::CompOp(PortComp::Leq, ..), _) => Ordering::Greater,
+            (_, Guard::CompOp(PortComp::Leq, ..)) => Ordering::Less,
+            (Guard::CompOp(PortComp::Geq, ..), _) => Ordering::Greater,
+            (_, Guard::CompOp(PortComp::Geq, ..)) => Ordering::Less,
+            (Guard::CompOp(PortComp::Lt, ..), _) => Ordering::Greater,
+            (_, Guard::CompOp(PortComp::Lt, ..)) => Ordering::Less,
+            (Guard::CompOp(PortComp::Gt, ..), _) => Ordering::Greater,
+            (_, Guard::CompOp(PortComp::Gt, ..)) => Ordering::Less,
+            (Guard::CompOp(PortComp::Eq, ..), _) => Ordering::Greater,
+            (_, Guard::CompOp(PortComp::Eq, ..)) => Ordering::Less,
+            (Guard::CompOp(PortComp::Neq, ..), _) => Ordering::Greater,
+            (_, Guard::CompOp(PortComp::Neq, ..)) => Ordering::Less,
             (Guard::Not(..), _) => Ordering::Greater,
             (_, Guard::Not(..)) => Ordering::Less,
             (Guard::Port(..), _) => Ordering::Greater,
@@ -384,12 +380,24 @@ impl Not for Guard {
 
     fn not(self) -> Self {
         match self {
-            Guard::Eq(lhs, rhs) => Guard::Neq(lhs, rhs),
-            Guard::Neq(lhs, rhs) => Guard::Eq(lhs, rhs),
-            Guard::Gt(lhs, rhs) => Guard::Leq(lhs, rhs),
-            Guard::Lt(lhs, rhs) => Guard::Geq(lhs, rhs),
-            Guard::Geq(lhs, rhs) => Guard::Lt(lhs, rhs),
-            Guard::Leq(lhs, rhs) => Guard::Gt(lhs, rhs),
+            Guard::CompOp(PortComp::Eq, lhs, rhs) => {
+                Guard::CompOp(PortComp::Neq, lhs, rhs)
+            }
+            Guard::CompOp(PortComp::Neq, lhs, rhs) => {
+                Guard::CompOp(PortComp::Eq, lhs, rhs)
+            }
+            Guard::CompOp(PortComp::Gt, lhs, rhs) => {
+                Guard::CompOp(PortComp::Leq, lhs, rhs)
+            }
+            Guard::CompOp(PortComp::Lt, lhs, rhs) => {
+                Guard::CompOp(PortComp::Geq, lhs, rhs)
+            }
+            Guard::CompOp(PortComp::Geq, lhs, rhs) => {
+                Guard::CompOp(PortComp::Lt, lhs, rhs)
+            }
+            Guard::CompOp(PortComp::Leq, lhs, rhs) => {
+                Guard::CompOp(PortComp::Gt, lhs, rhs)
+            }
             Guard::Not(expr) => *expr,
             _ => Guard::Not(Box::new(self)),
         }

--- a/calyx/src/ir/mod.rs
+++ b/calyx/src/ir/mod.rs
@@ -28,7 +28,7 @@ pub use common::{RRC, WRC};
 pub use component::{Component, IdList};
 pub use context::{BackendConf, Context, LibrarySignatures};
 pub use control::{Control, Empty, Enable, If, Invoke, Par, Seq, While};
-pub use guard::Guard;
+pub use guard::{Guard, PortComp};
 pub use id::Id;
 pub use primitives::{PortDef, Primitive, Width};
 pub use printer::Printer;

--- a/calyx/src/ir/printer.rs
+++ b/calyx/src/ir/printer.rs
@@ -448,12 +448,7 @@ impl Printer {
                 };
                 format!("{} {} {}", left, &guard.op_str(), right)
             }
-            ir::Guard::Eq(l, r)
-            | ir::Guard::Neq(l, r)
-            | ir::Guard::Gt(l, r)
-            | ir::Guard::Lt(l, r)
-            | ir::Guard::Geq(l, r)
-            | ir::Guard::Leq(l, r) => {
+            ir::Guard::CompOp(_, l, r) => {
                 format!(
                     "{} {} {}",
                     Self::get_port_access(&l.borrow()),

--- a/calyx/src/passes/lower_guards.rs
+++ b/calyx/src/passes/lower_guards.rs
@@ -23,12 +23,14 @@ fn guard_to_prim(guard: &ir::Guard) -> Option<String> {
     let var_name = match guard {
         ir::Guard::Or(..) => "or",
         ir::Guard::And(..) => "and",
-        ir::Guard::Eq(..) => "eq",
-        ir::Guard::Neq(..) => "neq",
-        ir::Guard::Gt(..) => "gt",
-        ir::Guard::Lt(..) => "lt",
-        ir::Guard::Geq(..) => "ge",
-        ir::Guard::Leq(..) => "le",
+        ir::Guard::CompOp(op, _, _) => match op {
+            ir::PortComp::Eq => "eq",
+            ir::PortComp::Neq => "neq",
+            ir::PortComp::Gt => "gt",
+            ir::PortComp::Lt => "lt",
+            ir::PortComp::Geq => "ge",
+            ir::PortComp::Leq => "le",
+        },
         ir::Guard::True | ir::Guard::Not(_) | ir::Guard::Port(_) => {
             return None;
         }
@@ -66,12 +68,7 @@ fn lower_guard(
             prim.get("out")
         }
 
-        ir::Guard::Eq(l, r)
-        | ir::Guard::Neq(l, r)
-        | ir::Guard::Gt(l, r)
-        | ir::Guard::Lt(l, r)
-        | ir::Guard::Geq(l, r)
-        | ir::Guard::Leq(l, r) => {
+        ir::Guard::CompOp(_, l, r) => {
             let prim = maybe_prim.unwrap();
             let prim_name = format!("std_{}", prim);
             let prim_cell =

--- a/calyx/src/passes/simplify_guards.rs
+++ b/calyx/src/passes/simplify_guards.rs
@@ -13,9 +13,10 @@ impl From<ir::Guard> for Expr<ir::Guard> {
             ir::Guard::Or(l, r) => Expr::or((*l).into(), (*r).into()),
             ir::Guard::Not(e) => Expr::not((*e).into()),
             ir::Guard::True => Expr::Const(true),
-            ir::Guard::Neq(l, r) => Expr::not(ir::Guard::Eq(l, r).into()),
-            ir::Guard::Leq(l, r) => Expr::not(ir::Guard::Gt(l, r).into()),
-            ir::Guard::Geq(l, r) => Expr::not(ir::Guard::Lt(l, r).into()),
+            ir::Guard::CompOp(
+                ir::PortComp::Neq | ir::PortComp::Leq | ir::PortComp::Geq,
+                ..,
+            ) => Expr::not((!guard).into()),
             _ => Expr::Terminal(guard),
         }
     }

--- a/interp/src/structures/environment.rs
+++ b/interp/src/structures/environment.rs
@@ -461,29 +461,17 @@ impl InterpreterState {
                 self.eval_guard(g1)? && self.eval_guard(g2)?
             }
             ir::Guard::Not(g) => !self.eval_guard(g)?,
-            ir::Guard::Eq(g1, g2) => {
-                self.get_from_port(&g1.borrow())
-                    == self.get_from_port(&g2.borrow())
-            }
-            ir::Guard::Neq(g1, g2) => {
-                self.get_from_port(&g1.borrow())
-                    != self.get_from_port(&g2.borrow())
-            }
-            ir::Guard::Gt(g1, g2) => {
-                self.get_from_port(&g1.borrow())
-                    > self.get_from_port(&g2.borrow())
-            }
-            ir::Guard::Lt(g1, g2) => {
-                self.get_from_port(&g1.borrow())
-                    < self.get_from_port(&g2.borrow())
-            }
-            ir::Guard::Geq(g1, g2) => {
-                self.get_from_port(&g1.borrow())
-                    >= self.get_from_port(&g2.borrow())
-            }
-            ir::Guard::Leq(g1, g2) => {
-                self.get_from_port(&g1.borrow())
-                    <= self.get_from_port(&g2.borrow())
+            ir::Guard::CompOp(op, g1, g2) => {
+                let p1 = self.get_from_port(&g1.borrow());
+                let p2 = self.get_from_port(&g2.borrow());
+                match op {
+                    ir::PortComp::Eq => p1 == p2,
+                    ir::PortComp::Neq => p1 != p2,
+                    ir::PortComp::Gt => p1 > p2,
+                    ir::PortComp::Lt => p1 < p2,
+                    ir::PortComp::Geq => p1 >= p2,
+                    ir::PortComp::Leq => p1 <= p2,
+                }
             }
             ir::Guard::Port(p) => {
                 let val = self.get_from_port(&p.borrow());


### PR DESCRIPTION
Unifies the various guard comparison variants like, `ir::Guard::Eq`, `ir::Guard::Leq`, into a single variant `ir::Guard::CompOp` which takes another enum `ir::PortComp` to describe which comparison to perform. Simplifies a bunch of code that often has to do the same thing for all the comparison operations anyways.
