### PR TITLE
Switch to official black format GA

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -329,15 +329,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Fud Formatting check
-        uses: RojerGS/python-black-check@master
+        uses: psf/black@stable
         with:
-          line-length: 88
-          path: 'fud'
+          options: "--line-length 88"
+          src: 'fud'
       - name: Systolic Array Formatting check
-        uses: RojerGS/python-black-check@master
+        uses: psf/black@stable
         with:
-          line-length: 88
-          path: 'frontends/systolic-lang'
+          options: "--line-length 88"
+          src: 'frontends/systolic-lang'
       - name: Fud Linting check
         uses: TrueBrain/actions-flake8@master
         with:


### PR DESCRIPTION
Recent [changes to a dependency of black formatter](https://github.com/psf/black/issues/2964) broke our CI for python formatting. Hopefully this switch will fix it.
