### PR TITLE
[fud] Make SSH optional in Xilinx emulation stage

### DIFF
--- a/docs/fud/synthesis.md
+++ b/docs/fud/synthesis.md
@@ -97,6 +97,19 @@ By default, the Xilinx tools run in a temporary directory that is deleted when `
 To instead keep the sandbox directory, use `-s xclbin.save_temps true`.
 You can then find the results in a directory named `fud-out-N` for some number `N`.
 
+### Emulate
+
+You can also execute compiled designs through Xilinx hardware emulation.
+Use the `wdb` state as your `fud` target:
+
+    fud e -vv foo.xclbin -s wdb.save_temps true -o out.wdb
+
+This stage produces a Vivado [waveform database (WDB) file][wdb]
+Through the magic of `fud`, you can also go all the way from a Calyx program to a `wdb` file in the same way.
+
+You also need to provide a host C++ program via the `wdb.host` parameter, but I don't know much about that yet, so documentation about that will have to wait.
+Similarly, I don't yet know what you're supposed to *do* with a WDB file; maybe we should figure out how to produce a VCD instead.
+
 ### How it Works
 
 The first step is to generate input files.
@@ -131,3 +144,4 @@ This step uses the `v++` tool, with a command line that looks like this:
 [xclbin]: https://xilinx.github.io/XRT/2021.2/html/formats.html#xclbin
 [gen_xo]: https://github.com/cucapra/calyx/blob/master/fud/bitstream/gen_xo.tcl
 [u50]: https://www.xilinx.com/products/boards-and-kits/alveo/u50.html
+[wdb]: https://support.xilinx.com/s/article/64000?language=en_US

--- a/docs/fud/synthesis.md
+++ b/docs/fud/synthesis.md
@@ -83,6 +83,14 @@ The options for `mode` are `hw_emu` (simulation) and `hw` (on-FPGA execution).
 The device string above is for the [Alveo U50][u50] card, which we have at Cornell, but I honestly don't know how you're supposed to find the right string for a different FPGA target.
 Hopefully someone will figure this out and document it in the future.
 
+To use hardware emulation, you will also need to configure the `wdb` stage.
+It has similar `ssh_host`, `ssh_username`, and `remote` options to the `xclbin` stage.
+You will also need to configure the stage to point to your installations of [Vitis][] and [XRT][], like this:
+
+    [stages.wdb]
+    xilinx_location: /scratch/opt/Xilinx/Vitis/2020.2
+    xrt_location: /opt/xilinx/xrt
+
 ### Compile
 
 The first step in the Xilinx toolchain is to generate [an `xclbin` executable file][xclbin].
@@ -106,6 +114,7 @@ Use the `wdb` state as your `fud` target:
 
 This stage produces a Vivado [waveform database (WDB) file][wdb]
 Through the magic of `fud`, you can also go all the way from a Calyx program to a `wdb` file in the same way.
+There is also a `wdb.save_temps` option, as with the `xclbin` stage.
 
 You also need to provide a host C++ program via the `wdb.host` parameter, but I don't know much about that yet, so documentation about that will have to wait.
 Similarly, I don't yet know what you're supposed to *do* with a WDB file; maybe we should figure out how to produce a VCD instead.

--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -79,6 +79,7 @@ DEFAULT_CONFIGURATION = {
             "mode": "hw_emu",
             "ssh_host": "",
             "ssh_username": "",
+            "remote": None,
             "host": None,
             "save_temps": None,
             "xilinx_location": "/scratch/opt/Xilinx/Vitis/2020.2",

--- a/fud/fud/errors.py
+++ b/fud/fud/errors.py
@@ -68,10 +68,9 @@ class MissingDynamicConfiguration(FudError):
 
     def __init__(self, variable):
         msg = (
-            "Provide an input file or "
-            + f"`{variable}' needs to be set. "
+            f"`{variable}' needs to be set. "
             + "Use the runtime configuration flag to provide a value: "
-            + "'-s {variable} <value>'."
+            + f"'-s {variable} <value>'."
         )
         super().__init__(msg)
 

--- a/fud/fud/stages/remote_context.py
+++ b/fud/fud/stages/remote_context.py
@@ -1,7 +1,9 @@
 import logging as log
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+import shutil
 
+from fud.utils import TmpDir, FreshDir
 from .. import errors
 from ..stages import Source, SourceType
 
@@ -150,8 +152,7 @@ class RemoteExecution:
             remote_tmpdir: SourceType.String,
             local_tmpdir: SourceType.Directory,
         ):
-            """
-            Copy files generated on server back to local host.
+            """Copy files generated on server back to local host.
             """
             with self.SCPClient(client.get_transport()) as scp:
                 scp.get(
@@ -183,3 +184,65 @@ class RemoteExecution:
         local_path = fetch_file(client, remote_tmpdir)
         self._close(client, remote_tmpdir, keep_tmpdir=keep_tmpdir)
         return local_path
+
+
+class LocalSandbox:
+    """A utility for running commands in a temporary directory.
+
+    This is meant as a local alternative to `RemoteExecution`. Like that
+    utility, this provides steps to create a temporary directory,
+    execute programs in that temporary directory, and then retrieve
+    files from it. However, all this happens locally instead of via SSH.
+    """
+
+    def __init__(self, stage, save_temps=False):
+        self.stage = stage
+        self.save_temps = save_temps
+
+    def create(self, input_files):
+        """Copy input files to a fresh temporary directory.
+
+        `input_files` is a dict with the same format as `open_and_send`:
+        it maps local Source paths to destination strings.
+
+        Return a path to the newly-created temporary directory.
+        """
+
+        @self.stage.step()
+        def copy_file(
+            tmpdir: SourceType.String,
+            src_path: SourceType.Path,
+            dest_path: SourceType.String,
+        ):
+            """Copy an input file."""
+            shutil.copyfile(src_path, Path(tmpdir) / dest_path)
+
+        tmpdir = Source(
+            FreshDir() if self.save_temps else TmpDir(),
+            SourceType.Directory,
+        )
+        for src_path, dest_path in input_files.items():
+            if not isinstance(src_path, Source):
+                src_path = Source(src_path, SourceType.Path)
+            if not isinstance(dest_path, Source):
+                dest_path = Source(dest_path, SourceType.String)
+            copy_file(tmpdir, src_path, dest_path)
+
+        self.tmpdir = tmpdir
+        return tmpdir
+
+    def get_file(self, name):
+        """Retrieve a file from the sandbox directory."""
+
+        @self.stage.step()
+        def read_file(
+            tmpdir: SourceType.Directory,
+            name: SourceType.String,
+        ) -> SourceType.Path:
+            """Read an output file."""
+            return Path(tmpdir.name) / name
+
+        return read_file(
+            self.tmpdir,
+            Source(name, SourceType.String),
+        )

--- a/fud/fud/stages/remote_context.py
+++ b/fud/fud/stages/remote_context.py
@@ -152,8 +152,7 @@ class RemoteExecution:
             remote_tmpdir: SourceType.String,
             local_tmpdir: SourceType.Directory,
         ):
-            """Copy files generated on server back to local host.
-            """
+            """Copy files generated on server back to local host."""
             with self.SCPClient(client.get_transport()) as scp:
                 scp.get(
                     remote_tmpdir, local_path=f"{local_tmpdir.name}", recursive=True

--- a/fud/fud/stages/xilinx/emulation.py
+++ b/fud/fud/stages/xilinx/emulation.py
@@ -191,4 +191,4 @@ class HwEmulationStage(Stage):
                 keep=self.save_temps,
             )
         else:
-            return sandbox.get_file(tmpdir, wdb_name)
+            return sandbox.get_file(wdb_name)

--- a/fud/fud/stages/xilinx/emulation.py
+++ b/fud/fud/stages/xilinx/emulation.py
@@ -141,7 +141,7 @@ class HwEmulationStage(Stage):
                 client,
                 tmpdir,
                 wdb_name,
-                keep=self.save_temps,
+                keep_tmpdir=self.save_temps,
             )
         else:
             return sandbox.get_file(wdb_name)

--- a/fud/fud/stages/xilinx/xclbin.py
+++ b/fud/fud/stages/xilinx/xclbin.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from fud.stages import Source, SourceType, Stage
 from fud.stages.remote_context import RemoteExecution, LocalSandbox
 from fud.stages.futil import FutilStage
-from fud.utils import TmpDir, shell
+from fud.utils import shell
 
 
 class XilinxStage(Stage):
@@ -61,14 +61,6 @@ class XilinxStage(Stage):
             log.debug(stdout)
 
     def _define_steps(self, input_data):
-        # Step 1: Make a new temporary directory
-        @self.step()
-        def mktmp() -> SourceType.Directory:
-            """
-            Make temporary directory to store generated files.
-            """
-            return TmpDir()
-
         # Step 2: Compile input using `-b xilinx`
         @self.step()
         def compile_xilinx(inp: SourceType.Stream) -> SourceType.Path:

--- a/fud/fud/stages/xilinx/xclbin.py
+++ b/fud/fud/stages/xilinx/xclbin.py
@@ -1,11 +1,10 @@
 import logging as log
 from pathlib import Path
-import shutil
 
 from fud.stages import Source, SourceType, Stage
-from fud.stages.remote_context import RemoteExecution
+from fud.stages.remote_context import RemoteExecution, LocalSandbox
 from fud.stages.futil import FutilStage
-from fud.utils import TmpDir, FreshDir, shell
+from fud.utils import TmpDir, shell
 
 
 class XilinxStage(Stage):
@@ -60,36 +59,6 @@ class XilinxStage(Stage):
         else:
             stdout = shell(cmd, capture_stdout=False)
             log.debug(stdout)
-
-    def _sandbox(self, input_files):
-        """Copy input files to a fresh temporary directory.
-
-        `input_files` is a dict with the same format as `open_and_send`:
-        it maps local Source paths to destination strings.
-
-        Return a path to the newly-created temporary directory.
-        """
-
-        @self.step()
-        def copy_file(
-            tmpdir: SourceType.String,
-            src_path: SourceType.Path,
-            dest_path: SourceType.String,
-        ):
-            """Copy an input file."""
-            shutil.copyfile(src_path, Path(tmpdir) / dest_path)
-
-        tmpdir = Source(
-            FreshDir() if self.save_temps else TmpDir(),
-            SourceType.Directory,
-        )
-        for src_path, dest_path in input_files.items():
-            if not isinstance(src_path, Source):
-                src_path = Source(src_path, SourceType.Path)
-            if not isinstance(dest_path, Source):
-                dest_path = Source(dest_path, SourceType.String)
-            copy_file(tmpdir, src_path, dest_path)
-        return tmpdir
 
     def _define_steps(self, input_data):
         # Step 1: Make a new temporary directory
@@ -176,14 +145,6 @@ class XilinxStage(Stage):
             )
             self._shell(client, cmd)
 
-        @self.step()
-        def read_file(
-            tmpdir: SourceType.Directory,
-            name: SourceType.String,
-        ) -> SourceType.Path:
-            """Read an output file."""
-            return Path(tmpdir.name) / name
-
         if self.remote_exec.use_ssh:
             self.remote_exec.import_libs()
 
@@ -200,7 +161,8 @@ class XilinxStage(Stage):
         if self.remote_exec.use_ssh:
             client, tmpdir = self.remote_exec.open_and_send(file_map)
         else:
-            tmpdir = self._sandbox(file_map)
+            sandbox = LocalSandbox(self, self.save_temps)
+            tmpdir = sandbox.create(file_map)
             client = Source(None, SourceType.UnTyped)
 
         package_xo(client, tmpdir)
@@ -214,7 +176,4 @@ class XilinxStage(Stage):
                 keep_tmpdir=self.save_temps,
             )
         else:
-            return read_file(
-                tmpdir,
-                Source("xclbin/kernel.xclbin", SourceType.String),
-            )
+            return sandbox.get_file("xclbin/kernel.xclbin")


### PR DESCRIPTION
This is one more smaller-scale PR that depends on on #850 and #851 (and should not be reviewed until those are merged).

The gist is basically the same thing as #850, but for the fud stage in `emulation.py`. This is the stage that compiles a host C++ program as a testbench to run the compiled emulation "bitstream" from the `xclbin` stage. It previously also required SSH and did so with copied-n-pasted SSH functionality; this does even more refactoring to our SSH utilities to make them generic enough to cover this stage as well. I also added a `LocalSandbox` utility that both stages can share to make it easy to run identical functionality either locally or remotely, depending on the configuration.

This also extends the documentation to describe how to use this new emulation stage. Unfortunately, I'm still missing a big piece of the puzzle: how to write that aforementioned host C++ program. As will become clear in future issues/PRs, however, I think we should probably not bother trying to address this stage and instead switch to the PyOpenCL-based alternative in `execution.py`.