### PR TITLE
[Interpreter/Cider] Output set of active leaf nodes

### DIFF
--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -244,9 +244,11 @@ impl Debugger {
                 Command::InfoWatch => self.debugging_ctx.print_watchpoints(),
                 Command::PrintPC => {
                     println!(
-                        "{}",
-                        component_interpreter.get_active_tree()[0]
-                            .format_tree::<true>(2)
+                        "{:?}",
+                        component_interpreter
+                            .get_active_tree()
+                            .remove(0)
+                            .flat_set()
                     )
                 }
             }

--- a/interp/src/debugger/name_tree.rs
+++ b/interp/src/debugger/name_tree.rs
@@ -1,3 +1,5 @@
+use serde::Serialize;
+
 use crate::structures::names::GroupQualifiedInstanceName;
 use std::{collections::HashSet, fmt::Write, iter::once};
 
@@ -100,6 +102,8 @@ impl IntoIterator for ActiveVec {
     }
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(transparent)]
 pub struct ActiveSet(HashSet<String>);
 
 impl From<ActiveVec> for ActiveSet {

--- a/interp/src/debugger/name_tree.rs
+++ b/interp/src/debugger/name_tree.rs
@@ -1,7 +1,7 @@
 use crate::structures::names::GroupQualifiedInstanceName;
-use std::fmt::Write;
+use std::{fmt::Write, iter::once};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ActiveTreeNode {
     name: GroupQualifiedInstanceName,
     children: Vec<ActiveTreeNode>,
@@ -56,5 +56,41 @@ impl ActiveTreeNode {
         }
 
         out
+    }
+
+    pub fn flatten(self) -> ActiveVec {
+        if self.name.is_leaf() {
+            once(self.name)
+                .chain(self.children.into_iter().flat_map(Self::flatten))
+                .collect()
+        } else {
+            self.children.into_iter().flat_map(Self::flatten).collect()
+        }
+    }
+}
+
+pub struct ActiveVec(Vec<GroupQualifiedInstanceName>);
+
+impl From<Vec<GroupQualifiedInstanceName>> for ActiveVec {
+    fn from(v: Vec<GroupQualifiedInstanceName>) -> Self {
+        Self(v)
+    }
+}
+
+impl FromIterator<GroupQualifiedInstanceName> for ActiveVec {
+    fn from_iter<T: IntoIterator<Item = GroupQualifiedInstanceName>>(
+        iter: T,
+    ) -> Self {
+        Self(Vec::from_iter(iter))
+    }
+}
+
+impl IntoIterator for ActiveVec {
+    type Item = GroupQualifiedInstanceName;
+
+    type IntoIter = std::vec::IntoIter<GroupQualifiedInstanceName>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }

--- a/interp/src/debugger/name_tree.rs
+++ b/interp/src/debugger/name_tree.rs
@@ -1,5 +1,5 @@
 use crate::structures::names::GroupQualifiedInstanceName;
-use std::{fmt::Write, iter::once};
+use std::{collections::HashSet, fmt::Write, iter::once};
 
 #[derive(Debug, Clone)]
 pub struct ActiveTreeNode {
@@ -67,6 +67,11 @@ impl ActiveTreeNode {
             self.children.into_iter().flat_map(Self::flatten).collect()
         }
     }
+
+    #[inline]
+    pub fn flat_set(self) -> ActiveSet {
+        self.flatten().into()
+    }
 }
 
 pub struct ActiveVec(Vec<GroupQualifiedInstanceName>);
@@ -92,5 +97,13 @@ impl IntoIterator for ActiveVec {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+pub struct ActiveSet(HashSet<String>);
+
+impl From<ActiveVec> for ActiveSet {
+    fn from(v: ActiveVec) -> Self {
+        Self(v.0.into_iter().map(|x| x.format_name()).collect())
     }
 }

--- a/interp/src/structures/names.rs
+++ b/interp/src/structures/names.rs
@@ -120,7 +120,7 @@ impl QualifiedInstanceName {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum GroupName {
     /// An actual group
     Group(Id),
@@ -130,6 +130,7 @@ pub enum GroupName {
     None,
 }
 
+#[derive(Clone)]
 pub struct GroupQualifiedInstanceName {
     pub prefix: ComponentQualifiedInstanceName,
     pub group: GroupName,
@@ -158,6 +159,10 @@ impl GroupQualifiedInstanceName {
             prefix: comp.clone(),
             group: GroupName::None,
         }
+    }
+
+    pub fn is_leaf(&self) -> bool {
+        !matches!(&self.group, GroupName::None)
     }
 }
 

--- a/interp/src/structures/names.rs
+++ b/interp/src/structures/names.rs
@@ -1,6 +1,11 @@
 use crate::interpreter_ir as iir;
 use calyx::ir::Id;
-use std::{fmt::Display, hash::Hash, ops::Deref, rc::Rc};
+use std::{
+    fmt::{Display, Write},
+    hash::Hash,
+    ops::Deref,
+    rc::Rc,
+};
 
 #[derive(Debug, Clone)]
 /// A portion of a qualified name representing an instance of a Calyx component.
@@ -163,6 +168,16 @@ impl GroupQualifiedInstanceName {
 
     pub fn is_leaf(&self) -> bool {
         !matches!(&self.group, GroupName::None)
+    }
+
+    pub fn format_name(&self) -> String {
+        let mut out: String = self.prefix.as_id().to_string();
+        match &self.group {
+            GroupName::Group(g) => write!(out, "::{}", g).unwrap(),
+            GroupName::Phantom(g) => write!(out, "::<{}>", g).unwrap(),
+            GroupName::None => {}
+        }
+        out
     }
 }
 


### PR DESCRIPTION
Small PR which changes the current implementation of cider's `where` (alias `pc`) command to output the set of active leaf nodes in the program as a first step towards a source level translation. This also sets up the minimal serde infrastructure required to serialize this as a json.

Currently invoke nodes are included with angle braces denoting that they correspond to a nameless "phantom" group. We'll likely want to change this placeholder once we have a better sense of the interface we want to expose.