### PR TITLE
[NFC] Refactor `analysis::ReadWriteSet`

### DIFF
--- a/calyx/src/analysis/read_write_set.rs
+++ b/calyx/src/analysis/read_write_set.rs
@@ -7,64 +7,59 @@ pub struct ReadWriteSet;
 
 impl ReadWriteSet {
     /// Returns [ir::Port] that are read from in the given Assignment.
-    pub fn port_reads(assign: &ir::Assignment) -> ir::PortIterator<'_> {
-        let iter = assign
+    pub fn port_reads(
+        assign: &ir::Assignment,
+    ) -> impl Iterator<Item = RRC<ir::Port>> + '_ {
+        assign
             .guard
             .all_ports()
             .into_iter()
             .chain(iter::once(Rc::clone(&assign.src)))
-            .filter(|port| !port.borrow().is_hole());
-        ir::PortIterator {
-            port_iter: Box::new(iter),
-        }
+            .filter(|port| !port.borrow().is_hole())
     }
 
     /// Returns [ir::Port] which are read from in the assignments.
-    pub fn port_read_set(assigns: &[ir::Assignment]) -> ir::PortIterator<'_> {
-        let iter = assigns.iter().flat_map(Self::port_reads);
-        ir::PortIterator {
-            port_iter: Box::new(iter),
-        }
+    pub fn port_read_set(
+        assigns: &[ir::Assignment],
+    ) -> impl Iterator<Item = RRC<ir::Port>> + '_ {
+        assigns.iter().flat_map(Self::port_reads)
     }
 
     /// Returns [ir::Port] which are written to in the assignments.
-    pub fn port_write_set(assigns: &[ir::Assignment]) -> ir::PortIterator<'_> {
-        let iter = assigns
+    pub fn port_write_set(
+        assigns: &[ir::Assignment],
+    ) -> impl Iterator<Item = RRC<ir::Port>> + '_ {
+        assigns
             .iter()
             .map(|assign| Rc::clone(&assign.dst))
-            .filter(|port| !port.borrow().is_hole());
-        ir::PortIterator {
-            port_iter: Box::new(iter),
-        }
+            .filter(|port| !port.borrow().is_hole())
     }
 
     /// Returns [ir::Cell] which are read from in the assignments.
     /// **Ignores** reads from group holes.
-    pub fn read_set(assigns: &[ir::Assignment]) -> ir::CellIterator<'_> {
-        let iter = Self::port_read_set(assigns)
+    pub fn read_set(
+        assigns: &[ir::Assignment],
+    ) -> impl Iterator<Item = RRC<ir::Cell>> + '_ {
+        Self::port_read_set(assigns)
             .map(|port| Rc::clone(&port.borrow().cell_parent()))
-            .unique_by(|cell| cell.clone_name());
-
-        ir::CellIterator {
-            iter: Box::new(iter),
-        }
+            .unique_by(|cell| cell.clone_name())
     }
 
     /// Returns [ir::Cell] which are written to by the assignments.
     /// **Ignores** reads from group holes.
-    pub fn write_set(assigns: &[ir::Assignment]) -> ir::CellIterator<'_> {
-        let iter = Self::port_write_set(assigns)
+    pub fn write_set(
+        assigns: &[ir::Assignment],
+    ) -> impl Iterator<Item = RRC<ir::Cell>> + '_ {
+        Self::port_write_set(assigns)
             .map(|port| Rc::clone(&port.borrow().cell_parent()))
-            .unique_by(|cell| cell.clone_name());
-
-        ir::CellIterator {
-            iter: Box::new(iter),
-        }
+            .unique_by(|cell| cell.clone_name())
     }
 
     /// Returns the register cells whose out port is read anywhere in the given
     /// assignments
-    pub fn register_reads(assigns: &[ir::Assignment]) -> ir::CellIterator<'_> {
+    pub fn register_reads(
+        assigns: &[ir::Assignment],
+    ) -> impl Iterator<Item = RRC<ir::Cell>> + '_ {
         fn is_register_out(port_ref: RRC<ir::Port>) -> Option<RRC<ir::Cell>> {
             let port = port_ref.borrow();
             if let ir::PortParent::Cell(cell_wref) = &port.parent {
@@ -81,7 +76,7 @@ impl ReadWriteSet {
                 .into_iter()
                 .filter_map(is_register_out)
         });
-        let iter = assigns
+        assigns
             .iter()
             .filter_map(|assign| is_register_out(Rc::clone(&assign.src)))
             .chain(guard_ports)
@@ -92,18 +87,16 @@ impl ReadWriteSet {
                     false
                 }
             })
-            .unique_by(|cell| cell.clone_name());
-
-        ir::CellIterator {
-            iter: Box::new(iter),
-        }
+            .unique_by(|cell| cell.clone_name())
     }
 
     /// Return the name of the cells that these assignments write to for writes
     /// that are guarded by true.
     /// **Ignores** writes to group holes.
-    pub fn must_write_set(assigns: &[ir::Assignment]) -> ir::CellIterator<'_> {
-        let iter = assigns
+    pub fn must_write_set(
+        assigns: &[ir::Assignment],
+    ) -> impl Iterator<Item = RRC<ir::Cell>> + '_ {
+        assigns
             .iter()
             .filter_map(|assignment| {
                 if let ir::Guard::True = *assignment.guard {
@@ -114,23 +107,17 @@ impl ReadWriteSet {
                 }
                 None
             })
-            .unique_by(|cell| cell.clone_name());
-
-        ir::CellIterator {
-            iter: Box::new(iter),
-        }
+            .unique_by(|cell| cell.clone_name())
     }
 
     /// Returns all uses of cells in this group. Uses constitute both reads and
     /// writes to cells.
-    pub fn uses(assigns: &[ir::Assignment]) -> ir::CellIterator<'_> {
+    pub fn uses(
+        assigns: &[ir::Assignment],
+    ) -> impl Iterator<Item = RRC<ir::Cell>> + '_ {
         let reads = Self::read_set(assigns);
-        let iter = reads
+        reads
             .chain(Self::write_set(assigns))
-            .unique_by(|cell| cell.clone_name());
-
-        ir::CellIterator {
-            iter: Box::new(iter),
-        }
+            .unique_by(|cell| cell.clone_name())
     }
 }

--- a/calyx/src/analysis/schedule_conflicts.rs
+++ b/calyx/src/analysis/schedule_conflicts.rs
@@ -14,18 +14,9 @@ pub struct ScheduleConflicts {
     rev_map: HashMap<Idx, ir::Id>,
 }
 
-/// Wrapper to iterate over all the conflict edges.
-pub struct ConflictIterator<'a> {
-    iter: Box<dyn Iterator<Item = (ir::Id, ir::Id)> + 'a>,
-}
-
-impl Iterator for ConflictIterator<'_> {
-    type Item = (ir::Id, ir::Id);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
-    }
-}
+/// A conflict between two group is specified using the name of the groups
+/// involved
+type Conflict = (ir::Id, ir::Id);
 
 impl ScheduleConflicts {
     /// Return a vector of all groups that conflict with this group.
@@ -40,18 +31,13 @@ impl ScheduleConflicts {
 
     /// Returns an iterator containing all conflict edges,
     /// `(src group: ir::Id, dst group: ir::Id)`, in this graph.
-    pub fn all_conflicts(&self) -> ConflictIterator<'_> {
-        let iter =
-            self.graph
-                .graph
-                .edge_references()
-                .map(move |(src, dst, _)| {
-                    (self.rev_map[&src].clone(), self.rev_map[&dst].clone())
-                });
-
-        ConflictIterator {
-            iter: Box::new(iter),
-        }
+    pub fn all_conflicts(&self) -> impl Iterator<Item = Conflict> + '_ {
+        self.graph
+            .graph
+            .edge_references()
+            .map(move |(src, dst, _)| {
+                (self.rev_map[&src].clone(), self.rev_map[&dst].clone())
+            })
     }
 
     /////////////// Internal Methods //////////////////

--- a/calyx/src/ir/context.rs
+++ b/calyx/src/ir/context.rs
@@ -15,19 +15,6 @@ pub struct LibrarySignatures {
     primitive_definitions: Vec<(PathBuf, LinkedHashMap<Id, Primitive>)>,
 }
 
-/// Iterator over primitive signatures defined in [LibrarySignatures].
-pub struct SigIter<'a> {
-    iter: Box<dyn Iterator<Item = &'a Primitive> + 'a>,
-}
-
-impl<'a> Iterator for SigIter<'a> {
-    type Item = &'a Primitive;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
-    }
-}
-
 impl LibrarySignatures {
     /// Return the [Primitive] associated with the given name if defined, otherwise return None.
     pub fn find_primitive<S>(&self, name: S) -> Option<&Primitive>
@@ -57,14 +44,10 @@ impl LibrarySignatures {
     }
 
     /// Return an iterator over all defined primitives.
-    pub fn signatures(&self) -> SigIter<'_> {
-        SigIter {
-            iter: Box::new(
-                self.primitive_definitions
-                    .iter()
-                    .flat_map(|(_, sig)| sig.values()),
-            ),
-        }
+    pub fn signatures(&self) -> impl Iterator<Item = &Primitive> + '_ {
+        self.primitive_definitions
+            .iter()
+            .flat_map(|(_, sig)| sig.values())
     }
 
     /// Return the underlying externs

--- a/calyx/src/ir/mod.rs
+++ b/calyx/src/ir/mod.rs
@@ -35,8 +35,8 @@ pub use printer::Printer;
 pub use reserved_names::RESERVED_NAMES;
 pub use rewriter::Rewriter;
 pub use structure::{
-    Assignment, Binding, Cell, CellIterator, CellType, CloneName, CombGroup,
-    Direction, GetName, Group, Port, PortIterator, PortParent,
+    Assignment, Binding, Cell, CellType, CloneName, CombGroup, Direction,
+    GetName, Group, Port, PortIterator, PortParent,
 };
 
 /// Visitor to traverse a control program.

--- a/calyx/src/ir/structure.rs
+++ b/calyx/src/ir/structure.rs
@@ -316,19 +316,6 @@ impl Cell {
     }
 }
 
-/// Generic wrapper for iterators that return [RRC] of [super::Cell].
-pub struct CellIterator<'a> {
-    pub iter: Box<dyn Iterator<Item = RRC<Cell>> + 'a>,
-}
-
-impl Iterator for CellIterator<'_> {
-    type Item = RRC<Cell>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
-    }
-}
-
 /// Represents a guarded assignment in the program
 #[derive(Clone, Debug)]
 pub struct Assignment {


### PR DESCRIPTION
Defines the `ReadWriteSet::port_reads` method and remove unnecessary uses of wrapped Iterators (`CellIterator` and `SigIter`). In general, iterators only need to be wrapped when the method may return multiple iterators in different branches. Otherwise, we should just return `impl Iterator` so that the compiler can inline the use of the Iterator.