### PR TITLE
better error message when the group uses static=0 annotation

### DIFF
--- a/calyx/src/passes/well_formed.rs
+++ b/calyx/src/passes/well_formed.rs
@@ -160,15 +160,18 @@ impl Visitor for WellFormed {
         let const_done_assign =
             asgn.guard.is_true() && asgn.src.borrow().is_constant(1, 1);
 
-        // A group with a constant done condition are not allowed.
+        if const_done_assign {
+            return Err(Error::malformed_structure("Group with constant done condition is invalid. Use `comb group` instead to define a combinational group.").with_pos(&group.attributes));
+        }
+
+        // A group with "static"=0 annotation
         if group
             .attributes
             .get("static")
             .map(|v| *v == 0)
             .unwrap_or(false)
-            || const_done_assign
         {
-            return Err(Error::malformed_structure("Group with constant done condition are invalid. Use `comb group` instead to define a combinational group.").with_pos(&group.attributes));
+            return Err(Error::malformed_structure("Group with annotation \"static\"=0 is invalid. Use `comb group` instead to define a combinational group or if the group's done condition is not constant, provide the correct \"static\" annotation.").with_pos(&group.attributes));
         }
 
         Ok(Action::Continue)


### PR DESCRIPTION
Fixes the confusing error message Pai ran into.
