### PR TITLE
Fix the Xilinx tests to work with recent fud

### DIFF
--- a/docs/fud/xilinx.md
+++ b/docs/fud/xilinx.md
@@ -103,7 +103,7 @@ You will also need to configure the stage to point to your installations of [Vit
 The first step in the Xilinx toolchain is to generate [an `xclbin` executable file][xclbin].
 Here's an example of going all the way from a Calyx program to that:
 
-    fud e examples/futil/dot-product.futil -o foo.xclbin
+    fud e examples/futil/dot-product.futil -o foo.xclbin --to xclbin
 
 On our machines, compiling even a simple example like the above for simulation takes about 5 minutes, end to end.
 A failed run takes about 2 minutes to produce an error.

--- a/tests/xilinx/runt.toml
+++ b/tests/xilinx/runt.toml
@@ -11,7 +11,7 @@ paths = [
 ]
 cmd = """
 fud exec -q -s futil.exec '../../target/debug/futil' \
-    {} -o {}.xclbin &&
+    {} -o {}.xclbin --to xclbin &&
     rm {}.xclbin
 """
 


### PR DESCRIPTION
In light of the problems in #867 and #946, the only way to make .xclbin generation work in fud is to combine *both* `-o foo.xclbin` *and* `--to xclbin`. This makes the relevant test do exactly that. It also changes the docs to similarly recommend `--to xclbin`.

(As a quick reminder, the reason we can't do `--to xclbin` by itself is that fud doesn't yet support binary output on stdout. So we must produce a file instead.)

/cc @yn224, who may be interested in this as a way to resolve #888.