### PR TITLE
Define `ir::Canonical` for port's canonical representation

### DIFF
--- a/calyx/src/analysis/graph.rs
+++ b/calyx/src/analysis/graph.rs
@@ -34,7 +34,7 @@ pub type CellGraph = DiGraph<Node, Edge>;
 /// such as all the reads from a port or all the write to a port.
 #[derive(Clone, Default, Debug)]
 pub struct GraphAnalysis {
-    nodes: HashMap<(Id, Id), NodeIndex>,
+    nodes: HashMap<ir::Canonical, NodeIndex>,
     graph: CellGraph,
 }
 
@@ -155,10 +155,9 @@ impl GraphAnalysis {
         for (a_ref, b_ref) in edges {
             let a = a_ref.borrow();
             let b = b_ref.borrow();
-            if let (Some(a_idx), Some(b_idx)) = (
-                nodes.get(&(a.get_parent_name(), a.name.clone())),
-                nodes.get(&(b.get_parent_name(), b.name.clone())),
-            ) {
+            if let (Some(a_idx), Some(b_idx)) =
+                (nodes.get(&a.canonical()), nodes.get(&b.canonical()))
+            {
                 graph.add_edge(*a_idx, *b_idx, ());
             }
         }
@@ -184,14 +183,8 @@ impl GraphAnalysis {
         start: &ir::Port,
         finish: &ir::Port,
     ) -> Vec<Vec<RRC<ir::Port>>> {
-        let start_idx = self
-            .nodes
-            .get(&(start.get_parent_name(), start.name.clone()))
-            .unwrap();
-        let finish_idx = self
-            .nodes
-            .get(&(finish.get_parent_name(), finish.name.clone()))
-            .unwrap();
+        let start_idx = self.nodes.get(&start.canonical()).unwrap();
+        let finish_idx = self.nodes.get(&finish.canonical()).unwrap();
 
         let paths: Vec<Vec<RRC<ir::Port>>> = algo::all_simple_paths(
             &self.graph,
@@ -275,8 +268,7 @@ impl GraphAnalysis {
                 .node_indices()
                 .find(|idx| *graph_copy[*idx].borrow() == *port)
                 .unwrap();
-            nodes_copy
-                .insert((port.get_parent_name(), port.name.clone()), n_idx);
+            nodes_copy.insert(port.canonical(), n_idx);
         }
 
         Self {

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -1,7 +1,7 @@
 use super::{
-    Assignment, Attributes, BackendConf, Builder, CellType, Component, Context,
-    Control, Direction, GetAttributes, Guard, Id, Invoke, LibrarySignatures,
-    Port, PortDef, Width, RESERVED_NAMES, RRC,
+    Assignment, Attributes, BackendConf, Builder, Canonical, CellType,
+    Component, Context, Control, Direction, GetAttributes, Guard, Id, Invoke,
+    LibrarySignatures, Port, PortDef, Width, RESERVED_NAMES, RRC,
 };
 use crate::{
     errors::{CalyxResult, Error, WithPos},
@@ -385,14 +385,14 @@ fn ensure_direction(pr: RRC<Port>, dir: Direction) -> CalyxResult<RRC<Port>> {
     let port_dir = pr.borrow().direction.clone();
     match (dir, port_dir) {
         (Direction::Input, Direction::Output) => {
-            let (c, p) = pr.borrow().canonical();
+            let Canonical(c, p) = pr.borrow().canonical();
             Err(Error::malformed_structure(format!(
                 "Port `{}.{}` occurs in write position but is an output port",
                 c, p
             )))
         }
         (Direction::Output, Direction::Input) => {
-            let (c, p) = pr.borrow().canonical();
+            let Canonical(c, p) = pr.borrow().canonical();
             Err(Error::malformed_structure(format!(
                 "Port `{}.{}` occurs in write position but is an output port",
                 c, p

--- a/calyx/src/ir/mod.rs
+++ b/calyx/src/ir/mod.rs
@@ -35,8 +35,8 @@ pub use printer::Printer;
 pub use reserved_names::RESERVED_NAMES;
 pub use rewriter::Rewriter;
 pub use structure::{
-    Assignment, Binding, Cell, CellType, CloneName, CombGroup, Direction,
-    GetName, Group, Port, PortIterator, PortParent,
+    Assignment, Binding, Canonical, Cell, CellType, CloneName, CombGroup,
+    Direction, GetName, Group, Port, PortIterator, PortParent,
 };
 
 /// Visitor to traverse a control program.

--- a/calyx/src/ir/mod.rs
+++ b/calyx/src/ir/mod.rs
@@ -18,7 +18,7 @@ mod id;
 mod primitives;
 mod printer;
 mod reserved_names;
-mod rewriter;
+pub mod rewriter;
 mod structure;
 
 // Re-export types at the module level.

--- a/calyx/src/ir/rewriter.rs
+++ b/calyx/src/ir/rewriter.rs
@@ -10,7 +10,7 @@ pub type CellRewriteMap = HashMap<ir::Id, RRC<ir::Cell>>;
 
 /// Map to rewrite port uses. Maps the canonical name of an old port (generated using
 /// [ir::Port::canonical]) to the new [ir::Port] instance.
-pub type PortRewriteMap = HashMap<(ir::Id, ir::Id), RRC<ir::Port>>;
+pub type PortRewriteMap = HashMap<ir::Canonical, RRC<ir::Port>>;
 
 /// Map name of old group to new group
 type GroupRewriteMap = HashMap<ir::Id, RRC<ir::Group>>;

--- a/calyx/src/ir/rewriter.rs
+++ b/calyx/src/ir/rewriter.rs
@@ -6,11 +6,11 @@ use super::CloneName;
 
 /// Map to rewrite cell uses. Maps name of the old cell to the new [ir::Cell]
 /// instance.
-type CellRewriteMap = HashMap<ir::Id, RRC<ir::Cell>>;
+pub type CellRewriteMap = HashMap<ir::Id, RRC<ir::Cell>>;
 
 /// Map to rewrite port uses. Maps the canonical name of an old port (generated using
 /// [ir::Port::canonical]) to the new [ir::Port] instance.
-type PortRewriteMap = HashMap<(ir::Id, ir::Id), RRC<ir::Port>>;
+pub type PortRewriteMap = HashMap<(ir::Id, ir::Id), RRC<ir::Port>>;
 
 /// Map name of old group to new group
 type GroupRewriteMap = HashMap<ir::Id, RRC<ir::Group>>;

--- a/calyx/src/ir/structure.rs
+++ b/calyx/src/ir/structure.rs
@@ -48,6 +48,10 @@ pub struct Port {
     pub attributes: Attributes,
 }
 
+/// Canonical name of a Port
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Canonical(pub Id, pub Id);
+
 impl Port {
     /// Checks if this port is a hole
     pub fn is_hole(&self) -> bool {
@@ -86,8 +90,8 @@ impl Port {
     }
 
     /// Get the canonical representation for this Port.
-    pub fn canonical(&self) -> (Id, Id) {
-        (self.get_parent_name(), self.name.clone())
+    pub fn canonical(&self) -> Canonical {
+        Canonical(self.get_parent_name(), self.name.clone())
     }
 }
 

--- a/calyx/src/passes/comb_prop.rs
+++ b/calyx/src/passes/comb_prop.rs
@@ -7,6 +7,10 @@ use crate::ir::{
     RRC,
 };
 
+/// A data structure to track rewrites of ports with added functionality to declare
+/// two wires to be "equal" when they are connected together.
+struct WireRewriter {}
+
 /// Propagate unconditional writes to the input port of `std_wire`s. Equivalent
 /// to copy propagation in software compilers.
 ///

--- a/calyx/src/passes/comb_prop.rs
+++ b/calyx/src/passes/comb_prop.rs
@@ -7,10 +7,6 @@ use crate::ir::{
     RRC,
 };
 
-/// A data structure to track rewrites of ports with added functionality to declare
-/// two wires to be "equal" when they are connected together.
-struct WireRewriter {}
-
 /// Propagate unconditional writes to the input port of `std_wire`s. Equivalent
 /// to copy propagation in software compilers.
 ///

--- a/calyx/src/passes/comb_prop.rs
+++ b/calyx/src/passes/comb_prop.rs
@@ -62,7 +62,7 @@ impl Visitor for CombProp {
         _sigs: &ir::LibrarySignatures,
         _comps: &[ir::Component],
     ) -> VisResult {
-        let mut port_rewrites: HashMap<(ir::Id, ir::Id), RRC<ir::Port>> =
+        let mut port_rewrites: HashMap<ir::Canonical, RRC<ir::Port>> =
             HashMap::new();
 
         // Build rewrites from unconditional continuous assignments to input

--- a/calyx/src/passes/component_iniliner.rs
+++ b/calyx/src/passes/component_iniliner.rs
@@ -8,14 +8,10 @@ use crate::errors::Error;
 use crate::ir::traversal::{Action, Named, VisResult, Visitor};
 use crate::ir::{self, CloneName, LibrarySignatures, RRC};
 
-/// Map name of old cell to the new cell
-type CellMap = HashMap<ir::Id, RRC<ir::Cell>>;
 /// Map name of old group to new group
 type GroupMap = HashMap<ir::Id, RRC<ir::Group>>;
 /// Map name of old combination group to new combinational group
 type CombGroupMap = HashMap<ir::Id, RRC<ir::CombGroup>>;
-/// Map canonical name of old port to new port
-type PortMap = HashMap<(ir::Id, ir::Id), RRC<ir::Port>>;
 
 /// Inlines all sub-components marked with the `@inline` attribute.
 /// Cannot inline components when they:
@@ -33,7 +29,7 @@ pub struct ComponentInliner {
     /// Map from the name of an instance to its associated control program.
     control_map: HashMap<ir::Id, ir::Control>,
     /// Mapping for ports on cells that have been inlined.
-    interface_rewrites: PortMap,
+    interface_rewrites: ir::rewriter::PortRewriteMap,
     /// Cells that have been inlined. We retain these so that references within
     /// the control program of the parent are valid.
     inlined_cells: Vec<RRC<ir::Cell>>,
@@ -135,7 +131,7 @@ impl ComponentInliner {
         builder: &mut ir::Builder,
         comp: &ir::Component,
         name: ir::Id,
-    ) -> PortMap {
+    ) -> ir::rewriter::PortRewriteMap {
         // For each output port, generate a wire that will store its value
         comp.signature
             .borrow()
@@ -173,7 +169,7 @@ impl ComponentInliner {
     ) {
         // For each cell in the component, create a new cell in the parent
         // of the same type and build a rewrite map using it.
-        let cell_map: CellMap = comp
+        let cell_map: ir::rewriter::CellRewriteMap = comp
             .cells
             .iter()
             .map(|cell_ref| Self::inline_cell(builder, cell_ref))
@@ -266,7 +262,8 @@ impl Visitor for ComponentInliner {
             .collect::<HashMap<_, _>>();
 
         // Rewrites for the interface ports of inlined cells.
-        let mut interface_rewrites: PortMap = HashMap::new();
+        let mut interface_rewrites: ir::rewriter::PortRewriteMap =
+            HashMap::new();
         // Track names of cells that were inlined.
         let mut inlined_cells = HashSet::new();
         let mut builder = ir::Builder::new(comp, sigs);

--- a/calyx/src/passes/hole_inliner.rs
+++ b/calyx/src/passes/hole_inliner.rs
@@ -28,7 +28,7 @@ impl Named for HoleInliner {
     }
 }
 
-type Store = HashMap<(ir::Id, ir::Id), (RRC<ir::Port>, ir::Guard)>;
+type Store = HashMap<ir::Canonical, (RRC<ir::Port>, ir::Guard)>;
 
 /// Finds the 'fixed_point' of a map from Hole names to guards under the
 /// inlining operation. The map contains entries like:

--- a/calyx/src/passes/merge_assign.rs
+++ b/calyx/src/passes/merge_assign.rs
@@ -36,10 +36,8 @@ impl Named for MergeAssign {
 }
 
 fn merge_assigns(assigns: Vec<ir::Assignment>) -> Vec<ir::Assignment> {
-    // A (cell, port) pair used as a key.
-    type Key = (ir::Id, ir::Id);
     // Map from (dst, src) -> Assignment
-    let mut map: LinkedHashMap<(Key, Key), ir::Assignment> =
+    let mut map: LinkedHashMap<(ir::Canonical, ir::Canonical), ir::Assignment> =
         LinkedHashMap::new();
 
     for assign in assigns {

--- a/calyx/src/passes/register_unsharing.rs
+++ b/calyx/src/passes/register_unsharing.rs
@@ -4,7 +4,7 @@ use crate::analysis::reaching_defns::{
     GroupOrInvoke, ReachingDefinitionAnalysis,
 };
 use crate::ir::traversal::{Action, Named, VisResult, Visitor};
-use crate::ir::{self, Builder, Cell, CloneName, LibrarySignatures, RRC};
+use crate::ir::{self, Builder, CloneName, LibrarySignatures};
 use std::collections::HashMap;
 
 /// Unsharing registers reduces the amount of multiplexers used in the final design, trading them
@@ -49,7 +49,7 @@ impl Named for RegisterUnsharing {
     }
 }
 
-type RewriteMap<T> = HashMap<T, HashMap<ir::Id, RRC<Cell>>>;
+type RewriteMap<T> = HashMap<T, ir::rewriter::CellRewriteMap>;
 
 // A struct for managing the overlapping analysis and rewrite information
 #[derive(Default)]

--- a/calyx/src/passes/remove_comb_groups.rs
+++ b/calyx/src/passes/remove_comb_groups.rs
@@ -79,7 +79,7 @@ pub struct RemoveCombGroups {
 }
 
 /// Represents (group_name, (cell_name, port_name))
-type PortInGroup = (ir::Id, (ir::Id, ir::Id));
+type PortInGroup = (ir::Id, ir::Canonical);
 
 impl Named for RemoveCombGroups {
     fn name() -> &'static str {

--- a/calyx/src/passes/sharing_components.rs
+++ b/calyx/src/passes/sharing_components.rs
@@ -155,7 +155,7 @@ impl<T: ShareComponents> Visitor for T {
             }
         });
 
-        let mut coloring = HashMap::new();
+        let mut coloring: ir::rewriter::CellRewriteMap = HashMap::new();
         for graph in graphs_by_type.values() {
             if graph.has_nodes() {
                 coloring.extend(
@@ -168,7 +168,7 @@ impl<T: ShareComponents> Visitor for T {
         }
 
         // Rewrite assignments using the coloring generated.
-        let empty_map = HashMap::new();
+        let empty_map: ir::rewriter::PortRewriteMap = HashMap::new();
         let rewriter = ir::Rewriter::new(&coloring, &empty_map);
         comp.for_each_assignment(|assign| {
             assign.for_each_port(|port| rewriter.get(port));

--- a/calyx/src/passes/well_formed.rs
+++ b/calyx/src/passes/well_formed.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 use crate::errors::{CalyxResult, Error};
 use crate::ir::traversal::{Action, Named, VisResult, Visitor};
 use crate::ir::{
@@ -43,16 +41,6 @@ impl Named for WellFormed {
     fn description() -> &'static str {
         "Check if the structure and control are well formed."
     }
-}
-
-/// Returns an error if the assignments are obviously conflicting. This happens when two
-/// assignments assign to the same port unconditionally.
-fn obvious_conflicts(assigns: &[ir::Assignment]) -> CalyxResult<()> {
-    /* let dst_grps = assigns
-    .iter()
-    .map(|a| (a.dst.borrow().canonical(), a))
-    .sorted_by(|dst1, dst2| dst); */
-    todo!()
 }
 
 impl Visitor for WellFormed {

--- a/calyx/src/passes/well_formed.rs
+++ b/calyx/src/passes/well_formed.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools;
+
 use crate::errors::{CalyxResult, Error};
 use crate::ir::traversal::{Action, Named, VisResult, Visitor};
 use crate::ir::{
@@ -41,6 +43,16 @@ impl Named for WellFormed {
     fn description() -> &'static str {
         "Check if the structure and control are well formed."
     }
+}
+
+/// Returns an error if the assignments are obviously conflicting. This happens when two
+/// assignments assign to the same port unconditionally.
+fn obvious_conflicts(assigns: &[ir::Assignment]) -> CalyxResult<()> {
+    /* let dst_grps = assigns
+    .iter()
+    .map(|a| (a.dst.borrow().canonical(), a))
+    .sorted_by(|dst1, dst2| dst); */
+    todo!()
 }
 
 impl Visitor for WellFormed {

--- a/interp/src/structures/environment.rs
+++ b/interp/src/structures/environment.rs
@@ -480,8 +480,9 @@ impl InterpreterState {
             ir::Guard::Port(p) => {
                 let val = self.get_from_port(&p.borrow());
                 if val.len() != 1 {
+                    let can = p.borrow().canonical();
                     return Err(InterpreterError::InvalidBoolCast(
-                        p.borrow().canonical(),
+                        (can.0, can.1),
                         p.borrow().width,
                     ));
                 } else {

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -313,7 +313,7 @@ fn emit_guard_disjoint_check(
     let mut check = v::SequentialIfElse::new(not_onehot0);
 
     // Generated error message
-    let (cell, port) = dst_ref.borrow().canonical();
+    let ir::Canonical(cell, port) = dst_ref.borrow().canonical();
     let msg = format!("Multiple assignment to port `{}.{}'.", cell, port);
     let err = v::Sequential::new_seqexpr(v::Expr::new_call(
         "$fatal",


### PR DESCRIPTION
Defining this struct enables a future opportunity to use Rc instead of cloning Id everywhere. Canonical representation of ports are pervasively used in the compiler so it should be cheaper to use them.
