### PR TITLE
[Cider] Overhaul source parsing

### DIFF
--- a/frontends/relay/relay_visitor.py
+++ b/frontends/relay/relay_visitor.py
@@ -139,7 +139,7 @@ class Relay2Calyx(ExprFunctor):
             tag = self.pos_count
             self.pos_count += 1
 
-            self.source_map[f"({tag}, )"] = [
+            self.source_map[tag] = [
                 x for x in str(let).splitlines() if x.startswith("let")
             ][0]
 
@@ -313,9 +313,9 @@ if __name__ == "__main__":
     calyx, metadata = emit_calyx(relay_ir)
 
     if args.write_metadata is not None:
-        import simplejson as sjson
 
         with open(args.write_metadata, "w") as f:
-            sjson.dump(metadata, f)
+            for key, val in metadata.items():
+                f.write(f'{key}: "{val}"\n')
 
     print(calyx)

--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -6,7 +6,7 @@ use super::{
     interactive_errors::DebuggerError,
     io_utils::Input,
 };
-use crate::debugger::source_location::SourceMap;
+use crate::debugger::source::SourceMap;
 use crate::environment::{InterpreterState, PrimitiveMap, StateView};
 use crate::errors::{InterpreterError, InterpreterResult};
 use crate::interpreter::{ComponentInterpreter, ConstCell, Interpreter};

--- a/interp/src/debugger/mod.rs
+++ b/interp/src/debugger/mod.rs
@@ -5,7 +5,7 @@ mod interactive_errors;
 mod io_utils;
 pub(crate) mod name_tree;
 pub(crate) mod parser;
-pub mod source_location;
+pub mod source;
 pub use commands::PrintCode;
 
 pub use cidr::Debugger;

--- a/interp/src/debugger/source/metadata.pest
+++ b/interp/src/debugger/source/metadata.pest
@@ -11,9 +11,7 @@ named_tag = { "(" ~ num ~ "," ~ id_string ~ ")" }
 tag = { named_tag | num }
 
 inner_position_string =  {
-    (ASCII_ALPHANUMERIC
-    | "[" | "]" | "(" | ")" | "%" | "=" | "/" 
-    | "*" | ";" | "." | "_" | ":" | "," | "-" | "+")*
+    (&(!("\"")) ~ ANY)*
 }
 
 position_string = { quote ~

--- a/interp/src/debugger/source/metadata.pest
+++ b/interp/src/debugger/source/metadata.pest
@@ -11,7 +11,7 @@ named_tag = { "(" ~ num ~ "," ~ id_string ~ ")" }
 tag = { named_tag | num }
 
 inner_position_string =  {
-    (&(!("\"")) ~ ANY)*
+    (!("\"") ~ ANY)*
 }
 
 position_string = { quote ~

--- a/interp/src/debugger/source/metadata.pest
+++ b/interp/src/debugger/source/metadata.pest
@@ -1,0 +1,29 @@
+WHITESPACE = _{ " " | "\t" | NEWLINE }
+dot = _{"."}
+ident_syms = _{ "_" | "-" | "'" }
+quote = _{"\""}
+num = @{ASCII_DIGIT+}
+
+id_string = @{ ("_" | ASCII_ALPHA)+ ~ (ident_syms | ASCII_ALPHA | ASCII_DIGIT | "::" |".")* }
+
+named_tag = { "(" ~ num ~ "," ~ id_string ~ ")" }
+
+tag = { named_tag | num }
+
+inner_position_string =  {
+    (ASCII_ALPHANUMERIC
+    | "[" | "]" | "(" | ")" | "%" | "=" | "/" 
+    | "*" | ";" | "." | "_" | ":" | "," | "-" | "+")*
+}
+
+position_string = { quote ~
+   inner_position_string
+    ~ quote }
+
+entry = { tag ~ ":" ~ position_string}
+
+metadata = {
+    SOI ~
+    entry+ ~
+    EOI
+}

--- a/interp/src/debugger/source/metadata_parser.rs
+++ b/interp/src/debugger/source/metadata_parser.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+
+use pest_consume::{match_nodes, Error, Parser};
+
+use crate::errors::InterpreterResult;
+
+use super::structures::{NamedTag, SourceMap};
+
+type ParseResult<T> = std::result::Result<T, Error<Rule>>;
+type Node<'i> = pest_consume::Node<'i, Rule, ()>;
+
+// include the grammar file so that Cargo knows to rebuild this file on grammar changes
+const _GRAMMAR: &str = include_str!("metadata.pest");
+
+#[derive(Parser)]
+#[grammar = "debugger/source/metadata.pest"]
+pub struct MetadataParser;
+
+#[pest_consume::parser]
+impl MetadataParser {
+    fn EOI(_input: Node) -> ParseResult<()> {
+        Ok(())
+    }
+    fn num(input: Node) -> ParseResult<u64> {
+        input
+            .as_str()
+            .parse::<u64>()
+            .map_err(|_| input.error("Expected non-negative number"))
+    }
+
+    fn id_string(input: Node) -> ParseResult<String> {
+        Ok(input.as_str().to_string())
+    }
+
+    fn named_tag(input: Node) -> ParseResult<NamedTag> {
+        Ok(match_nodes!(input.into_children();
+            [num(n), id_string(s)] => (n,s).into()
+        ))
+    }
+
+    fn tag(input: Node) -> ParseResult<NamedTag> {
+        Ok(match_nodes!(input.into_children();
+            [num(n)] => NamedTag::new_nameless(n),
+            [named_tag(t)] => t,
+        ))
+    }
+
+    fn inner_position_string(input: Node) -> ParseResult<String> {
+        Ok(input.as_str().to_string())
+    }
+
+    fn position_string(input: Node) -> ParseResult<String> {
+        Ok(match_nodes!(input.into_children();
+            [inner_position_string(i)] => i
+        ))
+    }
+
+    fn entry(input: Node) -> ParseResult<(NamedTag, String)> {
+        Ok(match_nodes!(input.into_children();
+            [tag(t), position_string(s)] => (t, s)
+        ))
+    }
+
+    fn metadata(input: Node) -> ParseResult<SourceMap> {
+        Ok(match_nodes!(input.into_children();
+            [entry(e).., EOI(_)] => {
+                let map: HashMap<NamedTag, String> = e.collect();
+                map.into()
+            }
+        ))
+    }
+}
+
+pub fn parse_metadata(input_str: &str) -> InterpreterResult<SourceMap> {
+    let inputs = MetadataParser::parse(Rule::metadata, input_str)?;
+    let input = inputs.single()?;
+    Ok(MetadataParser::metadata(input)?)
+}

--- a/interp/src/debugger/source/mod.rs
+++ b/interp/src/debugger/source/mod.rs
@@ -1,0 +1,4 @@
+pub(crate) mod metadata_parser;
+pub mod structures;
+
+pub use structures::{NamedTag, SourceMap};

--- a/interp/src/debugger/source/structures.rs
+++ b/interp/src/debugger/source/structures.rs
@@ -2,9 +2,17 @@ use calyx::errors::Error;
 use serde::{self, de::Visitor, Deserialize, Serialize};
 use std::{collections::HashMap, fs, path::PathBuf};
 
+use crate::errors::InterpreterResult;
+
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 
 pub struct NamedTag(u64, String);
+
+impl NamedTag {
+    pub fn new_nameless(tag: u64) -> Self {
+        Self(tag, String::new())
+    }
+}
 
 impl From<(u64, String)> for NamedTag {
     fn from(i: (u64, String)) -> Self {
@@ -85,5 +93,25 @@ impl SourceMap {
         } else {
             Ok(None)
         }
+    }
+
+    pub fn from_file_pest(
+        path: &Option<PathBuf>,
+    ) -> InterpreterResult<Option<Self>> {
+        if let Some(path) = path {
+            let v = fs::read(path)?;
+            let file_contents = std::str::from_utf8(&v)?;
+            let map: Self =
+                super::metadata_parser::parse_metadata(file_contents)?;
+            Ok(Some(map))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl From<HashMap<NamedTag, String>> for SourceMap {
+    fn from(i: HashMap<NamedTag, String>) -> Self {
+        Self(i)
     }
 }

--- a/interp/src/errors.rs
+++ b/interp/src/errors.rs
@@ -26,6 +26,13 @@ pub enum InterpreterError {
         pest_consume::Error<crate::debugger::parser::command_parser::Rule>,
     ),
 
+    /// Unable to parse the debugger command
+    #[error(transparent)]
+    MetadataParseError(
+        #[from]
+        pest_consume::Error<crate::debugger::source::metadata_parser::Rule>,
+    ),
+
     /// Wrapper for errors coming from the interactive CLI
     #[error(transparent)]
     ReadlineError(#[from] ReadlineError),
@@ -107,6 +114,9 @@ pub enum InterpreterError {
     // TODO (Griffin): Make this error message better please
     #[error("Computation has under/overflowed its bounds")]
     OverflowError(),
+
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
 }
 
 impl InterpreterError {
@@ -159,5 +169,11 @@ impl From<crate::structures::stk_env::CollisionError<*const ir::Port, Value>>
             v1: err.1,
             v2: err.2,
         }
+    }
+}
+
+impl From<std::str::Utf8Error> for InterpreterError {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Error::invalid_file(err.to_string()).into()
     }
 }

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -1,7 +1,7 @@
 use calyx::{frontend, ir, pass_manager::PassManager, utils::OutputFile};
 use interp::{
     configuration,
-    debugger::{source_location::SourceMap, Debugger},
+    debugger::{source::SourceMap, Debugger},
     environment::InterpreterState,
     errors::{InterpreterError, InterpreterResult},
     interpreter::ComponentInterpreter,
@@ -169,7 +169,7 @@ fn main() -> InterpreterResult<()> {
             ComponentInterpreter::interpret_program(env, main_component)
         }
         Command::Debug(CommandDebug { source_map_file }) => {
-            let map = SourceMap::from_file(&source_map_file)?;
+            let map = SourceMap::from_file_pest(&source_map_file)?;
             let mut cidb = Debugger::new(&components, main_component, map);
             cidb.main_loop(env)
         }

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -169,7 +169,7 @@ fn main() -> InterpreterResult<()> {
             ComponentInterpreter::interpret_program(env, main_component)
         }
         Command::Debug(CommandDebug { source_map_file }) => {
-            let map = SourceMap::from_file_pest(&source_map_file)?;
+            let map = SourceMap::from_file(&source_map_file)?;
             let mut cidb = Debugger::new(&components, main_component, map);
             cidb.main_loop(env)
         }


### PR DESCRIPTION
Replaces the sedre-based json source map parsing with a custom pest parser. This updates the relay code to match the format change.

Example metadata file:

```
0: "let %x: Tensor[(1, 20, 24, 24), float32] = nn.conv2d(%data, %conv1_w, padding=[0, 0, 0, 0], kernel_size=[5, 5]) /* ty=Tensor[(1, 20, 24, 24), float32] */;"
1: ""
2: "let %x2: Tensor[(1, 20, 12, 12), float32] = nn.max_pool2d(%x1, pool_size=[2, 2], strides=[2, 2], padding=[0, 0, 1, 1]) /* ty=Tensor[(1, 20, 12, 12), float32] */;"
3: "let %x3: Tensor[(1, 50, 8, 8), float32] = nn.conv2d(%x2, %conv2_w, padding=[0, 0, 0, 0], kernel_size=[5, 5]) /* ty=Tensor[(1, 50, 8, 8), float32] */;"
4: "let %x4: Tensor[(1, 50, 8, 8), float32] = nn.bias_add(%x3, %conv2_b) /* ty=Tensor[(1, 50, 8, 8), float32] */;"
5: "let %x5: Tensor[(1, 50, 4, 4), float32] = nn.max_pool2d(%x4, pool_size=[2, 2], strides=[2, 2], padding=[0, 0, 1, 1]) /* ty=Tensor[(1, 50, 4, 4), float32] */;"
6: "let %x6: Tensor[(1, 800), float32] = reshape(%x5, newshape=[-1, 800]) /* ty=Tensor[(1, 800), float32] */;"
7: "let %x7: Tensor[(1, 800), float32] = nn.batch_flatten(%x6) /* ty=Tensor[(1, 800), float32] */;"
8: "let %x8: Tensor[(1, 500), float32] = nn.dense(%x7, %ip1_w, units=500) /* ty=Tensor[(1, 500), float32] */;"
9: "let %x10: Tensor[(500), float32] = multiply(%x9, %ip1_b) /* ty=Tensor[(500), float32] */;"
10: "let %x11: Tensor[(1, 500), float32] = nn.bias_add(%x8, %x10) /* ty=Tensor[(1, 500), float32] */;"
11: "let %x12: Tensor[(1, 500), float32] = nn.relu(%x11) /* ty=Tensor[(1, 500), float32] */;"
12: "let %x13: Tensor[(1, 500), float32] = nn.batch_flatten(%x12) /* ty=Tensor[(1, 500), float32] */;"
13: "let %x14: Tensor[(1, 10), float32] = nn.dense(%x13, %ip2_w, units=10) /* ty=Tensor[(1, 10), float32] */;"
14: "let %x16: Tensor[(10), float32] = multiply(%x15, %ip2_b) /* ty=Tensor[(10), float32] */;"
15: "let %x17: Tensor[(1, 10), float32] = nn.bias_add(%x14, %x16) /* ty=Tensor[(1, 10), float32] */;"
(16, test.test) : "let %x18: Tensor[(1, 10), float32] = nn.softmax(%x17, axis=1) /* ty=Tensor[(1, 10), float32] */;"
```

Example invocation:
```
fud e --to debugger lenet.relay -s relay.flags "--write-metadata meta.json" -s debugger.flags "--source meta.json" -q 
```