### PR TITLE
[fud] Simplify & document .xo production

### DIFF
--- a/docs/fud/synthesis.md
+++ b/docs/fud/synthesis.md
@@ -128,19 +128,53 @@ We need to generate:
 * A Verilog interface wrapper, using `XilinxInterfaceBackend`, via `-b xilinx`. We call this `toplevel.v`.
 * An XML document describing the interface, using `XilinxXmlBackend`, via `-b xilinx-xml`. This file gets named `kernel.xml`.
 
-We also use [a static Tcl script, `gen_xo.tcl`,][gen_xo] to drive the Xilinx tools.
 The `fud` driver gathers these files together in a sandbox directory.
-Then, the Xilinx toolchain's first step is to compile the Verilog to a `.xo` file, which is a Xilinx analog of a `.o` object file.
+The next step is to run the Xilinx tools.
+
+#### Background: `.xo` and `.xclbin`
+
+In the Xilinx toolchain, compilation to an executable bitstream (or simulation blob) appears to requires two steps:
+taking your Verilog sources and creating an `.xo` file, and then taking that and producing an `.xclbin` “executable” file.
+The idea appears to be a kind of metaphor for a standard C compilation workflow in software-land: `.xo` is like a `.o` object file, and `.xclbin` contains actual executable code (bitstream or emulation equivalent), like a software executable binary.
+Going from Verilog to `.xo` is like “compilation” and going from `.xo` to `.xclbin` is like “linking.”
+
+However,  this analogy is kind of a lie.
+Generating an `.xo` file actually does very little work:
+it just packages up the Verilog source code and some auxiliary files.
+An `.xo` is literally a zip file with that stuff packed up inside.
+All the actual work happens during “linking,” i.e., going from `.xo` to `.xclbin` using the `v++` tool.
+This situation is a poignant reminder of how impossible separate compilation is in the EDA world.
+A proper analogy would involve separately compiling the Verilog into some kind of low-level representation, and then linking would properly smash together those separately-compiled objects.
+Instead, in Xilinx-land, “compilation” is just simple bundling and “linking” does all the compilation in one monolithic step.
+It’s kind of cute that the Xilinx toolchain is pretending the world is otherwise, but it’s also kind of sad.
+
+Anyway, the only way to produce a `.xo` file from RTL code appears to be to use Vivado (i.e., the actual `vivado` program).
+Nothing from the newer Vitis package currently appears capable of producing `.xo` files from Verilog (although `v++` can produce these files during HLS compilation, presumably by invoking Vivado).
+
+The main components in an `.xo` file, aside from the Verilog source code itself, are two XML files:
+`kernel.xml`, a short file describing the argument interfaces to the hardware design,
+and `component.xml`, a much longer and more complicated [IP-XACT][] file that also has to do with the interface to the RTL.
+We currently generate `kernel.xml` ourselves (with the `xilinx-xml` backend described above) and then use Vivado, via a Tcl script, to generate the IP-XACT file.
+
+In the future, we could consider trying to route around using Vivado by generating the IP-XACT file ourselves, using a tool such as [DUH][].
+
+#### Our Workflow
+
+The first step is to produce an `.xo` file.
+We also use [a static Tcl script, `gen_xo.tcl`,][gen_xo] which is a simplified version of [a script from Xilinx's Vitis tutorials][package_kernel].
+The gist of this script is that it creates a Vivado project, adds the source files, twiddles some settings, and then uses the [`package_xo` command][package_xo] to read stuff from this project as an "IP directory" and produce an `.xo` file.
 The Vivado command line looks roughly like this:
 
-    vivado -mode batch -source gen_xo.tcl -tclargs xclbin/kernel.xo kernel hw_emu xilinx_u50_gen3x16_xdma_201920_3
+    vivado -mode batch -source gen_xo.tcl -tclargs xclbin/kernel.xo
 
-Those arguments after `-tclargs`, unsurprisingly, get passed to [`gen_xo.tcl`][gen_xo].
+That output filename after `-tclargs`, unsurprisingly, gets passed to [`gen_xo.tcl`][gen_xo].
 
-Then, we take this `.xo` and turn it into an [`.xclbin`][xclbin], in a step that is Xilinx's analog of "linking" an executable.
+Then, we take this `.xo` and turn it into an [`.xclbin`][xclbin].
 This step uses the `v++` tool, with a command line that looks like this:
 
     v++ -g -t hw_emu --platform xilinx_u50_gen3x16_xdma_201920_3 --save-temps --profile.data all:all:all --profile.exec all:all:all -lo xclbin/kernel.xclbin xclbin/kernel.xo
+
+Fortunately, the `v++` tool doesn't need any Tcl to drive it; all the action happens on the command line.
 
 [vivado]: https://www.xilinx.com/products/design-tools/vivado.html
 [vhls]: https://www.xilinx.com/products/design-tools/vivado/integration/esl-design.html
@@ -154,3 +188,7 @@ This step uses the `v++` tool, with a command line that looks like this:
 [gen_xo]: https://github.com/cucapra/calyx/blob/master/fud/bitstream/gen_xo.tcl
 [u50]: https://www.xilinx.com/products/boards-and-kits/alveo/u50.html
 [wdb]: https://support.xilinx.com/s/article/64000?language=en_US
+[ip-xact]: https://en.wikipedia.org/wiki/IP-XACT
+[duh]: https://github.com/sifive/duh
+[package_kernel]: https://github.com/Xilinx/Vitis-Tutorials/blob/2021.1/Hardware_Acceleration/Feature_Tutorials/01-rtl_kernel_workflow/reference-files/scripts/package_kernel.tcl
+[package_xo]: https://docs.xilinx.com/r/en-US/ug1393-vitis-application-acceleration/package_xo-Command

--- a/fud/bitstream/gen_xo.tcl
+++ b/fud/bitstream/gen_xo.tcl
@@ -1,82 +1,33 @@
-# /*******************************************************************************
-# Copyright (c) 2018, Xilinx, Inc.
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without modification,
-# are permitted provided that the following conditions are met:
-# 
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 
-# 
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-# 
-# 
-# 3. Neither the name of the copyright holder nor the names of its contributors
-# may be used to endorse or promote products derived from this software
-# without specific prior written permission.
-# 
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,THE IMPLIED 
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY 
-# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
-# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-# *******************************************************************************/
-
-if { $::argc != 4 } {
-    puts "ERROR: Program \"$::argv0\" requires 4 arguments!\n"
-    puts "Usage: $::argv0 <xoname> <krnl_name> <target> <device>\n"
+if { $::argc != 1 } {
+    puts "ERROR: Program \"$::argv0\" requires 1 argument!\n"
+    puts "Usage: $::argv0 <xoname>\n"
     exit
 }
 
-set xoname    [lindex $::argv 0]
-set krnl_name [lindex $::argv 1]
-set target    [lindex $::argv 2]
-set device    [lindex $::argv 3]
+set xoname [lindex $::argv 0]
+set path_to_packaged "./packaged_kernel"
 
-set suffix "${krnl_name}_${target}_${device}"
+# Make a temporary Vivado project.
+create_project -force kernel_pack "./tmp_kernel_pack"
 
-set path_to_hdl "."
-set path_to_packaged "./packaged_kernel_${suffix}"
-set path_to_tmp_project "./tmp_kernel_pack_${suffix}"
+# Add all Verilog files in the current working directory.
+add_files -norecurse [glob *.v *.sv]
 
-create_project -force kernel_pack $path_to_tmp_project
-add_files -norecurse [glob $path_to_hdl/*.v $path_to_hdl/*.sv]
-update_compile_order -fileset sources_1
-update_compile_order -fileset sim_1
+# I don't really understand any of this.
 ipx::package_project -root_dir $path_to_packaged -vendor capra.cs.cornell.edu -library RTLKernel -taxonomy /KernelIP -import_files -set_current false
 ipx::unload_core $path_to_packaged/component.xml
 ipx::edit_ip_in_project -upgrade true -name tmp_edit_project -directory $path_to_packaged $path_to_packaged/component.xml
-set_property core_revision 2 [ipx::current_core]
-foreach up [ipx::get_user_parameters] {
-  ipx::remove_user_parameter [get_property NAME $up] [ipx::current_core]
-}
 set_property sdx_kernel true [ipx::current_core]
 set_property sdx_kernel_type rtl [ipx::current_core]
-ipx::create_xgui_files [ipx::current_core]
-# ipx::associate_bus_interfaces -busif m01_axi -clock ap_clk [ipx::current_core]
+
+# Declare bus interfaces.
 ipx::associate_bus_interfaces -busif s_axi_control -clock ap_clk [ipx::current_core]
 ipx::associate_bus_interfaces -busif m0_axi -clock ap_clk [ipx::current_core]
 
-set_property xpm_libraries {XPM_CDC XPM_MEMORY} [ipx::current_core]
-set_property supported_families { } [ipx::current_core]
-set_property auto_family_support_level level_2 [ipx::current_core]
+# Close & save the temporary project.
 ipx::update_checksums [ipx::current_core]
 ipx::save_core [ipx::current_core]
-close_project
-# -delete
+close_project -delete
 
-if {[file exists "${xoname}"]} {
-    file delete -force "${xoname}"
-}
-
-package_xo -xo_path ${xoname} -kernel_name Toplevel -ip_directory ./packaged_kernel_${suffix} -kernel_xml ./kernel.xml
+# Package the project as an .xo file.
+package_xo -xo_path ${xoname} -kernel_name Toplevel -ip_directory ${path_to_packaged} -kernel_xml ./kernel.xml

--- a/fud/fud/stages/xilinx/xclbin.py
+++ b/fud/fud/stages/xilinx/xclbin.py
@@ -102,17 +102,13 @@ class XilinxStage(Stage):
             """
             Package verilog into XO file.
             """
-            cmd = " ".join(
-                [
-                    f"cd {tmpdir}",
-                    "&&",
-                    "mkdir -p xclbin",
-                    "&&",
-                    "/scratch/opt/Xilinx/Vivado/2020.2/bin/vivado",
-                    "-mode batch",
-                    "-source gen_xo.tcl",
-                    f"-tclargs xclbin/kernel.xo kernel {self.mode} {self.device}",
-                ]
+            cmd = (
+                f"cd {tmpdir} && "
+                "mkdir -p xclbin && "
+                "/scratch/opt/Xilinx/Vivado/2020.2/bin/vivado "
+                "-mode batch "
+                "-source gen_xo.tcl "
+                f"-tclargs xclbin/kernel.xo kernel {self.mode} {self.device}"
             )
             self._shell(client, cmd)
 
@@ -121,19 +117,16 @@ class XilinxStage(Stage):
             """
             Compile XO into xclbin.
             """
-            cmd = " ".join(
-                [
-                    f"cd {tmpdir}",
-                    "&&",
-                    "/scratch/opt/Xilinx/Vitis/2020.2/bin/v++ -g",
-                    f"-t {self.mode}",
-                    f"--platform {self.device}",
-                    "--save-temps",
-                    "--profile.data all:all:all",
-                    "--profile.exec all:all:all",
-                    "-lo xclbin/kernel.xclbin",
-                    "xclbin/kernel.xo",
-                ]
+            cmd = (
+                f"cd {tmpdir} && "
+                "/scratch/opt/Xilinx/Vitis/2020.2/bin/v++ -g "
+                f"-t {self.mode} "
+                f"--platform {self.device} "
+                "--save-temps "
+                "--profile.data all:all:all "
+                "--profile.exec all:all:all "
+                "-lo xclbin/kernel.xclbin "
+                "xclbin/kernel.xo"
             )
             self._shell(client, cmd)
 

--- a/fud/fud/stages/xilinx/xclbin.py
+++ b/fud/fud/stages/xilinx/xclbin.py
@@ -108,7 +108,7 @@ class XilinxStage(Stage):
                 "/scratch/opt/Xilinx/Vivado/2020.2/bin/vivado "
                 "-mode batch "
                 "-source gen_xo.tcl "
-                f"-tclargs xclbin/kernel.xo kernel {self.mode} {self.device}"
+                f"-tclargs xclbin/kernel.xo"
             )
             self._shell(client, cmd)
 


### PR DESCRIPTION
The first step in using the Xilinx toolchain is to package our Verilog code in a format called `.xo`. Vivado (via Tcl) appears to be the only way to do this. We have a script, `gen_xo.tcl`, that is derived from the Xilinx tutorial examples that does this packaging.

In an effort to understand what is actually going on, I tried simplifying and commenting this file. I tried to delete anything that looked unnecessary while confirming experimentally that this didn't break anything. This is a painful process, however, because running the compiler takes 5-6 minutes per execution. So there may still yet be unnecessary steps in this Tcl file. (Continuing to delete stuff could be a "fun" project for anyone who's interested, such as @yn224.)

I also wrote a narrative description of how I believe everything works in the docs. One interesting insight to call out, for instance, is that it may theoretically be possible to generate the ingredients for `.xo` *without* Vivado using a tool such as [SiFive's DUH](https://github.com/sifive/duh) and its [IP-XACT backend](https://github.com/sifive/duh-ipxact).