### PR TITLE
[docs] do not install all `fud` dependencies

### DIFF
--- a/docs/fud/xilinx.md
+++ b/docs/fud/xilinx.md
@@ -17,6 +17,14 @@ You can set `fud` up to use either a local installation of the Xilinx tools or o
 The simplest way to use the Xilinx tools is to synthesize RTL or HLS designs to collect statistics about them.
 This route will not produce actual, runnable executables; see the next section for that.
 
+### Installing Dependencies
+
+`fud` uses extra dependencies to invoke the Xilinx toolchains.
+Run the following command to install all required dependencies:
+```
+cd fud && flit install -s --deps all
+```
+
 ### Set Up
 
 To set up to **invoke the Xilinx tools over SSH**, first tell `fud` your username and hostname for the server:

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -61,7 +61,7 @@ pip3 install flit
 
 Install `fud` (from the root of the repository):
 ```
-flit -f fud/pyproject.toml install -s
+flit -f fud/pyproject.toml install -s --deps production
 ```
 Configure `fud`:
 ```


### PR DESCRIPTION
@sampsyo seems like people keep into problems with the `opencl` dependency for `fud`. We should probably just not have them install it when getting started. Can you confirm that this is the right way to tell `flit` to skip optional dependencies?
