### PR TITLE
Implement ControlOrder analysis

### DIFF
--- a/calyx/src/analysis/control_order.rs
+++ b/calyx/src/analysis/control_order.rs
@@ -14,6 +14,7 @@ use crate::{
 
 /// Extract the dependency order of a list of control programs.
 /// Dependencies are defined using read/write sets used in the control program.
+/// The read/write sets ignore ports on constants and ThisComponent.
 ///
 /// For example, if we have control programs C1 and C2 with read sets R1 and
 /// R2 and write sets W1 and W2 respectively, we can define an order relationship:

--- a/calyx/src/analysis/control_order.rs
+++ b/calyx/src/analysis/control_order.rs
@@ -1,0 +1,23 @@
+use crate::ir;
+use crate::analysis::ReadWriteSet;
+
+/// Extract the dependency order of a list of control programs.
+/// Dependencies are defined using read/write sets used in the control program.
+///
+/// For example, if we have control programs C1 and C2 with read sets R1 and
+/// R2 and write sets W1 and W2 respectively, we can define an order relationship:
+///
+/// C1 < C2 if (R1 subset of W2) and (R2 disjoint W1)
+/// C1 > C2 if (R2 subset of W1) and (R1 disjoint W2)
+/// C1 =!= if (R1 subset of W2) and (R2 subset of W1)
+struct ControlOrder;
+
+impl ControlOrder {
+    /// Return a total order for the control programs.
+    /// If there is a cycle, then returns the indices of the cyclical dependencies.
+    pub fn get_total_order(
+        stmts: Vec<ir::Control>,
+    ) -> Result<Vec<usize>, Vec<usize>> {
+        todo!()
+    }
+}

--- a/calyx/src/analysis/control_order.rs
+++ b/calyx/src/analysis/control_order.rs
@@ -1,5 +1,5 @@
-use crate::ir;
 use crate::analysis::ReadWriteSet;
+use crate::ir;
 
 /// Extract the dependency order of a list of control programs.
 /// Dependencies are defined using read/write sets used in the control program.

--- a/calyx/src/analysis/control_order.rs
+++ b/calyx/src/analysis/control_order.rs
@@ -1,5 +1,16 @@
-use crate::analysis::ReadWriteSet;
-use crate::ir;
+use std::collections::HashMap;
+
+use itertools::Itertools;
+use petgraph::{
+    algo,
+    graph::{DiGraph, NodeIndex},
+};
+
+use crate::{analysis::ReadWriteSet, ir::RRC};
+use crate::{
+    errors::{CalyxResult, Error},
+    ir::{self, CloneName},
+};
 
 /// Extract the dependency order of a list of control programs.
 /// Dependencies are defined using read/write sets used in the control program.
@@ -10,14 +21,74 @@ use crate::ir;
 /// C1 < C2 if (R1 subset of W2) and (R2 disjoint W1)
 /// C1 > C2 if (R2 subset of W1) and (R1 disjoint W2)
 /// C1 =!= if (R1 subset of W2) and (R2 subset of W1)
-struct ControlOrder;
+pub struct ControlOrder;
 
 impl ControlOrder {
     /// Return a total order for the control programs.
-    /// If there is a cycle, then returns the indices of the cyclical dependencies.
+    /// Returns an error if there is a cycle
     pub fn get_total_order(
-        stmts: Vec<ir::Control>,
-    ) -> Result<Vec<usize>, Vec<usize>> {
-        todo!()
+        stmts: impl Iterator<Item = ir::Control>,
+    ) -> CalyxResult<Vec<ir::Control>> {
+        // Directed graph where edges means that a control program must be run before.
+        let mut gr: DiGraph<Option<ir::Control>, ()> = DiGraph::new();
+
+        // Mapping name of cell to all the indices that read or write to it.
+        let mut reads: HashMap<ir::Id, Vec<NodeIndex>> = HashMap::default();
+        let mut writes: HashMap<ir::Id, Vec<NodeIndex>> = HashMap::default();
+
+        let add_cells =
+            |idx: NodeIndex,
+             ports: Vec<RRC<ir::Port>>,
+             map: &mut HashMap<ir::Id, Vec<NodeIndex>>| {
+                let cells = ports
+                    .into_iter()
+                    .map(|p| p.borrow().cell_parent().clone_name())
+                    .unique();
+                for cell in cells {
+                    map.entry(cell.clone()).or_default().push(idx);
+                }
+            };
+
+        // Compute read/write sets and add them to the maps
+        for c in stmts {
+            let (port_reads, port_writes) =
+                ReadWriteSet::control_port_read_write_set(&c);
+            let idx = gr.add_node(Some(c));
+            add_cells(idx, port_reads, &mut reads);
+            add_cells(idx, port_writes, &mut writes);
+        }
+
+        // Add edges between read and writes
+        for (cell, r_idxs) in reads {
+            if let Some(wr_idxs) = writes.get(&cell) {
+                wr_idxs.iter().cartesian_product(r_idxs.iter()).for_each(
+                    |(wr, r)| {
+                        gr.add_edge(*r, *wr, ());
+                    },
+                );
+            }
+        }
+
+        if let Ok(order) = algo::toposort(&gr, None) {
+            let assigns = order
+                .into_iter()
+                .map(|idx| std::mem::replace(&mut gr[idx], None).unwrap())
+                .collect_vec();
+            Ok(assigns)
+        } else {
+            // Compute strongly connected component of the graph
+            let sccs = algo::kosaraju_scc(&gr);
+            let scc = sccs
+                .iter()
+                .find(|cc| cc.len() > 1)
+                .expect("All combinational cycles are self loops");
+            let msg = scc
+                .iter()
+                .map(|idx| {
+                    ir::Printer::control_to_str(gr[*idx].as_ref().unwrap())
+                })
+                .join("\n");
+            Err(Error::misc(format!("No possible sequential ordering. Control programs exhibit data race:\n{}", msg)))
+        }
     }
 }

--- a/calyx/src/analysis/mod.rs
+++ b/calyx/src/analysis/mod.rs
@@ -15,6 +15,7 @@ mod read_write_set;
 mod schedule_conflicts;
 mod variable_detection;
 
+pub use control_order::ControlOrder;
 pub use control_ports::ControlPorts;
 pub use dataflow_order::DataflowOrder;
 pub use graph::GraphAnalysis;

--- a/calyx/src/analysis/mod.rs
+++ b/calyx/src/analysis/mod.rs
@@ -13,6 +13,7 @@ pub mod reaching_defns;
 mod read_write_set;
 mod schedule_conflicts;
 mod variable_detection;
+mod control_order;
 
 pub use control_ports::ControlPorts;
 pub use dataflow_order::DataflowOrder;

--- a/calyx/src/analysis/mod.rs
+++ b/calyx/src/analysis/mod.rs
@@ -3,6 +3,7 @@
 //! The analyses construct data-structures that make answering certain queries
 //! about Calyx programs easier.
 
+mod control_order;
 mod control_ports;
 mod dataflow_order;
 mod graph;
@@ -13,7 +14,6 @@ pub mod reaching_defns;
 mod read_write_set;
 mod schedule_conflicts;
 mod variable_detection;
-mod control_order;
 
 pub use control_ports::ControlPorts;
 pub use dataflow_order::DataflowOrder;

--- a/calyx/src/analysis/read_write_set.rs
+++ b/calyx/src/analysis/read_write_set.rs
@@ -117,4 +117,67 @@ impl ReadWriteSet {
             .chain(Self::write_set(assigns))
             .unique_by(|cell| cell.clone_name())
     }
+
+    /// Returns the ports that are read by the given control program.
+    pub fn control_port_read_set(con: &ir::Control) -> Vec<RRC<ir::Port>> {
+        match con {
+            ir::Control::Empty(_) => vec![],
+            ir::Control::Enable(ir::Enable { group, .. }) => {
+                Self::port_read_set(group.borrow().assignments.iter()).collect()
+            }
+            ir::Control::Invoke(ir::Invoke {
+                inputs, comb_group, ..
+            }) => {
+                let inps = inputs.iter().map(|(_, p)| p).cloned();
+                match comb_group {
+                    Some(cg) => {
+                        Self::port_read_set(cg.borrow().assignments.iter())
+                            .chain(inps)
+                            .collect()
+                    }
+                    None => inps.collect(),
+                }
+            }
+
+            ir::Control::Seq(ir::Seq { stmts, .. })
+            | ir::Control::Par(ir::Par { stmts, .. }) => {
+                stmts.iter().flat_map(Self::control_port_read_set).collect()
+            }
+            ir::Control::If(ir::If {
+                port,
+                cond,
+                tbranch,
+                fbranch,
+                ..
+            }) => {
+                let common = Self::control_port_read_set(tbranch)
+                    .into_iter()
+                    .chain(Self::control_port_read_set(fbranch).into_iter())
+                    .chain(std::iter::once(Rc::clone(port)));
+                match cond {
+                    Some(cg) => {
+                        Self::port_read_set(cg.borrow().assignments.iter())
+                            .chain(common)
+                            .collect()
+                    }
+                    None => common.collect(),
+                }
+            }
+            ir::Control::While(ir::While {
+                port, cond, body, ..
+            }) => {
+                let common = Self::control_port_read_set(body)
+                    .into_iter()
+                    .chain(std::iter::once(Rc::clone(port)));
+                match cond {
+                    Some(cg) => {
+                        Self::port_read_set(cg.borrow().assignments.iter())
+                            .chain(common)
+                            .collect()
+                    }
+                    None => common.collect(),
+                }
+            }
+        }
+    }
 }

--- a/calyx/src/ir/printer.rs
+++ b/calyx/src/ir/printer.rs
@@ -275,6 +275,13 @@ impl Printer {
         String::from_utf8_lossy(buf.as_slice()).to_string()
     }
 
+    /// Convinience method to get string representation of [ir::Control].
+    pub fn control_to_str(assign: &ir::Control) -> String {
+        let mut buf = Vec::new();
+        Self::write_control(assign, 0, &mut buf).ok();
+        String::from_utf8_lossy(buf.as_slice()).to_string()
+    }
+
     /// Format and write a combinational group.
     pub fn write_comb_group<F: io::Write>(
         group: &ir::CombGroup,

--- a/calyx/src/passes/par_to_seq.rs
+++ b/calyx/src/passes/par_to_seq.rs
@@ -41,7 +41,7 @@ impl Visitor for ParToSeq {
         _comps: &[ir::Component],
     ) -> VisResult {
         let total_order =
-            analysis::ControlOrder::get_total_order(s.stmts.drain(..))?;
+            analysis::ControlOrder::<true>::get_total_order(s.stmts.drain(..))?;
         let par = ir::Control::seq(total_order);
         Ok(Action::Change(par))
     }

--- a/calyx/src/passes/par_to_seq.rs
+++ b/calyx/src/passes/par_to_seq.rs
@@ -3,8 +3,10 @@ use crate::ir::traversal::{Action, Named, VisResult, Visitor};
 use crate::ir::{self, LibrarySignatures};
 
 #[derive(Default)]
-/// Transforms all `par` into `seq`.
-/// Useful for debugging problems with `par`.
+/// Transforms all `par` into `seq`. Uses [analysis::ControlOrder] to get a
+/// sequentialization of `par` such that the program still computes the same
+/// value. When there is no such sequentialization, errors out.
+///
 ///
 /// # Example
 /// ```

--- a/calyx/src/passes/par_to_seq.rs
+++ b/calyx/src/passes/par_to_seq.rs
@@ -1,3 +1,4 @@
+use crate::analysis;
 use crate::ir::traversal::{Action, Named, VisResult, Visitor};
 use crate::ir::{self, LibrarySignatures};
 
@@ -39,7 +40,9 @@ impl Visitor for ParToSeq {
         _c: &LibrarySignatures,
         _comps: &[ir::Component],
     ) -> VisResult {
-        let par = ir::Control::seq(s.stmts.drain(..).collect());
+        let total_order =
+            analysis::ControlOrder::get_total_order(s.stmts.drain(..))?;
+        let par = ir::Control::seq(total_order);
         Ok(Action::Change(par))
     }
 }

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -62,7 +62,7 @@ class InterpreterStage(Stage):
         cmd = [
             script,
             self.flags,
-            unwrap_or(config["stages", self.name, "flags"], ""),
+            "{flags}",
             "-l",
             config["global", "futil_directory"],
             "--data" if data_path else "",
@@ -122,7 +122,9 @@ class InterpreterStage(Stage):
             Invoke the debugger
             """
             command = cmd.format(
-                data_file=Path(tmpdir.name) / _FILE_NAME, target=str(target)
+                data_file=Path(tmpdir.name) / _FILE_NAME,
+                target=str(target),
+                flags=unwrap_or(config["stages", self.name, "flags"], ""),
             )
             transparent_shell(command)
 

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -62,7 +62,7 @@ class InterpreterStage(Stage):
         cmd = [
             script,
             self.flags,
-            "{flags}",
+            unwrap_or(config["stages", self.name, "flags"], ""),
             "-l",
             config["global", "futil_directory"],
             "--data" if data_path else "",
@@ -122,9 +122,7 @@ class InterpreterStage(Stage):
             Invoke the debugger
             """
             command = cmd.format(
-                data_file=Path(tmpdir.name) / _FILE_NAME,
-                target=str(target),
-                flags=unwrap_or(config["stages", self.name, "flags"], ""),
+                data_file=Path(tmpdir.name) / _FILE_NAME, target=str(target)
             )
             transparent_shell(command)
 

--- a/tests/passes/par-to-seq/ignore-this-comp.expect
+++ b/tests/passes/par-to-seq/ignore-this-comp.expect
@@ -1,0 +1,28 @@
+import "primitives/core.futil";
+component main(in: 32, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out1: 32, out2: 32, @done done: 1) {
+  cells {
+    r0 = std_reg(32);
+    r1 = std_reg(32);
+  }
+  wires {
+    group write_out1 {
+      r0.in = in;
+      r0.write_en = 1'd1;
+      out1 = r0.out;
+      write_out1[done] = r0.done;
+    }
+    group write_out2 {
+      r1.in = r0.out;
+      r1.write_en = 1'd1;
+      out2 = r1.out;
+      write_out2[done] = r1.done;
+    }
+  }
+
+  control {
+    seq {
+      write_out2;
+      write_out1;
+    }
+  }
+}

--- a/tests/passes/par-to-seq/ignore-this-comp.futil
+++ b/tests/passes/par-to-seq/ignore-this-comp.futil
@@ -1,0 +1,30 @@
+// -p validate -p par-to-seq
+import "primitives/core.futil";
+component main(in: 32) -> (out1: 32, out2: 32) {
+  cells {
+    r0 = std_reg(32);
+    r1 = std_reg(32);
+  }
+  wires {
+    group write_out1 {
+      out1 = r0.out;
+      r0.write_en = 1'd1;
+      r0.in = in;
+      write_out1[done] = r0.done;
+    }
+
+    group write_out2 {
+      out2 = r1.out;
+      r1.write_en = 1'd1;
+      r1.in = r0.out;
+      write_out2[done] = r1.done;
+    }
+  }
+  control {
+    // When sequentializing, write_out2 needs to run before.
+    par {
+      write_out1;
+      write_out2;
+    }
+  }
+}

--- a/tests/passes/par-to-seq/no-order.expect
+++ b/tests/passes/par-to-seq/no-order.expect
@@ -1,0 +1,10 @@
+---CODE---
+1
+---STDERR---
+Error: No possible sequential ordering. Control programs exhibit data race:
+do_r0;
+  which reads: r1, r0
+  and writes: r0
+do_r1;
+  which reads: r0, r1
+  and writes: r1

--- a/tests/passes/par-to-seq/no-order.futil
+++ b/tests/passes/par-to-seq/no-order.futil
@@ -1,0 +1,28 @@
+// -p validate -p par-to-seq
+import "primitives/core.futil";
+component main() -> () {
+  cells {
+    r1 = std_reg(32);
+    r0 = std_reg(32);
+  }
+  wires {
+    group do_r0 {
+      r0.write_en = 1'd1;
+      r0.in = r1.out;
+      do_r0[done] = r0.done;
+    }
+
+    group do_r1 {
+      r1.write_en = 1'd1;
+      r1.in = r0.out;
+      do_r1[done] = r1.done;
+    }
+  }
+  control {
+    // classic hardware swap implementation
+    par {
+      do_r0;
+      do_r1;
+    }
+  }
+}

--- a/tests/passes/par-to-seq/reorder.expect
+++ b/tests/passes/par-to-seq/reorder.expect
@@ -1,0 +1,28 @@
+import "primitives/core.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    r0 = std_reg(32);
+    r1 = std_reg(32);
+  }
+  wires {
+    group do_r0 {
+      r0.in = r1.out;
+      r0.write_en = 1'd1;
+      do_r0[done] = r0.done;
+    }
+    group do_r1 {
+      r1.in = 32'd30;
+      r1.write_en = 1'd1;
+      do_r1[done] = r1.done;
+    }
+  }
+
+  control {
+    seq {
+      seq {
+        do_r0;
+        do_r1;
+      }
+    }
+  }
+}

--- a/tests/passes/par-to-seq/reorder.futil
+++ b/tests/passes/par-to-seq/reorder.futil
@@ -1,0 +1,31 @@
+// -p validate -p par-to-seq
+import "primitives/core.futil";
+component main() -> () {
+  cells {
+    r0 = std_reg(32);
+    r1 = std_reg(32);
+  }
+  wires {
+    group do_r0 {
+      r0.write_en = 1'd1;
+      r0.in = r1.out;
+      do_r0[done] = r0.done;
+    }
+    group do_r1 {
+      r1.write_en = 1'd1;
+      r1.in = 32'd30;
+      do_r1[done] = r1.done;
+    }
+  }
+  control {
+    // After running, we expect:
+    // r1 = 30;
+    // r0 = r1;
+    seq {
+      par {
+        do_r1;
+        do_r0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Make `par-to-seq` sort control programs in a way that they are correct wrt to dataflow dependencies