### PR TITLE
Combinational Propagation pass

### DIFF
--- a/calyx/src/default_passes.rs
+++ b/calyx/src/default_passes.rs
@@ -1,12 +1,12 @@
 //! Defines the default passes available to [PassManager].
 use crate::passes::{
-    Canonicalize, ClkInsertion, CollapseControl, CompileEmpty, CompileInvoke,
-    ComponentInliner, ComponentInterface, DeadCellRemoval, DeadGroupRemoval,
-    Externalize, GoInsertion, GroupToInvoke, HoleInliner, InferStaticTiming,
-    LowerGuards, MergeAssign, MinimizeRegs, Papercut, ParToSeq,
-    RegisterUnsharing, RemoveCombGroups, ResetInsertion, ResourceSharing,
-    SimplifyGuards, SynthesisPapercut, TopDownCompileControl, WellFormed,
-    WireInliner,
+    Canonicalize, ClkInsertion, CollapseControl, CombProp, CompileEmpty,
+    CompileInvoke, ComponentInliner, ComponentInterface, DeadCellRemoval,
+    DeadGroupRemoval, Externalize, GoInsertion, GroupToInvoke, HoleInliner,
+    InferStaticTiming, LowerGuards, MergeAssign, MinimizeRegs, Papercut,
+    ParToSeq, RegisterUnsharing, RemoveCombGroups, ResetInsertion,
+    ResourceSharing, SimplifyGuards, SynthesisPapercut, TopDownCompileControl,
+    WellFormed, WireInliner,
 };
 use crate::{
     errors::CalyxResult, ir::traversal::Named, pass_manager::PassManager,
@@ -41,6 +41,7 @@ impl PassManager {
         pm.register_pass::<InferStaticTiming>()?;
         pm.register_pass::<SimplifyGuards>()?;
         pm.register_pass::<MergeAssign>()?;
+        pm.register_pass::<CombProp>()?;
         pm.register_pass::<TopDownCompileControl>()?;
         // pm.register_pass::<TopDownStaticTiming>()?;
         pm.register_pass::<SynthesisPapercut>()?;

--- a/calyx/src/default_passes.rs
+++ b/calyx/src/default_passes.rs
@@ -18,39 +18,46 @@ impl PassManager {
         // Construct the pass manager and register all passes.
         let mut pm = PassManager::default();
 
-        // Register passes.
+        // Validation passes
         pm.register_pass::<WellFormed>()?;
-        // pm.register_pass::<StaticTiming>()?;
-        // pm.register_pass::<CompileControl>()?;
-        pm.register_pass::<CompileInvoke>()?;
+        pm.register_pass::<Papercut>()?;
+        pm.register_pass::<Canonicalize>()?;
+
+        // Optimization passes
+        pm.register_pass::<CombProp>()?;
         pm.register_pass::<ComponentInliner>()?;
-        pm.register_pass::<GoInsertion>()?;
-        pm.register_pass::<ComponentInterface>()?;
-        pm.register_pass::<WireInliner>()?;
-        pm.register_pass::<HoleInliner>()?;
-        pm.register_pass::<Externalize>()?;
         pm.register_pass::<CollapseControl>()?;
         pm.register_pass::<CompileEmpty>()?;
-        pm.register_pass::<Papercut>()?;
-        pm.register_pass::<ClkInsertion>()?;
-        pm.register_pass::<ResetInsertion>()?;
         pm.register_pass::<ResourceSharing>()?;
         pm.register_pass::<DeadCellRemoval>()?;
-        pm.register_pass::<DeadGroupRemoval>()?;
         pm.register_pass::<MinimizeRegs>()?;
         pm.register_pass::<InferStaticTiming>()?;
-        pm.register_pass::<SimplifyGuards>()?;
-        pm.register_pass::<MergeAssign>()?;
-        pm.register_pass::<CombProp>()?;
-        pm.register_pass::<TopDownCompileControl>()?;
-        // pm.register_pass::<TopDownStaticTiming>()?;
-        pm.register_pass::<SynthesisPapercut>()?;
-        pm.register_pass::<RegisterUnsharing>()?;
-        pm.register_pass::<Canonicalize>()?;
-        pm.register_pass::<LowerGuards>()?;
-        pm.register_pass::<ParToSeq>()?;
+
+        // Compilation passes
+        pm.register_pass::<CompileInvoke>()?;
         pm.register_pass::<RemoveCombGroups>()?;
+        pm.register_pass::<TopDownCompileControl>()?;
+
+        // Lowering passes
+        pm.register_pass::<GoInsertion>()?;
+        pm.register_pass::<ComponentInterface>()?;
+        pm.register_pass::<HoleInliner>()?;
+        pm.register_pass::<ClkInsertion>()?;
+        pm.register_pass::<ResetInsertion>()?;
+        pm.register_pass::<MergeAssign>()?;
+
+        // Enabled in the synthesis compilation flow
+        pm.register_pass::<SynthesisPapercut>()?;
+        pm.register_pass::<Externalize>()?;
+
+        // Disabled by default
+        pm.register_pass::<DeadGroupRemoval>()?;
+        pm.register_pass::<SimplifyGuards>()?;
+        pm.register_pass::<RegisterUnsharing>()?;
         pm.register_pass::<GroupToInvoke>()?;
+        pm.register_pass::<ParToSeq>()?;
+        pm.register_pass::<LowerGuards>()?;
+        pm.register_pass::<WireInliner>()?;
 
         register_alias!(pm, "validate", [WellFormed, Papercut, Canonicalize]);
         register_alias!(
@@ -58,6 +65,7 @@ impl PassManager {
             "pre-opt",
             [
                 ComponentInliner,
+                CombProp,
                 RemoveCombGroups, // Must run before `infer-static-timing`.
                 InferStaticTiming,
                 CollapseControl,
@@ -68,14 +76,13 @@ impl PassManager {
         register_alias!(
             pm,
             "compile",
-            [
-                CompileInvoke,
-                CompileEmpty,
-                // StaticTiming,
-                TopDownCompileControl
-            ]
+            [CompileInvoke, CompileEmpty, TopDownCompileControl]
         );
-        register_alias!(pm, "post-opt", [DeadCellRemoval]);
+        register_alias!(
+            pm,
+            "post-opt",
+            [DeadGroupRemoval, DeadCellRemoval, CombProp]
+        );
         register_alias!(
             pm,
             "lower",
@@ -89,7 +96,7 @@ impl PassManager {
             ]
         );
 
-        // Register aliases
+        // Default flow
         register_alias!(
             pm,
             "all",

--- a/calyx/src/ir/structure.rs
+++ b/calyx/src/ir/structure.rs
@@ -220,6 +220,20 @@ impl Cell {
         matches!(&self.prototype, CellType::Component { .. })
     }
 
+    /// Returns true if this is an instance of a primitive. If the optional name is provided then
+    /// only returns true if the primitive has the given name.
+    pub fn is_primitive<S>(&self, prim: Option<S>) -> bool
+    where
+        S: AsRef<str>,
+    {
+        match &self.prototype {
+            CellType::Primitive { name, .. } => {
+                prim.as_ref().map(|p| name.eq(p)).unwrap_or(true)
+            }
+            _ => false,
+        }
+    }
+
     /// Get a reference to the first port with the attribute `attr` and throw an error if none
     /// exist.
     pub fn get_with_attr<S>(&self, attr: S) -> RRC<Port>

--- a/calyx/src/passes/comb_prop.rs
+++ b/calyx/src/passes/comb_prop.rs
@@ -7,6 +7,37 @@ use crate::ir::{
     RRC,
 };
 
+/// Propagate unconditional writes to the input port of `std_wire`s. Equivalent
+/// to copy propagation in software compilers.
+///
+/// For example, we can safely inline the value `c` wherever `w.out` is read.
+/// ```
+/// w.in = c;
+/// group g {
+///   r.in = w.out
+/// }
+/// ```
+///
+/// Gets rewritten to:
+/// ```
+/// w.in = c;
+/// group g {
+///   r.in = c;
+/// }
+/// ```
+///
+/// Correctly propagates writes through mutliple wires:
+/// ```
+/// w1.in = c;
+/// w2.in = w1.out;
+/// r.in = w2.out;
+/// ```
+/// into:
+/// ```
+/// w1.in = c;
+/// w2.in = c;
+/// r.in = c;
+/// ```
 #[derive(Default)]
 pub struct CombProp;
 

--- a/calyx/src/passes/comb_prop.rs
+++ b/calyx/src/passes/comb_prop.rs
@@ -12,11 +12,11 @@ pub struct CombProp;
 
 impl Named for CombProp {
     fn name() -> &'static str {
-        todo!()
+        "comb-prop"
     }
 
     fn description() -> &'static str {
-        todo!()
+        "propagate unconditional continuous assignments"
     }
 }
 

--- a/calyx/src/passes/comb_prop.rs
+++ b/calyx/src/passes/comb_prop.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use crate::ir::{
+    self,
+    traversal::{Action, Named, VisResult, Visitor},
+    RRC,
+};
+
+#[derive(Default)]
+pub struct CombProp;
+
+impl Named for CombProp {
+    fn name() -> &'static str {
+        todo!()
+    }
+
+    fn description() -> &'static str {
+        todo!()
+    }
+}
+
+impl Visitor for CombProp {
+    fn start(
+        &mut self,
+        comp: &mut ir::Component,
+        _sigs: &ir::LibrarySignatures,
+        _comps: &[ir::Component],
+    ) -> VisResult {
+        // Build rewrites from unconditional continuous assignments.
+        let port_rewrites: HashMap<(ir::Id, ir::Id), RRC<ir::Port>> = comp
+            .continuous_assignments
+            .iter()
+            .filter(|assign| assign.guard.is_true())
+            .map(|assign| {
+                (assign.src.borrow().canonical(), Rc::clone(&assign.dst))
+            })
+            .collect();
+
+        let cell_rewrites = HashMap::new();
+        let rewriter = ir::Rewriter::new(&cell_rewrites, &port_rewrites);
+
+        // Rewrite assignments
+        comp.for_each_assignment(&|assign| {
+            assign.for_each_port(|port| {
+                if port.borrow().direction == ir::Direction::Output {
+                    port_rewrites.get(&port.borrow().canonical()).cloned()
+                } else {
+                    None
+                }
+            })
+        });
+        rewriter.rewrite_control(
+            &mut comp.control.borrow_mut(),
+            &HashMap::new(),
+            &HashMap::new(),
+        );
+
+        Ok(Action::Continue)
+    }
+}

--- a/calyx/src/passes/mod.rs
+++ b/calyx/src/passes/mod.rs
@@ -2,6 +2,7 @@
 mod canonical;
 mod clk_insertion;
 mod collapse_control;
+mod comb_prop;
 mod compile_empty;
 mod compile_invoke;
 mod component_iniliner;
@@ -33,6 +34,7 @@ mod wire_inliner;
 pub use canonical::Canonicalize;
 pub use clk_insertion::ClkInsertion;
 pub use collapse_control::CollapseControl;
+pub use comb_prop::CombProp;
 pub use compile_empty::CompileEmpty;
 pub use compile_invoke::CompileInvoke;
 pub use component_iniliner::ComponentInliner;

--- a/tests/passes/comb-prop.expect
+++ b/tests/passes/comb-prop.expect
@@ -1,0 +1,34 @@
+import "primitives/core.futil";
+component main(a: 4, b: 4, c: 1, @go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    w1 = std_wire(4);
+    w2 = std_wire(4);
+    w3 = std_wire(1);
+    w4 = std_wire(1);
+    r = std_reg(4);
+    lt = std_lt(4);
+  }
+  wires {
+    group g {
+      r.in = a;
+      r.write_en = 1'd1;
+      g[done] = r.done;
+    }
+    comb group cond {
+      lt.right = r.out;
+      lt.left = b;
+    }
+    w3.in = c;
+    w4.in = c;
+    w2.in = b;
+    w1.in = a;
+  }
+
+  control {
+    if lt.out with cond {
+      if c {
+        g;
+      }
+    }
+  }
+}

--- a/tests/passes/comb-prop.futil
+++ b/tests/passes/comb-prop.futil
@@ -1,0 +1,35 @@
+// -p validate -p comb-prop
+import "primitives/core.futil";
+component main(a: 4, b: 4, c: 1) -> () {
+  cells {
+    w1 = std_wire(4);
+    w2 = std_wire(4);
+    w3 = std_wire(1);
+    w4 = std_wire(1);
+    r = std_reg(4);
+    lt = std_lt(4);
+  }
+  wires {
+    group g {
+      r.write_en = 1'd1;
+      r.in = w1.out;
+      g[done] = r.done;
+    }
+    comb group cond {
+      lt.left = w2.out;
+      lt.right = r.out;
+    }
+
+    w1.in = a;
+    w2.in = b;
+    w3.in = c;
+    w4.in = w3.out;
+  }
+  control {
+    if lt.out with cond {
+      if w4.out {
+        g;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implements one of the two passes mentioned in https://github.com/cucapra/calyx/issues/869. See test file to see how this works. The only interesting thing is that it needs to propagate writes through wires (`w1` and `w2` are wires):
```
w1. in = c;
w2.in = w1.out;
r.in = w2.out;
```
into:
```
w1.in = c;
w2.in = c;
r.in = c;
```

This pass does not eliminate unused assignments. A different pass will be responsible for that.