### PR TITLE
[Interpreter / Calyx Comp] Fix the reset signals

### DIFF
--- a/interp/src/primitives/stateful.rs
+++ b/interp/src/primitives/stateful.rs
@@ -159,6 +159,7 @@ impl<const SIGNED: bool, const DEPTH: usize> Primitive
                 "left" => assert_eq!(v.len() as u64, self.width),
                 "right" => assert_eq!(v.len() as u64, self.width),
                 "go" => assert_eq!(v.len() as u64, 1),
+                "reset" => assert_eq!(v.len() as u64, 1),
                 p => unreachable!("Unknown port: {}", p),
             }
         }
@@ -366,6 +367,7 @@ impl<const SIGNED: bool> Primitive for StdDivPipe<SIGNED> {
                 "left" => assert_eq!(v.len() as u64, self.width),
                 "right" => assert_eq!(v.len() as u64, self.width),
                 "go" => assert_eq!(v.len() as u64, 1),
+                "reset" => assert_eq!(v.len() as u64, 1),
                 p => unreachable!("Unknown port: {}", p),
             }
         }

--- a/interp/src/structures/environment.rs
+++ b/interp/src/structures/environment.rs
@@ -172,8 +172,12 @@ impl InterpreterState {
                 cell_qin,
                 configs.error_on_overflow,
             )),
-            "sqrt" => Box::new(stateful::StdSqrt::new(params, cell_qin)),
-            "fp_sqrt" => Box::new(stateful::StdFpSqrt::new(params, cell_qin)),
+            "sqrt" => {
+                Box::new(stateful::StdSqrt::<false>::new(params, cell_qin))
+            }
+            "fp_sqrt" => {
+                Box::new(stateful::StdSqrt::<true>::new(params, cell_qin))
+            }
 
             // signed arith
             "std_smult_pipe" => {

--- a/interp/src/tests/primitives.rs
+++ b/interp/src/tests/primitives.rs
@@ -169,7 +169,8 @@ fn test_std_reg_imval() {
     //returns 0, and no DONE
     port_bindings![binds;
         r#in -> (16, 6),
-        write_en -> (0, 1)
+        write_en -> (0, 1),
+        reset -> (0, 1)
     ];
     let output_vals = reg1.validate_and_execute(&binds).unwrap();
     assert_eq!(0, output_vals.len()); //output_vals should be empty from execute
@@ -186,7 +187,8 @@ fn test_std_reg_imval() {
     //now have write_en high and see output from do_tick() is 16, 1
     port_bindings![binds;
         r#in -> (16, 6),
-        write_en -> (1, 1)
+        write_en -> (1, 1),
+        reset -> (0, 1)
     ];
     let output_vals = reg1.validate_and_execute(&binds).unwrap();
     assert_eq!(0, output_vals.len()); //output_vals should be empty from execute
@@ -203,7 +205,8 @@ fn test_std_reg_imval() {
     //now try to overwrite but w/ write_en low, and see 16 and 0 is returned
     port_bindings![binds;
         r#in -> (16, 6),
-        write_en -> (0, 1)
+        write_en -> (0, 1),
+        reset -> (0, 1)
     ];
     let output_vals = reg1.validate_and_execute(&binds).unwrap();
     assert_eq!(0, output_vals.len()); //output_vals should be empty from execute

--- a/interp/src/tests/primitives.rs
+++ b/interp/src/tests/primitives.rs
@@ -13,18 +13,22 @@ fn mult_flickering_go() {
         stfl::StdMultPipe::<false, 2>::from_constants(32, "".into(), false);
     port_bindings![binds;
         go -> (0, 1),
+        reset -> (0, 1),
         left -> (2, 32),
         right -> (7, 32)
     ];
     mult.validate_and_execute(&binds).unwrap();
     port_bindings![binds;
         go -> (1, 1),
+        reset -> (0, 1),
         left -> (3, 32),
         right -> (7, 32)
     ];
     mult.validate_and_execute(&binds).unwrap();
     mult.do_tick().unwrap();
+    mult.validate_and_execute(&binds).unwrap();
     mult.do_tick().unwrap();
+    mult.validate_and_execute(&binds).unwrap();
     let mut output_vals = mult.do_tick().unwrap().into_iter(); //should output done and 21, not 14
     assert_eq!(output_vals.len(), 2);
     let out = output_vals.next().unwrap().1;
@@ -41,6 +45,7 @@ fn test_std_mult_pipe() {
         stfl::StdMultPipe::<false, 2>::from_constants(32, "".into(), false);
     port_bindings![binds;
         go -> (1, 1),
+        reset -> (0, 1),
         left -> (2, 32),
         right -> (7, 32)
     ];
@@ -51,6 +56,7 @@ fn test_std_mult_pipe() {
     assert_eq!(output_vals.len(), 2);
     port_bindings![binds;
         go -> (1, 1),
+        reset -> (0, 1),
         left -> (3, 32),
         right -> (7, 32)
     ];
@@ -62,6 +68,7 @@ fn test_std_mult_pipe() {
     mult.validate_and_execute(&binds).unwrap();
     port_bindings![binds;
         go -> (0, 1), //b/c go is low, this should not overwrite 3*7!
+        reset -> (0, 1),
         left -> (4, 32),
         right -> (7, 32)
     ];
@@ -70,9 +77,13 @@ fn test_std_mult_pipe() {
     assert_eq!(output_vals.len(), 2);
     port_bindings![binds;
         go -> (1, 1),
+        reset -> (0, 1),
         left -> (5, 32),
         right -> (7, 32)
     ];
+    mult.validate_and_execute(&binds).unwrap();
+    mult.do_tick().unwrap();
+
     mult.validate_and_execute(&binds).unwrap();
     let mut output_vals = mult.do_tick().unwrap().into_iter(); //should output done and 14, internal queue: [35, N]
     assert_eq!(output_vals.len(), 2);
@@ -80,16 +91,18 @@ fn test_std_mult_pipe() {
     assert_eq!(out.as_u64(), 14);
     let done = output_vals.next().unwrap().1;
     assert_eq!(done.as_u64(), 1);
+    mult.validate_and_execute(&binds).unwrap();
     //now tick 3 more times; get empty vec, 35, empty vec
     output_vals = mult.do_tick().unwrap().into_iter(); //should output empty vec
     assert_eq!(output_vals.len(), 2);
+    mult.validate_and_execute(&binds).unwrap();
     output_vals = mult.do_tick().unwrap().into_iter(); //should output done and 35
     assert_eq!(output_vals.len(), 2);
     let out = output_vals.next().unwrap().1;
     assert_eq!(out.as_u64(), 35);
     let done = output_vals.next().unwrap().1;
     assert_eq!(done.as_u64(), 1);
-    //none (empty output vec)
+    mult.validate_and_execute(&binds).unwrap();
     output_vals = mult.do_tick().unwrap().into_iter(); //should output empty vec
     assert_eq!(output_vals.len(), 2);
 }
@@ -100,6 +113,7 @@ fn test_std_div_pipe() {
         stfl::StdDivPipe::<false>::from_constants(32, "".into(), false);
     port_bindings![binds;
         go -> (1, 1),
+        reset -> (0, 1),
         left -> (20, 32),
         right -> (7, 32)  //20/7 = 2 r. 6
     ];
@@ -110,12 +124,14 @@ fn test_std_div_pipe() {
     assert_eq!(output_vals.len(), 3);
     port_bindings![binds;
         go -> (1, 1),
+        reset -> (0, 1),
         left -> (20, 32),
         right -> (6, 32) //20/6 = 3 r. 2
     ];
     div.validate_and_execute(&binds).unwrap();
     port_bindings![binds;
         go -> (0, 1), //b/c go is low, this should not overwrite 20/6!
+        reset -> (0, 1),
         left -> (4, 32),
         right -> (7, 32)
     ];
@@ -127,11 +143,18 @@ fn test_std_div_pipe() {
     div.validate_and_execute(&binds).unwrap();
     let output_vals = div.do_tick().unwrap(); //internal q: [N, (2, 6)]
     assert_eq!(output_vals.len(), 3);
+
     port_bindings![binds;
         go -> (1, 1),
+        reset -> (0, 1),
         left -> (20, 32),
         right -> (5, 32) //20/5 = 4 r. 0
     ];
+
+    div.validate_and_execute(&binds).unwrap();
+    let output_vals = div.do_tick().unwrap();
+    assert_eq!(output_vals.len(), 3);
+
     div.validate_and_execute(&binds).unwrap();
     let mut output_vals = div.do_tick().unwrap().into_iter(); //should output done and out_quotient 2 and out_remainder 6
                                                               //internal q: [(4, 0), N]
@@ -147,6 +170,10 @@ fn test_std_div_pipe() {
     //internal q: [(4, 0), N]
     output_vals = div.do_tick().unwrap().into_iter(); //give none
     assert_eq!(output_vals.len(), 3);
+
+    div.validate_and_execute(&binds).unwrap();
+    div.do_tick().unwrap();
+
     //internal q: [N, (4, 0)]
     output_vals = div.do_tick().unwrap().into_iter(); //out_q : 4, out_r: 0
     assert_eq!(output_vals.len(), 3);
@@ -1557,13 +1584,16 @@ mod property_tests {
         fn std_mult(in_left: u64, in_right: u64){
             let mut mult = stateful::StdMultPipe::<false, 2>::from_constants(64, "".into(), false);
             port_bindings![binds;
+            reset -> (0, 1),
             left -> (in_left, 64),
             right -> (in_right, 64),
             go -> (1,1)
             ];
             mult.execute(&binds).unwrap();
             mult.do_tick().unwrap();
+            mult.execute(&binds).unwrap();
             mult.do_tick().unwrap();
+            mult.execute(&binds).unwrap();
             let output = mult.do_tick().unwrap();
             let out = extract_output!(output, "out");
             assert_eq!(out.as_u64(),u64::wrapping_mul(in_left, in_right))
@@ -1573,13 +1603,16 @@ mod property_tests {
         fn std_smult(in_left: i64, in_right: i64){
             let mut mult = stateful::StdMultPipe::<true, 2>::from_constants(64, "".into(), false);
             port_bindings![binds;
+            reset -> (0, 1),
             left -> (in_left, 64),
             right -> (in_right, 64),
             go -> (1,1)
             ];
             mult.execute(&binds).unwrap();
             mult.do_tick().unwrap();
+            mult.execute(&binds).unwrap();
             mult.do_tick().unwrap();
+            mult.execute(&binds).unwrap();
             let output = mult.do_tick().unwrap();
             let out = extract_output!(output, "out");
             assert_eq!(out.as_i64(), i64::wrapping_mul(in_left, in_right))
@@ -1591,11 +1624,14 @@ mod property_tests {
             port_bindings![binds;
             left -> (in_left, 64),
             right -> (in_right, 64),
-            go -> (1,1)
+            go -> (1,1),
+            reset -> (0, 1)
             ];
             mult.execute(&binds).unwrap();
             mult.do_tick().unwrap();
+            mult.execute(&binds).unwrap();
             mult.do_tick().unwrap();
+            mult.execute(&binds).unwrap();
             let output = mult.do_tick().unwrap();
             let out = extract_output!(output, "out_quotient");
             let remainder = extract_output!(output, "out_remainder");
@@ -1608,12 +1644,15 @@ mod property_tests {
             let mut mult = stateful::StdDivPipe::<true>::from_constants(64, "".into(), false);
             port_bindings![binds;
             left -> (in_left, 64),
+            reset -> (0, 1),
             right -> (in_right, 64),
             go -> (1,1)
             ];
             mult.execute(&binds).unwrap();
             mult.do_tick().unwrap();
+            mult.execute(&binds).unwrap();
             mult.do_tick().unwrap();
+            mult.execute(&binds).unwrap();
             let output = mult.do_tick().unwrap();
             let out = extract_output!(output, "out_quotient");
             // let remainder = extract_output!(output, "out_remainder");

--- a/primitives/binary_operators.sv
+++ b/primitives/binary_operators.sv
@@ -74,7 +74,11 @@ module std_fp_mult_pipe #(
 
   // Move the multiplication computation through the pipeline.
   always_ff @(posedge clk) begin
-    if (go) begin
+    if (reset) begin
+      rtmp <= 0;
+      ltmp <= 0;
+      out_tmp <= 0;
+    end else if (go) begin
       if (SIGNED) begin
         rtmp <= $signed(right);
         ltmp <= $signed(left);

--- a/primitives/binary_operators.sv
+++ b/primitives/binary_operators.sv
@@ -159,7 +159,10 @@ module std_fp_div_pipe #(
     end
 
     always_ff @(posedge clk) begin
-      if (start) begin
+      if (reset) begin
+        out_quotient <= 0;
+        out_remainder <= 0;
+      end else if (start) begin
         out_quotient <= 0;
         out_remainder <= left;
       end else if (go == 0) begin
@@ -181,7 +184,10 @@ module std_fp_div_pipe #(
     end
 
     always_ff @(posedge clk) begin
-      if (start) begin
+      if (reset) begin
+        acc <= 0;
+        quotient <= 0;
+      end else if (start) begin
         {acc, quotient} <= {{WIDTH{1'b0}}, left, 1'b0};
       end else begin
         acc <= acc_next;

--- a/primitives/math.sv
+++ b/primitives/math.sv
@@ -69,6 +69,9 @@ module fp_sqrt #(
       if (finished) begin
         done <= 1;
         out <= quotient_next;
+      end else if (reset) begin
+        done <= 0;
+        out <= 0;
       end else begin
         done <= 0;
         out <= out;


### PR DESCRIPTION
Small PR which closes #584 and (hopefully) fixes some discrepancies with the reset signal behavior in the verilog primitives.

