### PR TITLE
wire-inliner: do not compile when control program is empty

### DIFF
--- a/calyx/src/default_passes.rs
+++ b/calyx/src/default_passes.rs
@@ -78,14 +78,13 @@ impl PassManager {
         register_alias!(
             pm,
             "post-opt",
-            [DeadGroupRemoval, DeadCellRemoval, CombProp]
+            [DeadGroupRemoval, CombProp, DeadCellRemoval]
         );
         register_alias!(
             pm,
             "lower",
             [
                 GoInsertion,
-                ComponentInterface,
                 WireInliner,
                 ClkInsertion,
                 ResetInsertion,

--- a/tests/passes/wire-inliner.expect
+++ b/tests/passes/wire-inliner.expect
@@ -12,6 +12,8 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     @generated seq0_done = std_wire(1);
   }
   wires {
+    seq0_go.in = go;
+    done = seq0_done.out ? 1'd1;
     r1.in = write_r1_go.out ? 32'd1;
     r1.write_en = write_r1_go.out ? 1'd1;
     write_r1_done.in = r1.done;
@@ -21,6 +23,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     write_r1_go.in = fsm.out == 1'd0 & seq0_go.out ? 1'd1;
     write_r2_go.in = fsm.out == 1'd1 & seq0_go.out ? 1'd1;
     fsm.in = write_r1_done.out & seq0_go.out ? 1'd1;
+    fsm.write_en = write_r1_done.out & seq0_go.out ? 1'd1;
     seq0_done.in = write_r2_done.out;
   }
 

--- a/tests/passes/wire-inliner.futil
+++ b/tests/passes/wire-inliner.futil
@@ -26,6 +26,7 @@ component main() -> () {
       write_r1[go] = fsm.out == 1'b0 ? 1'b1;
       write_r2[go] = fsm.out == 1'b1 ? 1'b1;
       fsm.in = write_r1[done] ? 1'b1;
+      fsm.write_en = write_r1[done] ? 1'b1;
       seq0[done] = write_r2[done];
     }
   }


### PR DESCRIPTION
`hole-inliner` relied on the `compenent-interface-inserter` pass to assign to the `go` and `done` conditions for each component (this seems like an odd choice and I don't remember why we do it this way). `wire-inliner` no longer requires this.
