### PR TITLE
fud state inference for targets

### DIFF
--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -332,7 +332,7 @@ class Configuration:
         target: Optional[str] = None,
         input_file=None,
         output_file=None,
-        through=[]
+        through=[],
     ) -> List[stages.Stage]:
         """
         Construct the path of stages implied by the passed arguments.

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -292,6 +292,9 @@ def main():
         elif args.command == "config":
             if args.edit:
                 os.system(f"{os.getenv('EDITOR')} '{cfg.config_file}'")
+            elif args.remove:
+                log.info(f"Removing {cfg.config_file}")
+                os.remove(cfg.config_file)
             else:
                 display_config(args, cfg)
         elif args.command == "check":
@@ -364,6 +367,14 @@ def config_config(parser):
         "-e",
         "--edit",
         help="Edit the configuration file using $EDITOR",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--remove",
+        help=(
+            "Delete the stored configuration."
+            " Next invocation of `fud` will create a fresh config."
+        ),
         action="store_true",
     )
     parser.add_argument("key", help="The key to perform an action on.", nargs="?")

--- a/fud/fud/registry.py
+++ b/fud/fud/registry.py
@@ -39,7 +39,9 @@ class Registry:
 
         self.graph.add_edge(stage.src_state, stage.target_state, stage=stage)
 
-    def make_path(self, start, dest, through=[]) -> Optional[List[stages.Stage]]:
+    def make_path(
+        self, start: str, dest: str, through=[]
+    ) -> Optional[List[stages.Stage]]:
         """
         Compute a path from `start` to `dest` that contains all stages
         mentioned in `through`.


### PR DESCRIPTION
Fixes the problem with `fud` inferring the wrong state for output files. The inference function was always returning the source of a stage. #867 remains the actual underlying problem here---there is no clear meaning with associating file extensions to stages, which represent transformation from one state to another. The ideal solution would tie file extensions to particular states instead.
