### PR TITLE
[Interpreter] Change-based-sim and misc feature round-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ checksum = "a16910e685088843d53132b04e0f10a571fdb193224fc589685b3ba1ce4cb03d"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.28.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -609,8 +609,7 @@ dependencies = [
  "fraction",
  "ibig",
  "itertools 0.10.3",
- "lazy_static",
- "parking_lot",
+ "once_cell",
  "pest",
  "pest_consume",
  "pest_derive",
@@ -682,15 +681,6 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
-
-[[package]]
-name = "lock_api"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -851,29 +841,6 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys 0.32.0",
-]
 
 [[package]]
 name = "pest"
@@ -1679,24 +1646,11 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82ca39602d5cbfa692c4b67e3bcbb2751477355141c1ed434c94da4186836ff6"
 dependencies = [
- "windows_aarch64_msvc 0.28.0",
- "windows_i686_gnu 0.28.0",
- "windows_i686_msvc 0.28.0",
- "windows_x86_64_gnu 0.28.0",
- "windows_x86_64_msvc 0.28.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
-dependencies = [
- "windows_aarch64_msvc 0.32.0",
- "windows_i686_gnu 0.32.0",
- "windows_i686_msvc 0.32.0",
- "windows_x86_64_gnu 0.32.0",
- "windows_x86_64_msvc 0.32.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1706,22 +1660,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52695a41e536859d5308cc613b4a022261a274390b25bd29dfff4bf08505f3c2"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
-
-[[package]]
 name = "windows_i686_gnu"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f54725ac23affef038fecb177de6c9bf065787c2f432f79e3c373da92f3e1d8a"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1730,34 +1672,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d5158a43cc43623c0729d1ad6647e62fa384a3d135fd15108d37c683461f64"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc31f409f565611535130cfe7ee8e6655d3fa99c1c61013981e491921b5ce954"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f2b8c7cbd3bfdddd9ab98769f9746a7fad1bca236554cd032b78d768bc0e89f"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "wyz"

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -33,8 +33,7 @@ slog = "2.7.0"
 slog-term = "2.8.0"
 slog-async = "2.7.0"
 
-parking_lot = "0.12.0"
-
+once_cell = "1.9.0"
 [dev-dependencies]
 proptest = "1.0.0"
 

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -9,6 +9,8 @@ doctest = false # Don't run doc tests
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+changed-based-sim = []
 
 [dependencies]
 calyx = { path = "../calyx" }

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -23,7 +23,6 @@ argh = "0.1.5"
 rustyline = "=9.0.0"
 fraction = { version = "0.9.0", features = ["with-serde-support"] }
 thiserror = "1.0.26"
-lazy_static = "1.4.0"
 ibig = { version= "0.3.4", features = ["serde"] }
 pest = "2.1.3"
 pest_derive = "2.1.0"

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false # Don't run doc tests
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-changed-based-sim = []
+change_based_sim = []
 
 [dependencies]
 calyx = { path = "../calyx" }

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false # Don't run doc tests
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-change_based_sim = []
+change-based-sim = []
 
 [dependencies]
 calyx = { path = "../calyx" }

--- a/interp/src/configuration.rs
+++ b/interp/src/configuration.rs
@@ -1,24 +1,3 @@
-use once_cell::sync::OnceCell;
-
-static SETTINGS: OnceCell<Config> = OnceCell::new();
-
-pub fn get_config() -> &'static Config {
-    SETTINGS.get().unwrap_or_else(|| {
-        init_default_config();
-        SETTINGS.get().unwrap()
-    })
-}
-
-pub fn init_config(conf: Config) {
-    SETTINGS
-        .set(conf)
-        .expect("Failed to set config, perhaps it is already initialized");
-}
-
-#[allow(unused_must_use)]
-pub fn init_default_config() {
-    SETTINGS.set(Config::default());
-}
 // this can be a copy type because it's just a bunch of bools
 #[derive(Debug, Default, Clone, Copy)]
 /// Configuration struct which controls runtime behavior

--- a/interp/src/configuration.rs
+++ b/interp/src/configuration.rs
@@ -1,14 +1,20 @@
-use lazy_static::*;
-use parking_lot::RwLock;
+use once_cell::sync::OnceCell;
 
-lazy_static! {
-    /// Global configuration object which stores the current configuration options for
-    /// simulation and debugging. It is behind a RW lock but is largely meant to be
-    /// read-only after simulation has begun.
-    pub static ref SETTINGS: RwLock<Config> = RwLock::new(Config::default());
+static SETTINGS: OnceCell<Config> = OnceCell::new();
+
+pub fn get_config() -> &'static Config {
+    SETTINGS.get().expect("Config not initialized")
 }
 
-#[derive(Default)]
+pub fn init_config(conf: Config) {
+    SETTINGS
+        .set(conf)
+        .expect("Failed to set config, perhaps it is already initialized");
+}
+
+// this can be a copy type because it's just a bunch of bools
+#[derive(Debug, Default, Clone, Copy)]
+/// Configuration struct which controls runtime behavior
 pub struct Config {
     /// enables/disables "sloppy" interpretation which returns 0 for invalid indicies
     /// rather than erroring
@@ -17,6 +23,52 @@ pub struct Config {
     pub error_on_overflow: bool,
     /// permits "sloppy" interpretation with parallel blocks
     pub allow_par_conflicts: bool,
-    /// suppresses warning printing
+    /// suppresses warnings
     pub quiet: bool,
+}
+
+#[derive(Default)]
+pub struct ConfigBuilder {
+    allow_invalid_memory_access: Option<bool>,
+    error_on_overflow: Option<bool>,
+    allow_par_conflicts: Option<bool>,
+    quiet: Option<bool>,
+}
+
+impl ConfigBuilder {
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn quiet(mut self, value: bool) -> Self {
+        self.quiet = Some(value);
+        self
+    }
+
+    pub fn allow_invalid_memory_access(mut self, value: bool) -> Self {
+        self.allow_invalid_memory_access = Some(value);
+        self
+    }
+
+    pub fn error_on_overflow(mut self, value: bool) -> Self {
+        self.error_on_overflow = Some(value);
+        self
+    }
+
+    pub fn allow_par_conflicts(mut self, value: bool) -> Self {
+        self.allow_par_conflicts = Some(value);
+        self
+    }
+
+    pub fn build(self) -> Config {
+        Config {
+            allow_par_conflicts: self.allow_par_conflicts.unwrap_or_default(),
+            error_on_overflow: self.error_on_overflow.unwrap_or_default(),
+            quiet: self.quiet.unwrap_or_default(),
+            allow_invalid_memory_access: self
+                .allow_invalid_memory_access
+                .unwrap_or_default(),
+        }
+    }
 }

--- a/interp/src/configuration.rs
+++ b/interp/src/configuration.rs
@@ -3,7 +3,10 @@ use once_cell::sync::OnceCell;
 static SETTINGS: OnceCell<Config> = OnceCell::new();
 
 pub fn get_config() -> &'static Config {
-    SETTINGS.get().expect("Config not initialized")
+    SETTINGS.get().unwrap_or_else(|| {
+        init_default_config();
+        SETTINGS.get().unwrap()
+    })
 }
 
 pub fn init_config(conf: Config) {
@@ -12,6 +15,10 @@ pub fn init_config(conf: Config) {
         .expect("Failed to set config, perhaps it is already initialized");
 }
 
+#[allow(unused_must_use)]
+pub fn init_default_config() {
+    SETTINGS.set(Config::default());
+}
 // this can be a copy type because it's just a bunch of bools
 #[derive(Debug, Default, Clone, Copy)]
 /// Configuration struct which controls runtime behavior

--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -42,7 +42,6 @@ impl Debugger {
     pub fn main_loop(
         &mut self,
         env: InterpreterState,
-        pass_through: bool, //flag to just evaluate the debugger version (non-interactive mode)
     ) -> InterpreterResult<InterpreterState> {
         let qin = ComponentQualifiedInstanceName::new_single(
             &self.main_component,
@@ -54,11 +53,6 @@ impl Debugger {
             qin,
         );
         component_interpreter.set_go_high();
-
-        if pass_through {
-            component_interpreter.run()?;
-            return component_interpreter.deconstruct();
-        }
 
         let mut input_stream = Input::default();
         println!("== Calyx Interactive Debugger ==");

--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -1,22 +1,21 @@
-use std::cell::Ref;
-use std::collections::HashMap;
-use std::rc::Rc;
+use std::{cell::Ref, collections::HashMap, rc::Rc};
 
-use super::commands::{Command, PrintCode, PrintMode};
-use super::context::DebuggingContext;
-use super::io_utils::Input;
+use super::{
+    commands::{Command, PrintCode, PrintMode},
+    context::DebuggingContext,
+    interactive_errors::DebuggerError,
+    io_utils::Input,
+};
 use crate::environment::{InterpreterState, PrimitiveMap, StateView};
 use crate::errors::{InterpreterError, InterpreterResult};
-use crate::interpreter::{ComponentInterpreter, Interpreter};
-use crate::interpreter_ir as iir;
-use crate::primitives::Serializeable;
+use crate::interpreter::{ComponentInterpreter, ConstCell, Interpreter};
 use crate::structures::names::{CompGroupName, ComponentQualifiedInstanceName};
 use crate::utils::AsRaw;
+use crate::{interpreter_ir as iir, primitives::Serializeable};
 use calyx::ir::{self, Id, RRC};
-pub(super) const SPACING: &str = "    ";
-use super::interactive_errors::DebuggerError;
-use crate::interpreter::ConstCell;
 use std::fmt::Write;
+
+pub(super) const SPACING: &str = "    ";
 
 /// The interactive Calyx debugger. The debugger itself is run with the
 /// [main_loop] function while this struct holds auxilliary information used to

--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -15,6 +15,7 @@ use crate::{interpreter_ir as iir, primitives::Serializeable};
 use calyx::ir::{self, Id, RRC};
 use std::fmt::Write;
 
+/// Constant amount of space used for debugger messages
 pub(super) const SPACING: &str = "    ";
 
 /// The interactive Calyx debugger. The debugger itself is run with the

--- a/interp/src/interpreter/group_interpreter.rs
+++ b/interp/src/interpreter/group_interpreter.rs
@@ -194,6 +194,8 @@ impl AssignmentInterpreter {
     pub fn step_convergence(&mut self) -> InterpreterResult<()> {
         self.val_changed = Some(true); // always run convergence if called
 
+        let mut first_iteration = true;
+
         // this unwrap is safe
         while self.val_changed.unwrap() {
             let mut assigned_ports: HashSet<PortAssignment> = HashSet::new();
@@ -304,7 +306,11 @@ impl AssignmentInterpreter {
             let changed = eval_prims(
                 &mut self.state,
                 if cfg!(feature = "change-based-sim") {
-                    cells_to_run_rrc.iter()
+                    if first_iteration {
+                        self.cells.iter()
+                    } else {
+                        cells_to_run_rrc.iter()
+                    }
                 } else {
                     self.cells.iter()
                 },
@@ -312,6 +318,10 @@ impl AssignmentInterpreter {
             )?;
             if changed {
                 self.val_changed = Some(true);
+            }
+
+            if cfg!(feature = "change-based-sim") {
+                first_iteration = false;
             }
         }
         Ok(())

--- a/interp/src/interpreter/group_interpreter.rs
+++ b/interp/src/interpreter/group_interpreter.rs
@@ -239,10 +239,11 @@ impl AssignmentInterpreter {
                         self.state.get_from_port(&assignment.src.borrow());
                     // no need to make updates if the value has not changed
                     let port = assignment.dst.clone(); // Rc clone
-                    let new_val = new_val_ref.clone();
 
                     if old_val != new_val_ref {
-                        if cfg!(change_based_sim) {
+                        let new_val = new_val_ref.clone();
+
+                        if cfg!(feature = "change-based-sim") {
                             let pref = port.borrow();
 
                             if let ir::PortParent::Cell(cell) = &pref.parent {
@@ -278,7 +279,7 @@ impl AssignmentInterpreter {
                 let new_val = Value::from(0, old_val_width);
 
                 if old_val.as_unsigned() != 0_u32.into() {
-                    if cfg!(change_based_sim) {
+                    if cfg!(feature = "change-based-sim") {
                         let port_ref = &self.port_lookup_map[&port].borrow();
                         if let ir::PortParent::Cell(cell) = &port_ref.parent {
                             let cell_rrc = cell.upgrade();
@@ -302,7 +303,7 @@ impl AssignmentInterpreter {
 
             let changed = eval_prims(
                 &mut self.state,
-                if cfg!(change_based_sim) {
+                if cfg!(feature = "change-based-sim") {
                     cells_to_run_rrc.iter()
                 } else {
                     self.cells.iter()

--- a/interp/src/interpreter/group_interpreter.rs
+++ b/interp/src/interpreter/group_interpreter.rs
@@ -194,6 +194,7 @@ impl AssignmentInterpreter {
     pub fn step_convergence(&mut self) -> InterpreterResult<()> {
         self.val_changed = Some(true); // always run convergence if called
 
+        // only used when compiled with change-based-sim feature
         let mut first_iteration = true;
 
         // this unwrap is safe

--- a/interp/src/lib.rs
+++ b/interp/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod interpreter;
 pub mod primitives;
 pub use utils::MemoryMap;
-mod configuration;
+pub mod configuration;
 pub mod debugger;
 pub mod errors;
 pub mod interpreter_ir;
@@ -11,5 +11,4 @@ mod structures;
 mod tests;
 mod utils;
 
-pub use configuration::SETTINGS;
 pub use structures::{environment, stk_env, values};

--- a/interp/src/logging.rs
+++ b/interp/src/logging.rs
@@ -10,6 +10,10 @@ use slog::{Drain, Level};
 
 static ROOT_LOGGER: OnceCell<Logger> = OnceCell::new();
 
+pub fn initialze_default_logger() {
+    initialze_logger(&Config::default());
+}
+
 pub fn initialze_logger(config: &Config) {
     let decorator = slog_term::TermDecorator::new().stderr().build();
     let drain = slog_term::FullFormat::new(decorator).build();
@@ -24,13 +28,17 @@ pub fn initialze_logger(config: &Config) {
 
     let logger = slog::Logger::root(drain, o!());
 
-    ROOT_LOGGER
-        .set(logger)
-        .expect("Failed to set logger, perhaps it is already initialized");
+    #[allow(unused_must_use)]
+    {
+        ROOT_LOGGER.set(logger);
+    }
 }
 
 pub fn root() -> &'static Logger {
-    ROOT_LOGGER.get().expect("logger not initialized")
+    ROOT_LOGGER.get().unwrap_or_else(|| {
+        initialze_default_logger();
+        ROOT_LOGGER.get().unwrap()
+    })
 }
 
 /// Utility method for creating subloggers for components/primitives/etc. This

--- a/interp/src/logging.rs
+++ b/interp/src/logging.rs
@@ -5,23 +5,18 @@ pub use slog::Logger;
 #[allow(unused_imports)]
 pub(crate) use slog::{debug, error, info, o, trace, warn};
 
-use crate::configuration::Config;
 use slog::{Drain, Level};
 
 static ROOT_LOGGER: OnceCell<Logger> = OnceCell::new();
 
 pub fn initialze_default_logger() {
-    initialze_logger(&Config::default());
+    initialze_logger(false);
 }
 
-pub fn initialze_logger(config: &Config) {
+pub fn initialze_logger(quiet: bool) {
     let decorator = slog_term::TermDecorator::new().stderr().build();
     let drain = slog_term::FullFormat::new(decorator).build();
-    let filter_level = if config.quiet {
-        Level::Error
-    } else {
-        Level::Trace
-    };
+    let filter_level = if quiet { Level::Error } else { Level::Trace };
     let drain = drain.filter_level(filter_level).fuse();
 
     let drain = slog_async::Async::new(drain).build().fuse();

--- a/interp/src/logging.rs
+++ b/interp/src/logging.rs
@@ -1,35 +1,41 @@
-use lazy_static::*;
+use once_cell::sync::OnceCell;
 
 // re-export for convenience
 pub use slog::Logger;
 #[allow(unused_imports)]
 pub(crate) use slog::{debug, error, info, o, trace, warn};
 
+use crate::configuration::Config;
 use slog::{Drain, Level};
 
-lazy_static! {
-    /// Global root logger. Note should be initialized after SETTINGS to ensure
-    /// warning suppression, if desired. Directly using the root logger is not
-    /// recommended unless a sublogger is unavailable (see [new_sublogger]).
-    pub static ref ROOT_LOGGER: Logger = {
-        let decorator = slog_term::TermDecorator::new().stderr().build();
-        let drain = slog_term::FullFormat::new(decorator).build();
-        let filter_level = if crate::configuration::SETTINGS.read().quiet {
-            Level::Error
-        } else {
-            Level::Trace
-        };
-        let drain = drain.filter_level(filter_level).fuse();
+static ROOT_LOGGER: OnceCell<Logger> = OnceCell::new();
 
-        let drain = slog_async::Async::new(drain).build().fuse();
-
-        slog::Logger::root(drain, o!())
+pub fn initialze_logger(config: &Config) {
+    let decorator = slog_term::TermDecorator::new().stderr().build();
+    let drain = slog_term::FullFormat::new(decorator).build();
+    let filter_level = if config.quiet {
+        Level::Error
+    } else {
+        Level::Trace
     };
+    let drain = drain.filter_level(filter_level).fuse();
+
+    let drain = slog_async::Async::new(drain).build().fuse();
+
+    let logger = slog::Logger::root(drain, o!());
+
+    ROOT_LOGGER
+        .set(logger)
+        .expect("Failed to set logger, perhaps it is already initialized");
+}
+
+pub fn root() -> &'static Logger {
+    ROOT_LOGGER.get().expect("logger not initialized")
 }
 
 /// Utility method for creating subloggers for components/primitives/etc. This
 /// is the prefered method for getting a logger. Initializes the source key with
 /// the supplied name.
 pub fn new_sublogger<S: AsRef<str>>(source_name: S) -> Logger {
-    ROOT_LOGGER.new(o!("source" => String::from(source_name.as_ref())))
+    root().new(o!("source" => String::from(source_name.as_ref())))
 }

--- a/interp/src/macros.rs
+++ b/interp/src/macros.rs
@@ -17,6 +17,7 @@
 /// `StdAdd::new(bindings: ir::Params)` and `StdAdd::from_constants(ports)`
 ///
 /// TODO(rachit): $out_width is never used.
+/// (TODO: Griffin) fix the copy-paste
 #[macro_export]
 macro_rules! comb_primitive {
     ($name:ident[
@@ -26,6 +27,40 @@ macro_rules! comb_primitive {
     ) => {
         comb_primitive!(LOG; NAME; $name[$( $param ),+]($( $port : $width ),+) -> ($($out : $out_width),+ ) $execute);
     };
+
+
+    (FLAG : $flag:ident; LOG: $log:ident; $name:ident[
+        $( $param:ident ),+
+    ]( $( $port:ident : $width:ident ),+ ) ->
+     ( $( $out:ident : $out_width:ident ),+ ) $execute:block
+    ) => {
+        comb_primitive!($flag; $log; NAME; $name[$( $param ),+]($( $port : $width ),+) -> ($($out : $out_width),+ ) $execute);
+    };
+
+    (LOG: $log:ident; FLAG : $flag:ident; $name:ident[
+        $( $param:ident ),+
+    ]( $( $port:ident : $width:ident ),+ ) ->
+     ( $( $out:ident : $out_width:ident ),+ ) $execute:block
+    ) => {
+        comb_primitive!($flag; $log; NAME; $name[$( $param ),+]($( $port : $width ),+) -> ($($out : $out_width),+ ) $execute);
+    };
+
+    (FLAG : $flag:ident; $name:ident[
+        $( $param:ident ),+
+    ]( $( $port:ident : $width:ident ),+ ) ->
+     ( $( $out:ident : $out_width:ident ),+ ) $execute:block
+    ) => {
+        comb_primitive!($flag; LOG; NAME; $name[$( $param ),+]($( $port : $width ),+) -> ($($out : $out_width),+ ) $execute);
+    };
+
+    (FLAG : $flag:ident; NAME : $full_name:ident; $name:ident[
+        $( $param:ident ),+
+    ]( $( $port:ident : $width:ident ),+ ) ->
+     ( $( $out:ident : $out_width:ident ),+ ) $execute:block
+    ) => {
+        comb_primitive!($flag; LOG; $full_name; $name[$( $param ),+]($( $port : $width ),+) -> ($($out : $out_width),+ ) $execute);
+    };
+
 
     (LOG : $log:ident; $name:ident[
         $( $param:ident ),+
@@ -151,6 +186,138 @@ macro_rules! comb_primitive {
                         .expect(&format!("No value for port: {}", $crate::in_fix!($port)).to_string()) ),+,
                     &self.logger,
                     $crate::primitives::Named::get_full_name(self),
+                )?;
+
+                return Ok(vec![
+                    $( ($crate::in_fix!($out).into(), $out) ),+
+                ])
+
+            }
+
+            // Combinational components cannot be reset
+            fn reset(
+                &mut self,
+                inputs: &[(calyx::ir::Id, &$crate::values::Value)],
+            ) -> $crate::errors::InterpreterResult<Vec<(calyx::ir::Id, $crate::values::Value)>> {
+                self.execute(inputs)
+            }
+
+        }
+    };
+
+    ($flag: ident; $log:ident; $full_name:ident; $name:ident[
+        $( $param:ident ),+
+    ]( $( $port:ident : $width:ident ),+ ) ->
+     ( $( $out:ident : $out_width:ident ),+ ) $execute:block
+    ) => {
+        #[derive(Clone, Debug)]
+        #[allow(non_snake_case)]
+        pub struct $name {
+            $($param: u64),+,
+            name: calyx::ir::Id,
+            logger: $crate::logging::Logger,
+            $flag: bool
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self {
+                    name: "".into(),
+                    logger: $crate::logging::new_sublogger(""),
+                    $flag: false,
+                    $($param: 0),+,
+                }
+            }
+        }
+
+
+        impl $name {
+            pub fn new(params: &calyx::ir::Binding, name: calyx::ir::Id, $flag: bool) -> Self {
+                let mut base = Self::default();
+                for (param, value) in params {
+                    match param.as_ref() {
+                        $( $crate::in_fix!($param) => base.$param = *value ),+,
+                        p => unreachable!(format!("Unknown parameter: {}", p)),
+                    }
+                }
+                base.logger = $crate::logging::new_sublogger(&name);
+                base.name = name;
+                base.$flag = $flag;
+                base
+            }
+
+            #[allow(non_snake_case)]
+            pub fn from_constants($( $param: u64 ),+, name: calyx::ir::Id, $flag: bool) -> Self {
+                $name {
+                    $($param),+,
+                    logger: $crate::logging::new_sublogger(&name),
+                    name,
+                    $flag
+                }
+            }
+        }
+
+        impl $crate::primitives::Named for $name {
+            fn get_full_name(&self) -> &calyx::ir::Id {
+                &self.name
+            }
+        }
+
+
+        impl $crate::primitives::Primitive for $name {
+
+            //null-op; comb don't use do_tick()
+            fn do_tick(&mut self) -> $crate::errors::InterpreterResult<Vec<(calyx::ir::Id, $crate::values::Value)>>{
+                Ok(vec![])
+            }
+
+            fn is_comb(&self) -> bool { true }
+
+            fn validate(
+                &self,
+                inputs: &[(calyx::ir::Id, &$crate::values::Value)]
+            ) {
+                for (id, v) in inputs {
+                    match id.as_ref() {
+                        $( $crate::in_fix!($port) => assert_eq!(v.len() as u64, self.$width) ),+,
+                        p => unreachable!(format!("Unknown port: {}", p)),
+                    }
+                }
+            }
+
+            #[allow(non_snake_case,unused)]
+            fn execute(
+                &mut self,
+                inputs: &[(calyx::ir::Id, &$crate::values::Value)],
+            ) -> $crate::errors::InterpreterResult<Vec<(calyx::ir::Id, $crate::values::Value)>> {
+
+                #[derive(Default)]
+                struct Ports<'a> {
+                    $( $port: Option<&'a $crate::values::Value> ),+
+                }
+
+                let mut base = Ports::default();
+
+                for (id, v) in inputs {
+                    match id.as_ref() {
+                        $( $crate::in_fix!($port) => base.$port = Some(v) ),+,
+                        p => unreachable!(format!("Unknown port: {}", p)),
+                    }
+                }
+
+                let exec_func = |$($param: u64),+, $( $port: &Value ),+, $log: &$crate::logging::Logger, $full_name:&calyx::ir::Id, $flag: bool| -> $crate::errors::InterpreterResult<Value> {
+                    $execute
+                };
+
+                #[allow(unused_parens)]
+                let ($( $out ),+) = exec_func(
+                    $(self.$param),+,
+                    $( base
+                        .$port
+                        .expect(&format!("No value for port: {}", $crate::in_fix!($port)).to_string()) ),+,
+                    &self.logger,
+                    $crate::primitives::Named::get_full_name(self),
+                    self.$flag
                 )?;
 
                 return Ok(vec![

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -111,8 +111,7 @@ fn main() -> InterpreterResult<()> {
         .allow_par_conflicts(opts.allow_par_conflicts)
         .build();
 
-    interp::logging::initialze_logger(&config);
-    configuration::init_config(config);
+    interp::logging::initialze_logger(config.quiet);
 
     let log = interp::logging::root();
 
@@ -145,8 +144,12 @@ fn main() -> InterpreterResult<()> {
 
     let mems = interp::MemoryMap::inflate_map(&opts.data_file)?;
 
-    let env =
-        InterpreterState::init_top_level(&components, main_component, &mems)?;
+    let env = InterpreterState::init_top_level(
+        &components,
+        main_component,
+        &mems,
+        &config,
+    )?;
     let res = match opts.comm.unwrap_or(Command::Interpret(CommandInterpret {}))
     {
         Command::Interpret(_) => {

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -81,11 +81,7 @@ struct CommandInterpret {}
 #[derive(FromArgs)]
 #[argh(subcommand, name = "debug")]
 /// Interpret the given program with the interactive debugger
-struct CommandDebug {
-    #[argh(switch, short = 'p', long = "pass-through")]
-    /// flag which runs the program to completion through the debugger
-    pass_through: bool,
-}
+struct CommandDebug {}
 
 #[inline]
 fn print_res(
@@ -161,9 +157,9 @@ fn main() -> InterpreterResult<()> {
         Command::Interpret(_) => {
             ComponentInterpreter::interpret_program(env, main_component)
         }
-        Command::Debug(CommandDebug { pass_through }) => {
+        Command::Debug(CommandDebug {}) => {
             let mut cidb = Debugger::new(&components, main_component);
-            cidb.main_loop(env, pass_through)
+            cidb.main_loop(env)
         }
     };
 

--- a/interp/src/primitives/combinational.rs
+++ b/interp/src/primitives/combinational.rs
@@ -200,7 +200,7 @@ comb_primitive!(FLAG: error_on_overflow; NAME: full_name; StdSub[WIDTH](left: WI
 });
 
 // TODO (Griffin): Make these wrappers around the normal add
-comb_primitive!(StdFpAdd[WIDTH, INT_WIDTH, FRAC_WIDTH](left: WIDTH, right: WIDTH) -> (out: WIDTH) {
+comb_primitive!(FLAG: error_on_overflow; LOG: logger; StdFpAdd[WIDTH, INT_WIDTH, FRAC_WIDTH](left: WIDTH, right: WIDTH) -> (out: WIDTH) {
     let a_iter = left.iter();
     let b_iter = right.iter();
     let mut c_in = false;
@@ -215,14 +215,20 @@ comb_primitive!(StdFpAdd[WIDTH, INT_WIDTH, FRAC_WIDTH](left: WIDTH, right: WIDTH
         c_in = bi & c_in || ai & c_in || ai & bi || ai & c_in & bi;
     }
     let tr = Value::from_bv(sum);
+    if c_in {
+        if error_on_overflow {
+            return Err(InterpreterError::OverflowError());
+        }
+        warn!(logger, "Computation over/underflow");
+    }
     //as a sanity check, check tr has same width as left
-    assert_eq!(tr.width(), left.width());
+    debug_assert_eq!(tr.width(), left.width());
     Ok(tr)
 });
-comb_primitive!(NAME: NAME; StdFpSub[WIDTH, INT_WIDTH, FRAC_WIDTH](left: WIDTH, right: WIDTH) -> (out: WIDTH) {
+comb_primitive!(FLAG: error_on_overflow; NAME: full_name; StdFpSub[WIDTH, INT_WIDTH, FRAC_WIDTH](left: WIDTH, right: WIDTH) -> (out: WIDTH) {
     //first turn right into ~right + 1
     let new_right = !right.clone_bit_vec();
-    let mut adder = StdFpAdd::from_constants(WIDTH, INT_WIDTH, FRAC_WIDTH, NAME.clone());
+    let mut adder = StdFpAdd::from_constants(WIDTH, INT_WIDTH, FRAC_WIDTH, full_name.clone(), error_on_overflow);
     let new_right = adder
         .execute(
             &[("left".into(), &Value::from_bv(new_right)),

--- a/interp/src/primitives/combinational.rs
+++ b/interp/src/primitives/combinational.rs
@@ -179,7 +179,7 @@ comb_primitive!(FLAG: error_on_overflow; LOG: logger; StdAdd[WIDTH](left: WIDTH,
     }
     let tr: Value = sum.into();
     //as a sanity check, check tr has same width as left
-    assert_eq!(tr.width(), left.width());
+    debug_assert_eq!(tr.width(), left.width());
     Ok(tr)
 });
 comb_primitive!(FLAG: error_on_overflow; NAME: full_name; StdSub[WIDTH](left: WIDTH, right: WIDTH) -> (out: WIDTH) {

--- a/interp/src/primitives/combinational.rs
+++ b/interp/src/primitives/combinational.rs
@@ -172,7 +172,7 @@ comb_primitive!(LOG: logger; StdAdd[WIDTH](left: WIDTH, right: WIDTH) -> (out: W
         c_in = bi & c_in || ai & c_in || ai & bi || ai & c_in & bi;
     }
     if c_in {
-        if crate::SETTINGS.read().error_on_overflow {
+        if crate::configuration::get_config().error_on_overflow {
             return Err(InterpreterError::OverflowError());
         }
         warn!(logger, "Computation over/underflow");

--- a/interp/src/primitives/stateful.rs
+++ b/interp/src/primitives/stateful.rs
@@ -69,7 +69,7 @@ impl<const SIGNED: bool> Primitive for StdMultPipe<SIGNED> {
                 )
             };
 
-            if overflow & crate::SETTINGS.read().error_on_overflow {
+            if overflow & crate::configuration::get_config().error_on_overflow {
                 return Err(InterpreterError::OverflowError());
             } else if overflow {
                 warn!(
@@ -248,7 +248,9 @@ impl<const SIGNED: bool> Primitive for StdDivPipe<SIGNED> {
                 // the only way this is possible is if the division is signed and the
                 // min_val is divided by negative one as the resultant postitive value will
                 // not be representable in the desired bit width
-                if (overflow) & crate::SETTINGS.read().error_on_overflow {
+                if (overflow)
+                    & crate::configuration::get_config().error_on_overflow
+                {
                     return Err(InterpreterError::OverflowError());
                 } else if overflow {
                     warn!(
@@ -559,7 +561,7 @@ impl Primitive for StdMemD1 {
         //if there is an update, update and return along w/ a done
         //else this memory was used combinationally and there is nothing to tick
         if self.last_index >= self.size {
-            if crate::SETTINGS.read().allow_invalid_memory_access {
+            if crate::configuration::get_config().allow_invalid_memory_access {
                 if self.write_en {
                     return Ok(vec![
                         (ir::Id::from("read_data"), Value::zeroes(self.width)),
@@ -816,7 +818,7 @@ impl Primitive for StdMemD2 {
     //null-op for now
     fn do_tick(&mut self) -> InterpreterResult<Vec<(ir::Id, Value)>> {
         if self.calc_addr(self.last_idx.0, self.last_idx.1) >= self.max_idx() {
-            if crate::SETTINGS.read().allow_invalid_memory_access {
+            if crate::configuration::get_config().allow_invalid_memory_access {
                 if self.write_en {
                     return Ok(vec![
                         (ir::Id::from("read_data"), Value::zeroes(self.width)),
@@ -1095,7 +1097,7 @@ impl Primitive for StdMemD3 {
     fn do_tick(&mut self) -> InterpreterResult<Vec<(ir::Id, Value)>> {
         let (addr0, addr1, addr2) = self.last_idx;
         if self.calc_addr(addr0, addr1, addr2) >= self.max_idx() {
-            if crate::SETTINGS.read().allow_invalid_memory_access {
+            if crate::configuration::get_config().allow_invalid_memory_access {
                 if self.write_en {
                     return Ok(vec![
                         (ir::Id::from("read_data"), Value::zeroes(self.width)),
@@ -1410,7 +1412,7 @@ impl Primitive for StdMemD4 {
     fn do_tick(&mut self) -> InterpreterResult<Vec<(ir::Id, Value)>> {
         let (addr0, addr1, addr2, addr3) = self.last_idx;
         if self.calc_addr(addr0, addr1, addr2, addr3) >= self.max_idx() {
-            if crate::SETTINGS.read().allow_invalid_memory_access {
+            if crate::configuration::get_config().allow_invalid_memory_access {
                 if self.write_en {
                     return Ok(vec![
                         (ir::Id::from("read_data"), Value::zeroes(self.width)),

--- a/interp/src/structures/environment.rs
+++ b/interp/src/structures/environment.rs
@@ -146,10 +146,18 @@ impl InterpreterState {
             )),
             // fp basic arith
             "std_fp_sadd" | "std_fp_add" => {
-                Box::new(combinational::StdFpAdd::new(params, cell_qin))
+                Box::new(combinational::StdFpAdd::new(
+                    params,
+                    cell_qin,
+                    configs.error_on_overflow,
+                ))
             }
             "std_fp_ssub" | "std_fp_sub" => {
-                Box::new(combinational::StdFpSub::new(params, cell_qin))
+                Box::new(combinational::StdFpSub::new(
+                    params,
+                    cell_qin,
+                    configs.error_on_overflow,
+                ))
             }
             // unsigned arith
             "std_mult_pipe" => Box::new(stateful::StdMultPipe::<false>::new(

--- a/interp/src/structures/environment.rs
+++ b/interp/src/structures/environment.rs
@@ -5,6 +5,7 @@ use super::names::{
     QualifiedInstanceName,
 };
 use super::stk_env::Smoosher;
+use crate::configuration::Config;
 use crate::debugger::name_tree::ActiveTreeNode;
 use crate::debugger::PrintCode;
 use crate::errors::{InterpreterError, InterpreterResult};
@@ -62,6 +63,8 @@ pub struct InterpreterState {
     pub component: Rc<iir::Component>,
 
     pub sub_comp_set: Rc<HashSet<ConstCell>>,
+
+    allow_par_conflicts: bool,
 }
 
 /// Helper functions for the environment.
@@ -72,11 +75,13 @@ impl InterpreterState {
         ctx: &iir::ComponentCtx,
         target: &Rc<iir::Component>,
         mems: &Option<MemoryMap>,
+        configs: &Config,
     ) -> InterpreterResult<Self> {
         // only for the main component
         let qin =
             ComponentQualifiedInstanceName::new_single(target, &target.name);
-        let (map, set) = Self::construct_cell_map(target, ctx, mems, &qin)?;
+        let (map, set) =
+            Self::construct_cell_map(target, ctx, mems, &qin, configs)?;
 
         Ok(Self {
             context: Rc::clone(ctx),
@@ -85,6 +90,7 @@ impl InterpreterState {
             cell_map: map,
             component: target.clone(),
             sub_comp_set: Rc::new(set),
+            allow_par_conflicts: configs.allow_par_conflicts,
         })
     }
 
@@ -93,8 +99,10 @@ impl InterpreterState {
         target: &Rc<iir::Component>,
         mems: &Option<MemoryMap>,
         qin: &ComponentQualifiedInstanceName,
+        configs: &Config,
     ) -> InterpreterResult<Self> {
-        let (map, set) = Self::construct_cell_map(target, ctx, mems, qin)?;
+        let (map, set) =
+            Self::construct_cell_map(target, ctx, mems, qin, configs)?;
 
         Ok(Self {
             context: Rc::clone(ctx),
@@ -103,6 +111,7 @@ impl InterpreterState {
             cell_map: map,
             component: target.clone(),
             sub_comp_set: Rc::new(set),
+            allow_par_conflicts: configs.allow_par_conflicts,
         })
     }
 
@@ -117,6 +126,7 @@ impl InterpreterState {
         cell_name: &ir::Id,
         mems: &Option<MemoryMap>,
         qin_name: &ComponentQualifiedInstanceName,
+        configs: &Config,
     ) -> InterpreterResult<Box<dyn Primitive>> {
         let cell_qin = QualifiedInstanceName::new(qin_name, cell_name).as_id();
         Ok(match prim_name.as_ref() {
@@ -124,12 +134,16 @@ impl InterpreterState {
                 Box::new(combinational::StdConst::new(params, cell_qin))
             }
             // unsigned and signed basic arith
-            "std_add" | "std_sadd" => {
-                Box::new(combinational::StdAdd::new(params, cell_qin))
-            }
-            "std_sub" | "std_ssub" => {
-                Box::new(combinational::StdSub::new(params, cell_qin))
-            }
+            "std_add" | "std_sadd" => Box::new(combinational::StdAdd::new(
+                params,
+                cell_qin,
+                configs.error_on_overflow,
+            )),
+            "std_sub" | "std_ssub" => Box::new(combinational::StdSub::new(
+                params,
+                cell_qin,
+                configs.error_on_overflow,
+            )),
             // fp basic arith
             "std_fp_sadd" | "std_fp_add" => {
                 Box::new(combinational::StdFpAdd::new(params, cell_qin))
@@ -138,19 +152,27 @@ impl InterpreterState {
                 Box::new(combinational::StdFpSub::new(params, cell_qin))
             }
             // unsigned arith
-            "std_mult_pipe" => {
-                Box::new(stateful::StdMultPipe::<false>::new(params, cell_qin))
-            }
-            "std_div_pipe" => {
-                Box::new(stateful::StdDivPipe::<false>::new(params, cell_qin))
-            }
+            "std_mult_pipe" => Box::new(stateful::StdMultPipe::<false>::new(
+                params,
+                cell_qin,
+                configs.error_on_overflow,
+            )),
+            "std_div_pipe" => Box::new(stateful::StdDivPipe::<false>::new(
+                params,
+                cell_qin,
+                configs.error_on_overflow,
+            )),
             // signed arith
-            "std_smult_pipe" => {
-                Box::new(stateful::StdMultPipe::<true>::new(params, cell_qin))
-            }
-            "std_sdiv_pipe" => {
-                Box::new(stateful::StdDivPipe::<true>::new(params, cell_qin))
-            }
+            "std_smult_pipe" => Box::new(stateful::StdMultPipe::<true>::new(
+                params,
+                cell_qin,
+                configs.error_on_overflow,
+            )),
+            "std_sdiv_pipe" => Box::new(stateful::StdDivPipe::<true>::new(
+                params,
+                cell_qin,
+                configs.error_on_overflow,
+            )),
             // fp unsigned arith
             "std_fp_mult_pipe" => Box::new(
                 stateful::StdFpMultPipe::<false>::new(params, cell_qin),
@@ -211,8 +233,11 @@ impl InterpreterState {
             // State components
             "std_reg" => Box::new(stateful::StdReg::new(params, cell_qin)),
             "std_mem_d1" => {
-                let mut prim =
-                    Box::new(stateful::StdMemD1::new(params, cell_qin));
+                let mut prim = Box::new(stateful::StdMemD1::new(
+                    params,
+                    cell_qin,
+                    configs.allow_invalid_memory_access,
+                ));
 
                 let init = mems.as_ref().and_then(|x| x.get(cell_name));
 
@@ -222,8 +247,11 @@ impl InterpreterState {
                 prim
             }
             "std_mem_d2" => {
-                let mut prim =
-                    Box::new(stateful::StdMemD2::new(params, cell_qin));
+                let mut prim = Box::new(stateful::StdMemD2::new(
+                    params,
+                    cell_qin,
+                    configs.allow_invalid_memory_access,
+                ));
 
                 let init = mems.as_ref().and_then(|x| x.get(cell_name));
 
@@ -233,8 +261,11 @@ impl InterpreterState {
                 prim
             }
             "std_mem_d3" => {
-                let mut prim =
-                    Box::new(stateful::StdMemD3::new(params, cell_qin));
+                let mut prim = Box::new(stateful::StdMemD3::new(
+                    params,
+                    cell_qin,
+                    configs.allow_invalid_memory_access,
+                ));
 
                 let init = mems.as_ref().and_then(|x| x.get(cell_name));
 
@@ -244,8 +275,11 @@ impl InterpreterState {
                 prim
             }
             "std_mem_d4" => {
-                let mut prim =
-                    Box::new(stateful::StdMemD4::new(params, cell_qin));
+                let mut prim = Box::new(stateful::StdMemD4::new(
+                    params,
+                    cell_qin,
+                    configs.allow_invalid_memory_access,
+                ));
 
                 let init = mems.as_ref().and_then(|x| x.get(cell_name));
 
@@ -264,6 +298,7 @@ impl InterpreterState {
         ctx: &iir::ComponentCtx,
         mems: &Option<MemoryMap>,
         qin_name: &ComponentQualifiedInstanceName,
+        configs: &Config,
     ) -> InterpreterResult<(PrimitiveMap, HashSet<ConstCell>)> {
         let mut map = HashMap::new();
         let mut set = HashSet::new();
@@ -284,6 +319,7 @@ impl InterpreterState {
                             cl.name(),
                             mems,
                             qin_name,
+                            configs,
                         )?,
                     );
                 }
@@ -292,7 +328,7 @@ impl InterpreterState {
                         ctx.iter().find(|x| x.name == name).unwrap();
                     let qin = qin_name
                         .new_extend(InstanceName::new(inner_comp, cl.name()));
-                    let env = Self::init(ctx, inner_comp, mems, &qin)?;
+                    let env = Self::init(ctx, inner_comp, mems, &qin, configs)?;
                     let comp_interp: Box<dyn Primitive> =
                         Box::new(ComponentInterpreter::from_component(
                             inner_comp, env, qin,
@@ -399,6 +435,7 @@ impl InterpreterState {
             context: Rc::clone(&self.context),
             component: self.component.clone(),
             sub_comp_set: Rc::clone(&self.sub_comp_set),
+            allow_par_conflicts: self.allow_par_conflicts,
         }
     }
     /// Creates a fork of the source environment which has the same clock and
@@ -413,6 +450,7 @@ impl InterpreterState {
             context: Rc::clone(&self.context),
             component: self.component.clone(),
             sub_comp_set: Rc::clone(&self.sub_comp_set),
+            allow_par_conflicts: self.allow_par_conflicts,
         }
     }
 
@@ -433,6 +471,7 @@ impl InterpreterState {
         let merged = port_map.merge_many(
             others.into_iter().map(|x| x.port_map).collect(),
             overlap,
+            self.allow_par_conflicts,
         );
 
         self.port_map = match merged {

--- a/interp/src/structures/stk_env.rs
+++ b/interp/src/structures/stk_env.rs
@@ -864,11 +864,12 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
                         a_head.insert(k, v);
                     } else {
                         let prev = a_head.remove(&k).unwrap();
-                        if crate::SETTINGS.read().allow_par_conflicts
+                        if crate::configuration::get_config()
+                            .allow_par_conflicts
                             && prev == v
                         {
                             crate::logging::warn!(
-                                crate::logging::ROOT_LOGGER,
+                                crate::logging::root(),
                                 "Allowing parallel conflict"
                             )
                         } else {

--- a/interp/src/structures/stk_env.rs
+++ b/interp/src/structures/stk_env.rs
@@ -793,7 +793,7 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     /// lst.push(b);
     /// lst.push(c);
     /// lst.push(e);
-    /// let d = Smoosher::merge_many(a, lst, &HashSet::new()).unwrap();
+    /// let d = Smoosher::merge_many(a, lst, &HashSet::new(), false).unwrap();
     /// assert_eq!(*d.get(&"privet").unwrap(), 11);
     /// assert_eq!(*d.get(&"hi!").unwrap(), 3);
     /// assert_eq!(*d.get(&"bye").unwrap(), 2);
@@ -817,13 +817,14 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     /// let mut lst = Vec::new();
     /// lst.push(b);
     /// lst.push(c);
-    /// let d = Smoosher::merge_many(a, lst, &HashSet::new()); //a and b has a different fork point
+    /// let d = Smoosher::merge_many(a, lst, &HashSet::new(), false); //a and b has a different fork point
     //from a and c
     /// ```
     pub fn merge_many(
         self,
         other: Vec<Self>,
         overlap_keys: &HashSet<K>,
+        allow_par_conflicts: bool,
     ) -> Result<Self, CollisionError<K, V>> {
         if other.is_empty() {
             return Ok(self);
@@ -864,10 +865,7 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
                         a_head.insert(k, v);
                     } else {
                         let prev = a_head.remove(&k).unwrap();
-                        if crate::configuration::get_config()
-                            .allow_par_conflicts
-                            && prev == v
-                        {
+                        if allow_par_conflicts && prev == v {
                             crate::logging::warn!(
                                 crate::logging::root(),
                                 "Allowing parallel conflict"

--- a/interp/src/tests/primitives.rs
+++ b/interp/src/tests/primitives.rs
@@ -9,7 +9,8 @@ use calyx::ir;
 
 #[test]
 fn mult_flickering_go() {
-    let mut mult = stfl::StdMultPipe::<false>::from_constants(32, "".into());
+    let mut mult =
+        stfl::StdMultPipe::<false>::from_constants(32, "".into(), false);
     port_bindings![binds;
         go -> (0, 1),
         left -> (2, 32),
@@ -36,7 +37,8 @@ fn mult_flickering_go() {
 
 #[test]
 fn test_std_mult_pipe() {
-    let mut mult = stfl::StdMultPipe::<false>::from_constants(32, "".into());
+    let mut mult =
+        stfl::StdMultPipe::<false>::from_constants(32, "".into(), false);
     port_bindings![binds;
         go -> (1, 1),
         left -> (2, 32),
@@ -94,7 +96,8 @@ fn test_std_mult_pipe() {
 
 #[test]
 fn test_std_div_pipe() {
-    let mut div = stfl::StdDivPipe::<false>::from_constants(32, "".into());
+    let mut div =
+        stfl::StdDivPipe::<false>::from_constants(32, "".into(), false);
     port_bindings![binds;
         go -> (1, 1),
         left -> (20, 32),
@@ -642,7 +645,7 @@ fn test_std_rsh_above64() {
 fn test_std_add() {
     // without overflow
     // add [0011] (3) and [1010] (10) -> [1101] (13)
-    let mut add = comb::StdAdd::from_constants(4, "".into());
+    let mut add = comb::StdAdd::from_constants(4, "".into(), false);
     port_bindings![binds;
         left -> (3, 4),
         right -> (10, 4)
@@ -674,7 +677,7 @@ fn test_std_add() {
 #[test]
 fn test_std_add_above64() {
     // without overflow
-    let mut add = comb::StdAdd::from_constants(165, "".into());
+    let mut add = comb::StdAdd::from_constants(165, "".into(), false);
     port_bindings![binds;
         left -> (17, 165),
         right -> (35, 165)
@@ -692,7 +695,7 @@ fn test_std_add_above64() {
 #[test]
 #[should_panic]
 fn test_std_add_panic() {
-    let mut add = comb::StdAdd::from_constants(7, "".into());
+    let mut add = comb::StdAdd::from_constants(7, "".into(), false);
     port_bindings![binds;
         left -> (81, 7),
         right -> (10, 4)
@@ -703,7 +706,7 @@ fn test_std_add_panic() {
 fn test_std_sub() {
     // without overflow
     // sub [0110] (6) from [1010] (10) -> [0100] (4)
-    let mut sub = comb::StdSub::from_constants(4, "".into());
+    let mut sub = comb::StdSub::from_constants(4, "".into(), false);
     port_bindings![binds;
         left -> (10, 4),
         right -> (6, 4)
@@ -750,7 +753,7 @@ fn test_std_sub() {
 #[test]
 fn test_std_sub_above64() {
     // without overflow
-    let mut sub = comb::StdSub::from_constants(1605, "".into());
+    let mut sub = comb::StdSub::from_constants(1605, "".into(), false);
     port_bindings![binds;
         left -> (57, 1605),
         right -> (35, 1605)
@@ -768,7 +771,7 @@ fn test_std_sub_above64() {
 #[test]
 #[should_panic]
 fn test_std_sub_panic() {
-    let mut sub = comb::StdAdd::from_constants(5, "".into());
+    let mut sub = comb::StdAdd::from_constants(5, "".into(), false);
     port_bindings![binds;
         left -> (52, 6),
         right -> (16, 5)
@@ -1523,7 +1526,7 @@ mod property_tests {
     proptest! {
         #[test]
         fn std_add(in_left: u128, in_right: u128) {
-            let mut adder = combinational::StdAdd::from_constants(128, "".into());
+            let mut adder = combinational::StdAdd::from_constants(128, "".into(), false);
             port_bindings![binds;
             left -> (in_left, 128),
             right -> (in_right, 128)
@@ -1536,7 +1539,7 @@ mod property_tests {
 
         #[test]
         fn std_sub(in_left: u128, in_right: u128) {
-            let mut sub = combinational::StdSub::from_constants(128, "".into());
+            let mut sub = combinational::StdSub::from_constants(128, "".into(), false);
             port_bindings![binds;
             left -> (in_left, 128),
             right -> (in_right, 128)
@@ -1549,7 +1552,7 @@ mod property_tests {
 
         #[test]
         fn std_mult(in_left: u64, in_right: u64){
-            let mut mult = stateful::StdMultPipe::<false>::from_constants(64, "".into());
+            let mut mult = stateful::StdMultPipe::<false>::from_constants(64, "".into(), false);
             port_bindings![binds;
             left -> (in_left, 64),
             right -> (in_right, 64),
@@ -1565,7 +1568,7 @@ mod property_tests {
 
         #[test]
         fn std_smult(in_left: i64, in_right: i64){
-            let mut mult = stateful::StdMultPipe::<true>::from_constants(64, "".into());
+            let mut mult = stateful::StdMultPipe::<true>::from_constants(64, "".into(), false);
             port_bindings![binds;
             left -> (in_left, 64),
             right -> (in_right, 64),
@@ -1581,7 +1584,7 @@ mod property_tests {
 
         #[test]
         fn std_div(in_left: u64, in_right in (1..u64::MAX)) {
-            let mut mult = stateful::StdDivPipe::<false>::from_constants(64, "".into());
+            let mut mult = stateful::StdDivPipe::<false>::from_constants(64, "".into(), false);
             port_bindings![binds;
             left -> (in_left, 64),
             right -> (in_right, 64),
@@ -1599,7 +1602,7 @@ mod property_tests {
 
         #[test]
         fn std_sdiv(in_left: i64, in_right in (i64::MIN..i64::MAX).prop_filter("non-zero", |v| *v != 0_i64))  {
-            let mut mult = stateful::StdDivPipe::<true>::from_constants(64, "".into());
+            let mut mult = stateful::StdDivPipe::<true>::from_constants(64, "".into(), false);
             port_bindings![binds;
             left -> (in_left, 64),
             right -> (in_right, 64),


### PR DESCRIPTION
Sorry for the eclectic PR, kinda kept jumping from one thing to another on this one. This takes care of a few things that have been on the back of my todo list for a while:
- removes the outmoded `-p` flag from the debugger
- Remove the global config struct and weave the configuration options through the appropriate calls
- Update the root logger to feature an explicit initiation call and replace use of `lazy_static` with `once_cell` to make the deferred initialization easier
- Add an overflow warning to the `StdFpAdd` and `StdFpSub` primitives. Not sure why this was missing in the first place.
- Added a `ConfigBuilder` struct to make putting together the configuration a little nicer. It's not really necessary for anything but it does make me happy, so there's that at least.

This also adds the changed based simulation under a rust feature called `change-based-sim`. You can build the interpreter with it via:
```
cargo build --features change-based-sim
```

or (from the root dir)
```
cargo build --features interp/change-based-sim
```

Numbers to follow soon