### PR TITLE
Eliminate dead combinational assignments

### DIFF
--- a/calyx/src/analysis/control_ports.rs
+++ b/calyx/src/analysis/control_ports.rs
@@ -32,6 +32,11 @@ impl<const WITH_MAP: bool> ControlPorts<WITH_MAP> {
         self.used_ports.remove(group)
     }
 
+    /// Get all the ports used in the control program
+    pub fn get_ports(self) -> impl Iterator<Item = RRC<ir::Port>> {
+        self.used_ports.into_values().flatten()
+    }
+
     /// Get all bindings for an instance
     pub fn get_bindings(&self, instance: &ir::Id) -> Option<&Vec<Binding>> {
         if WITH_MAP {

--- a/calyx/src/analysis/control_ports.rs
+++ b/calyx/src/analysis/control_ports.rs
@@ -14,14 +14,14 @@ type InvokeMap = HashMap<ir::Id, Vec<Binding>>;
 /// Contains a mapping from name of [ir::CombGroup] to the ports read by the control program
 /// as well as the mapping from invoke statements to the port mappings.
 /// The vector of ports is guaranteed to only contain unique ports.
-pub struct ControlPorts {
+pub struct ControlPorts<const WITH_MAP: bool> {
     // Map name of combinational group to the ports read by the control program.
     used_ports: PortMap,
     // Mapping from name of invoke instance to the port bindings.
     invoke_map: InvokeMap,
 }
 
-impl ControlPorts {
+impl<const WITH_MAP: bool> ControlPorts<WITH_MAP> {
     /// Return a reference to the port reads associated with the group.
     pub fn get(&self, group: &ir::Id) -> Option<&Vec<RRC<ir::Port>>> {
         self.used_ports.get(group)
@@ -34,112 +34,124 @@ impl ControlPorts {
 
     /// Get all bindings for an instance
     pub fn get_bindings(&self, instance: &ir::Id) -> Option<&Vec<Binding>> {
-        self.invoke_map.get(instance)
+        if WITH_MAP {
+            self.invoke_map.get(instance)
+        } else {
+            panic!("ControlPorts instance built without invoke_map")
+        }
     }
 
     /// Return the entire invoke binding map.
     pub fn get_all_bindings(self) -> InvokeMap {
-        self.invoke_map
-    }
-}
-
-/// Helper method to construct a [ControlPorts] instance.
-fn construct(
-    con: &ir::Control,
-    used_ports: &mut PortMap,
-    invoke_map: &mut InvokeMap,
-) {
-    match con {
-        ir::Control::Enable(_) | ir::Control::Empty(_) => {}
-        ir::Control::Invoke(ir::Invoke {
-            comp,
-            comb_group,
-            inputs,
-            outputs,
-            ..
-        }) => {
-            if let Some(c) = comb_group {
-                let cells = super::ReadWriteSet::uses(&c.borrow().assignments)
-                    .into_iter()
-                    .map(|cell| cell.clone_name())
-                    .collect::<HashSet<_>>();
-                // Only add ports that come from cells used in this comb group.
-                let ports =
-                    inputs.iter().map(|(_, port)| Rc::clone(port)).filter(
-                        |port| cells.contains(&port.borrow().get_parent_name()),
-                    );
-                used_ports
-                    .entry(c.borrow().name().clone())
-                    .or_default()
-                    .extend(ports);
-            }
-            let name = comp.borrow().clone_name();
-            let bindings =
-                inputs.iter().chain(outputs.iter()).cloned().collect_vec();
-            invoke_map.entry(name).or_default().push(bindings);
-        }
-        ir::Control::If(ir::If {
-            cond,
-            port,
-            tbranch,
-            fbranch,
-            ..
-        }) => {
-            if let Some(c) = cond {
-                used_ports
-                    .entry(c.borrow().name().clone())
-                    .or_default()
-                    .push(Rc::clone(port));
-            }
-
-            construct(tbranch, used_ports, invoke_map);
-            construct(fbranch, used_ports, invoke_map);
-        }
-        ir::Control::While(ir::While {
-            cond, port, body, ..
-        }) => {
-            if let Some(c) = cond {
-                used_ports
-                    .entry(c.borrow().name().clone())
-                    .or_default()
-                    .push(Rc::clone(port));
-            }
-            construct(body, used_ports, invoke_map);
-        }
-        ir::Control::Seq(ir::Seq { stmts, .. })
-        | ir::Control::Par(ir::Par { stmts, .. }) => {
-            stmts
-                .iter()
-                .for_each(|con| construct(con, used_ports, invoke_map));
+        if WITH_MAP {
+            self.invoke_map
+        } else {
+            panic!("ControlPorts instance built without invoke_map")
         }
     }
 }
 
-impl From<&ir::Control> for ControlPorts {
+impl<const WITH_MAP: bool> ControlPorts<WITH_MAP> {
+    fn construct(&mut self, con: &ir::Control) {
+        match con {
+            ir::Control::Enable(_) | ir::Control::Empty(_) => {}
+            ir::Control::Invoke(ir::Invoke {
+                comp,
+                comb_group,
+                inputs,
+                outputs,
+                ..
+            }) => {
+                if let Some(c) = comb_group {
+                    let cells =
+                        super::ReadWriteSet::uses(&c.borrow().assignments)
+                            .into_iter()
+                            .map(|cell| cell.clone_name())
+                            .collect::<HashSet<_>>();
+                    // Only add ports that come from cells used in this comb group.
+                    let ports = inputs
+                        .iter()
+                        .map(|(_, port)| Rc::clone(port))
+                        .filter(|port| {
+                            cells.contains(&port.borrow().get_parent_name())
+                        });
+                    self.used_ports
+                        .entry(c.borrow().name().clone())
+                        .or_default()
+                        .extend(ports);
+                }
+                if WITH_MAP {
+                    let name = comp.borrow().clone_name();
+                    let bindings = inputs
+                        .iter()
+                        .chain(outputs.iter())
+                        .cloned()
+                        .collect_vec();
+                    self.invoke_map.entry(name).or_default().push(bindings);
+                }
+            }
+            ir::Control::If(ir::If {
+                cond,
+                port,
+                tbranch,
+                fbranch,
+                ..
+            }) => {
+                if let Some(c) = cond {
+                    self.used_ports
+                        .entry(c.borrow().name().clone())
+                        .or_default()
+                        .push(Rc::clone(port));
+                }
+
+                self.construct(tbranch);
+                self.construct(fbranch);
+            }
+            ir::Control::While(ir::While {
+                cond, port, body, ..
+            }) => {
+                if let Some(c) = cond {
+                    self.used_ports
+                        .entry(c.borrow().name().clone())
+                        .or_default()
+                        .push(Rc::clone(port));
+                }
+                self.construct(body);
+            }
+            ir::Control::Seq(ir::Seq { stmts, .. })
+            | ir::Control::Par(ir::Par { stmts, .. }) => {
+                stmts.iter().for_each(|con| self.construct(con));
+            }
+        }
+    }
+}
+
+impl<const WITH_MAP: bool> From<&ir::Control> for ControlPorts<WITH_MAP> {
     fn from(con: &ir::Control) -> Self {
-        let mut used_ports = HashMap::new();
-        let mut invoke_map = HashMap::new();
-        construct(con, &mut used_ports, &mut invoke_map);
+        let mut cp = ControlPorts {
+            used_ports: HashMap::new(),
+            invoke_map: HashMap::new(),
+        };
+        cp.construct(con);
         // Deduplicate all group port reads
-        used_ports.values_mut().for_each(|v| {
+        cp.used_ports.values_mut().for_each(|v| {
             *v = v.drain(..).unique_by(|p| p.borrow().canonical()).collect()
         });
-        // Deduplicate all invoke bindings
-        invoke_map.values_mut().for_each(|v| {
-            *v = v
-                .drain(..)
-                .unique_by(|binding| {
-                    binding
-                        .clone()
-                        .into_iter()
-                        .map(|(p, v)| (p, v.borrow().canonical()))
-                        .collect_vec()
-                })
-                .collect()
-        });
-        ControlPorts {
-            used_ports,
-            invoke_map,
+        // Deduplicate all invoke bindings if map was constructed
+        if WITH_MAP {
+            cp.invoke_map.values_mut().for_each(|v| {
+                *v = v
+                    .drain(..)
+                    .unique_by(|binding| {
+                        binding
+                            .clone()
+                            .into_iter()
+                            .map(|(p, v)| (p, v.borrow().canonical()))
+                            .collect_vec()
+                    })
+                    .collect()
+            });
         }
+        cp
     }
 }

--- a/calyx/src/ir/component.rs
+++ b/calyx/src/ir/component.rs
@@ -122,9 +122,9 @@ impl Component {
     }
 
     /// Apply function on all assignments contained within the component.
-    pub fn for_each_assignment<F>(&mut self, f: &F)
+    pub fn for_each_assignment<F>(&mut self, f: F)
     where
-        F: Fn(&mut Assignment),
+        F: FnMut(&mut Assignment) + Copy,
     {
         // Detach assignments from the group so that ports that use group
         // `go` and `done` condition can access the parent group.

--- a/calyx/src/ir/component.rs
+++ b/calyx/src/ir/component.rs
@@ -122,22 +122,26 @@ impl Component {
     }
 
     /// Apply function on all assignments contained within the component.
-    pub fn for_each_assignment<F>(&mut self, f: F)
+    pub fn for_each_assignment<F>(&mut self, mut f: F)
     where
-        F: FnMut(&mut Assignment) + Copy,
+        F: FnMut(&mut Assignment),
     {
         // Detach assignments from the group so that ports that use group
         // `go` and `done` condition can access the parent group.
         for group_ref in self.groups.iter() {
             let mut assigns =
                 group_ref.borrow_mut().assignments.drain(..).collect_vec();
-            assigns.iter_mut().for_each(f);
+            for assign in &mut assigns {
+                f(assign)
+            }
             group_ref.borrow_mut().assignments = assigns;
         }
         for group_ref in self.comb_groups.iter() {
             let mut assigns =
                 group_ref.borrow_mut().assignments.drain(..).collect_vec();
-            assigns.iter_mut().for_each(f);
+            for assign in &mut assigns {
+                f(assign)
+            }
             group_ref.borrow_mut().assignments = assigns;
         }
         self.continuous_assignments.iter_mut().for_each(f);

--- a/calyx/src/ir/guard.rs
+++ b/calyx/src/ir/guard.rs
@@ -71,9 +71,9 @@ impl Guard {
     /// Mutates a guard by calling `f` on every leaf in the
     /// guard tree and replacing the leaf with the guard that `f`
     /// returns.
-    pub fn for_each<F>(&mut self, f: &F)
+    pub fn for_each<F>(&mut self, f: &mut F)
     where
-        F: Fn(RRC<Port>) -> Option<Guard>,
+        F: FnMut(RRC<Port>) -> Option<Guard>,
     {
         match self {
             Guard::And(l, r) | Guard::Or(l, r) => {

--- a/calyx/src/ir/structure.rs
+++ b/calyx/src/ir/structure.rs
@@ -323,9 +323,9 @@ pub struct Assignment {
 impl Assignment {
     /// Apply function `f` to each port contained within the assignment and
     /// replace the port with the generated value if not None.
-    pub fn for_each_port<F>(&mut self, f: F)
+    pub fn for_each_port<F>(&mut self, mut f: F)
     where
-        F: Fn(&RRC<Port>) -> Option<RRC<Port>>,
+        F: FnMut(&RRC<Port>) -> Option<RRC<Port>>,
     {
         if let Some(new_src) = f(&self.src) {
             self.src = new_src;
@@ -333,7 +333,7 @@ impl Assignment {
         if let Some(new_dst) = f(&self.dst) {
             self.dst = new_dst;
         }
-        self.guard.for_each(&|port| f(&port).map(Guard::port))
+        self.guard.for_each(&mut |port| f(&port).map(Guard::port))
     }
 }
 

--- a/calyx/src/passes/component_iniliner.rs
+++ b/calyx/src/passes/component_iniliner.rs
@@ -300,7 +300,7 @@ impl Visitor for ComponentInliner {
         // Rewrite all assignment in the component to use interface wires
         // from the inlined instances and check if the `go` or `done` ports
         // on any of the instances was used for structural invokes.
-        builder.component.for_each_assignment(&|assign| {
+        builder.component.for_each_assignment(|assign| {
             assign.for_each_port(|pr| {
                 let port = &pr.borrow();
                 let np = interface_rewrites.get(&port.canonical());

--- a/calyx/src/passes/component_iniliner.rs
+++ b/calyx/src/passes/component_iniliner.rs
@@ -316,11 +316,12 @@ impl Visitor for ComponentInliner {
 
         // Use analysis to get all bindings for invokes and filter out bindings
         // for inlined cells.
-        let invoke_bindings =
-            analysis::ControlPorts::from(&*builder.component.control.borrow())
-                .get_all_bindings()
-                .into_iter()
-                .filter(|(instance, _)| inlined_cells.contains(instance));
+        let invoke_bindings = analysis::ControlPorts::<true>::from(
+            &*builder.component.control.borrow(),
+        )
+        .get_all_bindings()
+        .into_iter()
+        .filter(|(instance, _)| inlined_cells.contains(instance));
 
         // Ensure that all invokes use the same parameters and inline the parameter assignments.
         for (instance, mut bindings) in invoke_bindings {

--- a/calyx/src/passes/dead_assign_removal.rs
+++ b/calyx/src/passes/dead_assign_removal.rs
@@ -1,0 +1,71 @@
+use std::collections::HashSet;
+
+use crate::analysis::ControlPorts;
+use crate::ir::{
+    self,
+    traversal::{Action, Named, VisResult, Visitor},
+};
+use crate::ir::{CloneName, RRC};
+
+/// Removes assignments to combinational elements that are never read.
+#[derive(Default)]
+struct DeadAssignRemoval {
+    all_reads: HashSet<ir::Id>,
+}
+
+impl Named for DeadAssignRemoval {
+    fn name() -> &'static str {
+        "dead-assign-removal"
+    }
+
+    fn description() -> &'static str {
+        "removes assignments to combinational primitives that are never read"
+    }
+}
+
+// Return a port's parent cell name if it is an output port on a combinational
+// cell.
+fn get_port(port: &RRC<ir::Port>) -> Option<ir::Id> {
+    let port = port.borrow();
+    if port.direction == ir::Direction::Output {
+        let cr = port.cell_parent();
+        let cell = cr.borrow();
+        match &cell.prototype {
+            ir::CellType::Primitive { is_comb, .. } if *is_comb => {
+                return Some(cell.clone_name());
+            }
+            _ => (),
+        };
+    }
+    None
+}
+
+impl Visitor for DeadAssignRemoval {
+    fn start(
+        &mut self,
+        comp: &mut ir::Component,
+        _sigs: &ir::LibrarySignatures,
+        _comps: &[ir::Component],
+    ) -> VisResult {
+        // Add all combinational cells that have at least one output read.
+        comp.for_each_assignment(|assign| {
+            assign.for_each_port(|port| {
+                if let Some(port) = get_port(port) {
+                    self.all_reads.insert(port);
+                }
+                None
+            });
+        });
+
+        // Add all of the ports in the control program.
+        ControlPorts::<false>::from(&*comp.control.borrow())
+            .get_ports()
+            .for_each(|port| {
+                if let Some(port) = get_port(&port) {
+                    self.all_reads.insert(port);
+                }
+            });
+
+        Ok(Action::Stop)
+    }
+}

--- a/calyx/src/passes/hole_inliner.rs
+++ b/calyx/src/passes/hole_inliner.rs
@@ -86,7 +86,7 @@ fn fixed_point(graph: &GraphAnalysis, map: &mut Store) {
             let key = read.borrow().canonical();
             map.entry(read.borrow().canonical())
                 .and_modify(|(_, guard)| {
-                    guard.for_each(&|port| {
+                    guard.for_each(&mut |port| {
                         if port.borrow().canonical() == hole_key {
                             Some(new_guard.clone())
                         } else {
@@ -208,7 +208,7 @@ impl Visitor for HoleInliner {
 
         // replace reads from a hole with the value in the map
         for asgn in &mut assignments {
-            asgn.guard.for_each(&|port| {
+            asgn.guard.for_each(&mut |port| {
                 if port.borrow().is_hole() {
                     Some(map[&port.borrow().canonical()].1.clone())
                 } else {

--- a/calyx/src/passes/mod.rs
+++ b/calyx/src/passes/mod.rs
@@ -6,6 +6,7 @@ mod compile_empty;
 mod compile_invoke;
 mod component_iniliner;
 mod component_interface;
+mod dead_assign_removal;
 mod dead_cell_removal;
 mod dead_group_removal;
 mod externalize;

--- a/calyx/src/passes/remove_comb_groups.rs
+++ b/calyx/src/passes/remove_comb_groups.rs
@@ -103,7 +103,7 @@ impl Visitor for RemoveCombGroups {
         self.updated = false;
 
         let mut used_ports =
-            analysis::ControlPorts::from(&*comp.control.borrow());
+            analysis::ControlPorts::<false>::from(&*comp.control.borrow());
 
         // If any groups were updated, tell the pass that updates
         // were made.

--- a/calyx/src/passes/sharing_components.rs
+++ b/calyx/src/passes/sharing_components.rs
@@ -170,7 +170,7 @@ impl<T: ShareComponents> Visitor for T {
         // Rewrite assignments using the coloring generated.
         let empty_map = HashMap::new();
         let rewriter = ir::Rewriter::new(&coloring, &empty_map);
-        comp.for_each_assignment(&|assign| {
+        comp.for_each_assignment(|assign| {
             assign.for_each_port(|port| rewriter.get(port));
         });
 

--- a/calyx/src/passes/wire_inliner.rs
+++ b/calyx/src/passes/wire_inliner.rs
@@ -43,7 +43,7 @@ fn rewrite_assign(map: &HoleMapping, assign: &mut ir::Assignment) {
     if let Some(cell) = rewrite(&assign.src) {
         assign.src = cell.borrow().get("out");
     }
-    assign.guard.for_each(&|port| {
+    assign.guard.for_each(&mut |port| {
         rewrite(&port).map(|cell| ir::Guard::port(cell.borrow().get("out")))
     });
 }


### PR DESCRIPTION
The second pass mentioned in #869 that removes unused combinational primitives. Combinational primitives are unused if they're only ever written to and never read from.

Actually, now that I think of it, there is no specific reason why this only applies to combinational primitives. If the output ports of a sequential element are never read, it is also unused. There is no magical way to have a write in a combinational component affect something else in the circuit.
