### PR TITLE
Enable multi-driver checking in Icarus backend

### DIFF
--- a/fud/icarus/icarus.py
+++ b/fud/icarus/icarus.py
@@ -179,7 +179,7 @@ class FutilToIcarus(futil.FutilStage):
         super().__init__(
             config,
             "icarus-verilog",
-            "-b verilog --disable-verify --disable-init",
+            "-b verilog --disable-init",
             "Compile Calyx to Verilog instrumented for simulation",
         )
 

--- a/fud/icarus/tb.sv
+++ b/fud/icarus/tb.sv
@@ -22,14 +22,16 @@ string OUT;
 int NOTRACE;
 // Maximum number of cycles to simulate
 int CYCLE_LIMIT;
+// Dummy variable to track value returned by $value$plusargs
+int CODE;
 
 initial begin
-  $value$plusargs("OUT=%s", OUT);
-  $value$plusargs("CYCLE_LIMIT=%d", CYCLE_LIMIT);
+  CODE = $value$plusargs("OUT=%s", OUT);
+  CODE = $value$plusargs("CYCLE_LIMIT=%d", CYCLE_LIMIT);
   if (CYCLE_LIMIT != 0) begin
     $display("cycle limit set to %d", CYCLE_LIMIT);
   end
-  $value$plusargs("NOTRACE=%d", NOTRACE);
+  CODE = $value$plusargs("NOTRACE=%d", NOTRACE);
   if (NOTRACE == 0) begin
     $display("VCD tracing enabled");
     $dumpfile(OUT);

--- a/tests/backend/verilog/memory-with-external-attribute.expect
+++ b/tests/backend/verilog/memory-with-external-attribute.expect
@@ -371,8 +371,9 @@ module main (
     output logic done
 );
     string DATA;
+    int CODE;
     initial begin
-        $value$plusargs("DATA=%s", DATA);
+        CODE = $value$plusargs("DATA=%s", DATA);
         $display("DATA (path to meminit files): %s", DATA);
         $readmemh({DATA, "/m1.dat"}, m1.mem);
     end


### PR DESCRIPTION
Also fixes #769.

With the runtime error test, we get:
```
% fud e tests/errors/runtime/multiple-drivers.futil --to dat --through icarus-verilog
✖ icarus-verilog → dat
`/var/folders/2c/3km1m01x2dgf3x4d3vfmvsl80000gn/T/tmppg5f4m5z/main.vvp +DATA=/var/folders/2c/3km1m01x2dgf3x4d3vfmvsl80000gn/T/tmppg5f4m5z +CYCLE_LIMIT=500000000 +OUT=/var/folders/2c/3km1m01x2dgf3x4d3vfmvsl80000gn/T/tmppg5f4m5z/output.vcd +NOTRACE=1' failed:
=====STDERR=====

=====STDOUT=====
DATA (path to meminit files): /var/folders/2c/3km1m01x2dgf3x4d3vfmvsl80000gn/T/tmppg5f4m5z
cycle limit set to   500000000
VCD tracing disabled
FATAL: /var/folders/2c/3km1m01x2dgf3x4d3vfmvsl80000gn/T/tmphylbw8x5:484: Multiple assignment to port `fsm.in'.
       Time: 0 Scope: TOP.main
```
