### PR TITLE
fud can accept streams as input

### DIFF
--- a/fud/fud/exec.py
+++ b/fud/fud/exec.py
@@ -54,8 +54,9 @@ def run_fud(args, config):
     )
 
     # check if input is needed
+    inp_type = path[0].input_type
     if args.input_file is None:
-        if path[0].input_type not in [SourceType.UnTyped, SourceType.Terminal]:
+        if inp_type not in [SourceType.UnTyped, SourceType.Terminal, SourceType.Stream]:
             raise errors.NeedInputSpecified(path[0])
 
     # check if we need `-o` specified
@@ -87,7 +88,10 @@ def run_fud(args, config):
     # construct a source object for the input
     input = None
     if input_file is None:
-        input = Source(None, SourceType.UnTyped)
+        if inp_type is SourceType.Stream:
+            input = Source(sys.stdin, SourceType.Stream)
+        else:
+            input = Source(None, SourceType.UnTyped)
     else:
         input = Source.path(input_file)
 

--- a/runt.toml
+++ b/runt.toml
@@ -144,9 +144,8 @@ fud e --from ntt {} --through verilog --to dat -s verilog.data {}.data -q
 name = "exp (taylor series approximation) correctness"
 paths = [ "tests/correctness/exp/*.txt" ]
 cmd = """
-python3 calyx-py/calyx/gen_exp.py {} > {}.futil; \
-fud e {}.futil --to dat --through verilog -s verilog.data {}.data -q 2>/dev/null; \
-rm {}.futil;
+python3 calyx-py/calyx/gen_exp.py {} |\
+fud e --from futil --to dat --through verilog -s verilog.data {}.data -q
 """
 
 [[tests]]


### PR DESCRIPTION
`fud` couldn't read from input streams. This PR changes some checking logic to make sure it can.
