### PR TITLE
[Cider] Update the active set output to include pos tags

### DIFF
--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -72,8 +72,10 @@ impl Debugger {
             };
 
             match comm {
-                Command::Step => {
-                    component_interpreter.step()?;
+                Command::Step(n) => {
+                    for _ in 0..n {
+                        component_interpreter.step()?;
+                    }
                 }
                 Command::Continue => {
                     self.debugging_ctx.set_current_time(

--- a/interp/src/debugger/commands.rs
+++ b/interp/src/debugger/commands.rs
@@ -131,10 +131,10 @@ impl Display for PrintTuple {
 }
 
 pub enum Command {
-    Step,                                                      // Step execution
-    Continue, // Execute until breakpoint
-    Empty,    // Empty command, does nothing
-    Display,  // Display full environment contents
+    Step(u64), // Step execution
+    Continue,  // Execute until breakpoint
+    Empty,     // Empty command, does nothing
+    Display,   // Display full environment contents
     Print(Option<Vec<Vec<calyx::ir::Id>>>, Option<PrintCode>), // Print something
     Break(Vec<GroupName>), // Create a breakpoint
     Help,                  // Help message

--- a/interp/src/debugger/name_tree.rs
+++ b/interp/src/debugger/name_tree.rs
@@ -104,10 +104,16 @@ impl IntoIterator for ActiveVec {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(transparent)]
-pub struct ActiveSet(HashSet<String>);
+pub struct ActiveSet(HashSet<(u64, String)>);
 
 impl From<ActiveVec> for ActiveSet {
     fn from(v: ActiveVec) -> Self {
-        Self(v.0.into_iter().map(|x| x.format_name()).collect())
+        Self(
+            v.0.into_iter()
+                .filter_map(|x| {
+                    x.pos_tag.and_then(|tag| (tag, x.format_name()).into())
+                })
+                .collect(),
+        )
     }
 }

--- a/interp/src/debugger/parser/command_parser.rs
+++ b/interp/src/debugger/parser/command_parser.rs
@@ -31,8 +31,11 @@ impl CommandParser {
         Ok(Command::Continue)
     }
 
-    fn step(_input: Node) -> ParseResult<Command> {
-        Ok(Command::Step)
+    fn step(input: Node) -> ParseResult<Command> {
+        Ok(match_nodes!(input.into_children();
+            [num(n)] => Command::Step(n),
+            [] => Command::Step(1)
+        ))
     }
 
     fn display(_input: Node) -> ParseResult<Command> {

--- a/interp/src/debugger/parser/commands.pest
+++ b/interp/src/debugger/parser/commands.pest
@@ -47,7 +47,7 @@ watch = {
 
 step_over = {^"step-over" ~ group }
 
-step = { (^"step" | ^"s") }
+step = { (^"step" | ^"s")  ~ num? }
 cont = {
     (^"continue" | ^"c")
 }

--- a/interp/src/interpreter/control_interpreter.rs
+++ b/interp/src/interpreter/control_interpreter.rs
@@ -111,6 +111,22 @@ impl EnableHolder {
             EnableHolder::CombGroup(_) | EnableHolder::Vec(_) => None,
         }
     }
+
+    fn pos_tag(&self) -> Option<u64> {
+        match self {
+            EnableHolder::Group(g) => g
+                .borrow()
+                .get_attributes()
+                .and_then(|x| x.get("pos"))
+                .cloned(),
+            EnableHolder::CombGroup(g) => g
+                .borrow()
+                .get_attributes()
+                .and_then(|x| x.get("pos"))
+                .cloned(),
+            EnableHolder::Vec(_) => None,
+        }
+    }
 }
 
 impl From<RRC<ir::Group>> for EnableHolder {
@@ -243,7 +259,7 @@ impl Interpreter for EnableInterpreter {
             None => GroupQualifiedInstanceName::new_empty(&self.qin),
         };
 
-        vec![ActiveTreeNode::new(name)]
+        vec![ActiveTreeNode::new(name.with_tag(self.enable.pos_tag()))]
     }
 }
 
@@ -1035,7 +1051,9 @@ impl Interpreter for InvokeInterpreter {
             &(format!("invoke {}", self.invoke.comp.borrow().name()).into()),
         );
 
-        vec![ActiveTreeNode::new(name)]
+        let pos_tag = self.invoke.attributes.get("pos").cloned();
+
+        vec![ActiveTreeNode::new(name.with_tag(pos_tag))]
     }
 }
 

--- a/interp/src/interpreter/control_interpreter.rs
+++ b/interp/src/interpreter/control_interpreter.rs
@@ -21,6 +21,9 @@ use calyx::ir::{self, Assignment, Guard, RRC};
 use std::collections::HashSet;
 use std::rc::Rc;
 
+/// The key to lookup for the position tags
+const POS_TAG: &str = "pos";
+
 #[derive(Debug, Clone)]
 pub struct ComponentInfo {
     pub continuous_assignments: iir::ContinuousAssignments,
@@ -117,12 +120,12 @@ impl EnableHolder {
             EnableHolder::Group(g) => g
                 .borrow()
                 .get_attributes()
-                .and_then(|x| x.get("pos"))
+                .and_then(|x| x.get(POS_TAG))
                 .cloned(),
             EnableHolder::CombGroup(g) => g
                 .borrow()
                 .get_attributes()
-                .and_then(|x| x.get("pos"))
+                .and_then(|x| x.get(POS_TAG))
                 .cloned(),
             EnableHolder::Vec(_) => None,
         }
@@ -1051,7 +1054,7 @@ impl Interpreter for InvokeInterpreter {
             &(format!("invoke {}", self.invoke.comp.borrow().name()).into()),
         );
 
-        let pos_tag = self.invoke.attributes.get("pos").cloned();
+        let pos_tag = self.invoke.attributes.get(POS_TAG).cloned();
 
         vec![ActiveTreeNode::new(name.with_tag(pos_tag))]
     }

--- a/interp/src/structures/names.rs
+++ b/interp/src/structures/names.rs
@@ -131,7 +131,7 @@ pub enum GroupName {
     Group(Id),
     /// A phantom group with a displayable name
     Phantom(Id),
-    /// No group name
+    /// No group name (this allows components to be in the tree)
     None,
 }
 
@@ -139,6 +139,7 @@ pub enum GroupName {
 pub struct GroupQualifiedInstanceName {
     pub prefix: ComponentQualifiedInstanceName,
     pub group: GroupName,
+    pub pos_tag: Option<u64>,
 }
 
 impl GroupQualifiedInstanceName {
@@ -146,6 +147,7 @@ impl GroupQualifiedInstanceName {
         Self {
             prefix: comp.clone(),
             group: GroupName::Group(name.clone()),
+            pos_tag: None,
         }
     }
 
@@ -156,6 +158,7 @@ impl GroupQualifiedInstanceName {
         Self {
             prefix: comp.clone(),
             group: GroupName::Phantom(name.clone()),
+            pos_tag: None,
         }
     }
 
@@ -163,11 +166,16 @@ impl GroupQualifiedInstanceName {
         Self {
             prefix: comp.clone(),
             group: GroupName::None,
+            pos_tag: None,
         }
     }
 
     pub fn is_leaf(&self) -> bool {
         !matches!(&self.group, GroupName::None)
+    }
+
+    pub fn has_tag(&self) -> bool {
+        self.pos_tag.is_some()
     }
 
     pub fn format_name(&self) -> String {
@@ -178,6 +186,11 @@ impl GroupQualifiedInstanceName {
             GroupName::None => {}
         }
         out
+    }
+
+    pub fn with_tag(mut self, tag: Option<u64>) -> Self {
+        self.pos_tag = tag;
+        self
     }
 }
 


### PR DESCRIPTION
Keeping with the conversation yesterday, the `pc` command now outputs the set of active (pos_tag, instance_name) pairs. It does not currently include any of the leaf nodes which lack a `pos` annotation. This means the interpreter side of the source position approach is mostly complete. 

As an afterthought, we may wish to support multiple position annotations if we find the idea of source tracking through multiple translation layers worthwhile. (TVM -> Dahlia -> Calyx)

Also added an optional numerical argument for the step command so `s 5` now performs step five times. This is mostly as a convenience (for me, primarily).