### PR TITLE
Discover states instead of stages using filenames

### DIFF
--- a/fud/fud/errors.py
+++ b/fud/fud/errors.py
@@ -36,13 +36,8 @@ class UnknownExtension(FudError):
     Thrown when the implicit stage discovery mechanism fails.
     """
 
-    def __init__(self, filename):
-        path = Path(filename)
-        ext = path.suffix
-        super().__init__(
-            f"`{ext}' does not correspond to any known stage. "
-            + "Please provide an explicit stage using --to or --from."
-        )
+    def __init__(self, msg, filename):
+        super().__init__(msg + "Please provide an explicit stage using --to or --from.")
 
 
 class UnsetConfiguration(FudError):
@@ -255,7 +250,6 @@ class FudRegisterError(FudError):
     An error raised when an external stage is not valid.
     """
 
-    def __init__(self, msg, stage_name=None):
-        name = f" `{stage_name}'" if stage_name is not None else ""
-        msg = f"""Failed to register`{name}': {msg}"""
+    def __init__(self, conf, msg):
+        msg = f"""Failed to register `{conf}': {msg}"""
         super().__init__(msg)

--- a/fud/fud/errors.py
+++ b/fud/fud/errors.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-
-
 class FudError(Exception):
     """
     An error caught by the Calyx Driver.

--- a/fud/fud/errors.py
+++ b/fud/fud/errors.py
@@ -92,8 +92,9 @@ class UndefinedStage(FudError):
     No stage with the defined name.
     """
 
-    def __init__(self, stage):
-        msg = f"No stage named {stage}"
+    def __init__(self, stage, ctx=None):
+        more = "" if ctx is None else f" .Context: {ctx}"
+        msg = f"No stage named {stage}{more}"
         super().__init__(msg)
 
 

--- a/fud/fud/registry.py
+++ b/fud/fud/registry.py
@@ -16,6 +16,17 @@ class Registry:
         self.config = config
         self.graph = nx.DiGraph()
 
+    def get_states(self, stage):
+        """
+        Returns the pairs of input and output states that the given stage
+        operates upon.
+        """
+        out = [
+            (s, e) for (s, e, st) in self.graph.edges(data="stage") if st.name == stage
+        ]
+        assert len(out) > 0, f"No state tranformation for {stage} found."
+        return out
+
     def register(self, stage):
         """
         Defines a new stage named `stage` that converts programs from `src` to

--- a/fud/fud/registry.py
+++ b/fud/fud/registry.py
@@ -45,10 +45,10 @@ class Registry:
 
         nodes = self.graph.nodes()
         if start not in nodes:
-            raise UndefinedStage(start)
+            raise UndefinedStage(start, "Validate source state of the path")
 
         if dest not in nodes:
-            raise UndefinedStage(dest)
+            raise UndefinedStage(dest, "Validate target state of the path")
 
         all_paths = list(nx.all_simple_edge_paths(self.graph, start, dest))
 


### PR DESCRIPTION
A bandage solution to the problem in https://github.com/cucapra/calyx/issues/867. Assumes that the file discovery stuff is defined in stage configuration and uses the registry to find the states that the given may generate. The logic is gnarly which is sad.
