### PR TITLE
Error if multiple values for an attribute provided

### DIFF
--- a/tests/errors/multiple-attr-vals.expect
+++ b/tests/errors/multiple-attr-vals.expect
@@ -1,0 +1,9 @@
+---CODE---
+1
+---STDERR---
+Error: Calyx Parser:  --> 4:5
+  |
+4 |     @external(1) @external(2) r = std_reg(32);␊
+  |     ^-----------------------^
+  |
+  = Malformed Structure: Multiple entries for attribute: external

--- a/tests/errors/multiple-attr-vals.futil
+++ b/tests/errors/multiple-attr-vals.futil
@@ -1,0 +1,8 @@
+import "primitives/core.futil";
+component main() -> () {
+  cells {
+    @external(1) @external(2) r = std_reg(32);
+  }
+  wires {}
+  control {}
+}


### PR DESCRIPTION
The attribute structure only support String -> u64 mapping. Previously, if multiple values are provided for the same key, the compiler would silently select the last one. Now, this is an error.
