### PR TITLE
Separate counter for @bound while

### DIFF
--- a/calyx/src/ir/attribute.rs
+++ b/calyx/src/ir/attribute.rs
@@ -102,13 +102,13 @@ impl<T: GetAttributes> WithPos for T {
     }
 }
 
-impl<S> Index<&S> for Attributes
+impl<S> Index<S> for Attributes
 where
     S: AsRef<str> + std::fmt::Display,
 {
     type Output = u64;
 
-    fn index(&self, key: &S) -> &u64 {
+    fn index(&self, key: S) -> &u64 {
         self.get(&key)
             .unwrap_or_else(|| panic!("No key `{}` in attribute map", key))
     }


### PR DESCRIPTION
Compressing the FSMs generated by `top-down-st` doesn't seem to be enough to make the Verilator errors stop. This attempts to separate out the counter for `@bound` optimized static `while` loops.