### PR TITLE
[Calyx/Cider + Frontends] Metadata rewrite

### DIFF
--- a/calyx-py/calyx/py_ast.py
+++ b/calyx-py/calyx/py_ast.py
@@ -360,7 +360,7 @@ class Metadata:
     metadata_map: Dict[any, str]
 
     def doc(self) -> str:
-        out = "METADATA #{\n"
+        out = "metadata #{\n"
         for key, val in self.metadata_map.items():
             out += f"{key}: {val}\n"
         out += "}#"

--- a/calyx-py/calyx/py_ast.py
+++ b/calyx-py/calyx/py_ast.py
@@ -355,6 +355,18 @@ class If(Control):
         return block(cond, true_branch, sep="") + false_branch
 
 
+@dataclass
+class Metadata:
+    metadata_map: Dict[any, str]
+
+    def doc(self) -> str:
+        out = "METADATA #{\n"
+        for key, val in self.metadata_map.items():
+            out += f"{key}: {val}\n"
+        out += "}#"
+        return out
+
+
 ### Standard Library ###
 
 

--- a/calyx-py/calyx/py_ast.py
+++ b/calyx-py/calyx/py_ast.py
@@ -357,7 +357,7 @@ class If(Control):
 
 @dataclass
 class Metadata:
-    metadata_map: Dict[any, str]
+    metadata_map: dict[any, str]
 
     def doc(self) -> str:
         out = "metadata #{\n"

--- a/calyx/src/frontend/ast.rs
+++ b/calyx/src/frontend/ast.rs
@@ -17,6 +17,8 @@ pub struct NamespaceDef {
     pub components: Vec<ComponentDef>,
     /// Extern statements and any primitive declarations in them.
     pub externs: Vec<(String, Vec<ir::Primitive>)>,
+    /// Optional opaque metadata
+    pub metadata: Option<String>,
 }
 
 impl NamespaceDef {

--- a/calyx/src/frontend/syntax.pest
+++ b/calyx/src/frontend/syntax.pest
@@ -42,13 +42,16 @@ comb = { "comb" }
 file = {
       SOI
       ~ imports
-      ~ extern_or_component*
+      ~ externs_and_comps
+      ~ metadata?
       ~ EOI
 }
 
 extern_or_component = {
   component | ext
 }
+
+externs_and_comps = { extern_or_component* }
 
 component = {
       "component" ~ name_with_attribute ~ signature
@@ -273,3 +276,10 @@ stmt = {
 control = {
       "control" ~ (("{" ~ "}") | block)
 }
+
+// metadata
+
+any_char = { ANY }
+metadata_char = ${ !"}#" ~ any_char }
+
+metadata = ${ ^"metadata" ~ WHITESPACE* ~ "#{" ~ metadata_char* ~ "}#"}

--- a/calyx/src/frontend/workspace.rs
+++ b/calyx/src/frontend/workspace.rs
@@ -47,6 +47,8 @@ pub struct Workspace {
     pub externs: Vec<(PathBuf, Vec<ir::Primitive>)>,
     /// Original import statements present in the top-level file.
     pub original_imports: Vec<String>,
+    /// Optional opaque metadata attached to the top-level file
+    pub metadata: Option<String>,
 }
 
 impl Workspace {
@@ -161,6 +163,10 @@ impl Workspace {
 
         // Add original imports to workspace
         workspace.original_imports = namespace.imports.clone();
+
+        // TODO (griffin): Probably not a great idea to clone the metadata
+        // string but it works for now
+        workspace.metadata = namespace.metadata.clone();
 
         // Function to merge contents of a namespace into the workspace and
         // return the dependencies that need to be parsed next.

--- a/calyx/src/ir/context.rs
+++ b/calyx/src/ir/context.rs
@@ -98,6 +98,6 @@ pub struct Context {
     /// Configuration flags for backends.
     pub bc: BackendConf,
     /// Extra options provided to the command line.
-    /// Interperted by individual passes
+    /// Interpreted by individual passes
     pub extra_opts: Vec<String>,
 }

--- a/calyx/src/ir/context.rs
+++ b/calyx/src/ir/context.rs
@@ -93,7 +93,7 @@ pub struct Context {
     pub components: Vec<Component>,
     /// Library definitions imported by the program.
     pub lib: LibrarySignatures,
-    // Entrypoint for the program
+    /// Entrypoint for the program
     pub entrypoint: Id,
     /// Configuration flags for backends.
     pub bc: BackendConf,

--- a/calyx/src/ir/context.rs
+++ b/calyx/src/ir/context.rs
@@ -100,4 +100,6 @@ pub struct Context {
     /// Extra options provided to the command line.
     /// Interpreted by individual passes
     pub extra_opts: Vec<String>,
+    /// An optional opaque metadata string which is used by Cider
+    pub metadata: Option<String>,
 }

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -156,6 +156,7 @@ pub fn ast_to_ir(mut workspace: frontend::Workspace) -> CalyxResult<Context> {
         bc: BackendConf::default(),
         entrypoint,
         extra_opts: vec![],
+        metadata: workspace.metadata,
     })
 }
 

--- a/calyx/src/ir/printer.rs
+++ b/calyx/src/ir/printer.rs
@@ -526,7 +526,7 @@ impl Printer {
     /// Formats the top-level metadata if present
     pub fn format_metadata(metadata: &Option<String>) -> String {
         if let Some(metadata_str) = metadata {
-            format!("METADATA #{{\n{}\n}}#\n", metadata_str)
+            format!("metadata #{{\n{}\n}}#\n", metadata_str)
         } else {
             String::new()
         }

--- a/calyx/src/ir/printer.rs
+++ b/calyx/src/ir/printer.rs
@@ -526,7 +526,7 @@ impl Printer {
     /// Formats the top-level metadata if present
     pub fn format_metadata(metadata: &Option<String>) -> String {
         if let Some(metadata_str) = metadata {
-            format!("METADATA #{{\n{}\n}}#", metadata_str)
+            format!("METADATA #{{\n{}\n}}#\n", metadata_str)
         } else {
             String::new()
         }

--- a/calyx/src/ir/printer.rs
+++ b/calyx/src/ir/printer.rs
@@ -522,4 +522,13 @@ impl Printer {
             ),
         }
     }
+
+    /// Formats the top-level metadata if present
+    pub fn format_metadata(metadata: &Option<String>) -> String {
+        if let Some(metadata_str) = metadata {
+            format!("METADATA #{{\n{}\n}}#", metadata_str)
+        } else {
+            String::new()
+        }
+    }
 }

--- a/frontends/relay/relay_visitor.py
+++ b/frontends/relay/relay_visitor.py
@@ -290,11 +290,8 @@ if __name__ == "__main__":
     parser.add_argument("file", help="Path to the Relay IR.")
     parser.add_argument(
         "--write-metadata",
-        type=str,
-        default=None,
-        help="the output file to write",
+        action="store_true",
         dest="write_metadata",
-        nargs="?",
     )
 
     args = parser.parse_args()
@@ -312,10 +309,8 @@ if __name__ == "__main__":
     relay_ir = relay.fromtext(relay_ir)
     calyx, metadata = emit_calyx(relay_ir)
 
-    if args.write_metadata is not None:
-
-        with open(args.write_metadata, "w") as f:
-            for key, val in metadata.items():
-                f.write(f"{key}: {val}\n")
-
     print(calyx)
+
+    if args.write_metadata:
+        metadata = Metadata(metadata)
+        print(metadata.doc())

--- a/frontends/systolic-lang/gen-systolic.py
+++ b/frontends/systolic-lang/gen-systolic.py
@@ -558,11 +558,8 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--write-metadata",
-        type=str,
-        default=None,
-        help="the output file to write",
+        action="store_true",
         dest="write_metadata",
-        nargs="?",
     )
 
     args = parser.parse_args()
@@ -596,11 +593,9 @@ if __name__ == "__main__":
         gen_metadata=args.write_metadata is not None,
     )
 
-    if args.write_metadata is not None:
-
-        with open(args.write_metadata, "w") as f:
-            for key, val in metadata.items():
-                f.write(f"{key}: {val}\n")
-
     program.emit()
     print(PE_DEF)
+
+    if args.write_metadata:
+        metadata = py_ast.Metadata(metadata)
+        print(metadata.doc())

--- a/frontends/systolic-lang/gen-systolic.py
+++ b/frontends/systolic-lang/gen-systolic.py
@@ -590,7 +590,7 @@ if __name__ == "__main__":
         top_depth=top_depth,
         left_length=left_length,
         left_depth=left_depth,
-        gen_metadata=args.write_metadata is not None,
+        gen_metadata=args.write_metadata,
     )
 
     program.emit()

--- a/interp/src/debugger/source/metadata.pest
+++ b/interp/src/debugger/source/metadata.pest
@@ -11,12 +11,12 @@ named_tag = { "(" ~ num ~ "," ~ id_string ~ ")" }
 tag = { named_tag | num }
 
 escaped_newline = @{ "\\" ~ NEWLINE }
-string_char = ${ !(NEWLINE) ~ ANY }
+string_char = ${ !(NEWLINE | EOI) ~ ANY }
 source_char = { escaped_newline | string_char }
 
 inner_position_string =  ${ source_char* }
 
-position_string = { inner_position_string ~ NEWLINE }
+position_string = { inner_position_string ~ (NEWLINE | &EOI) }
 
 entry = { tag ~ ":" ~ position_string}
 

--- a/interp/src/debugger/source/structures.rs
+++ b/interp/src/debugger/source/structures.rs
@@ -45,6 +45,13 @@ impl SourceMap {
             Ok(None)
         }
     }
+
+    pub fn from_string<S>(input: S) -> InterpreterResult<Self>
+    where
+        S: AsRef<str>,
+    {
+        super::metadata_parser::parse_metadata(input.as_ref())
+    }
 }
 
 impl From<HashMap<NamedTag, String>> for SourceMap {

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn main() -> CalyxResult<()> {
             ir::Printer::write_component(comp, out)?;
             writeln!(out)?
         }
-        writeln!(out, "{}", ir::Printer::format_metadata(&ctx.metadata))?;
+        write!(out, "{}", ir::Printer::format_metadata(&ctx.metadata))?;
         Ok(())
     } else {
         opts.run_backend(ctx)

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ fn main() -> CalyxResult<()> {
             ir::Printer::write_component(comp, out)?;
             writeln!(out)?
         }
+        writeln!(out, "{}", ir::Printer::format_metadata(&ctx.metadata))?;
         Ok(())
     } else {
         opts.run_backend(ctx)

--- a/tests/parsing/metadata.expect
+++ b/tests/parsing/metadata.expect
@@ -57,7 +57,7 @@ component main(go: 1, clk: 1, @go go0: 1, @clk clk0: 1, @reset reset: 1) -> (don
     }
   }
 }
-METADATA #{
+metadata #{
 1:test
 2: test
 3: this is some test metadata

--- a/tests/parsing/metadata.expect
+++ b/tests/parsing/metadata.expect
@@ -1,0 +1,65 @@
+import "primitives/core.futil";
+component add(left: 32, right: 32, go: 1, clk: 1, @go go0: 1, @clk clk0: 1, @reset reset: 1) -> (out: 32, done: 1, @done done0: 1) {
+  cells {
+    adder = std_add(32);
+    outpt = std_reg(32);
+  }
+  wires {
+    group do_add {
+      adder.left = left;
+      adder.right = right;
+      outpt.in = adder.out;
+      outpt.write_en = 1'd1;
+      do_add[done] = outpt.done;
+    }
+  }
+
+  control {
+    seq {
+      do_add;
+    }
+  }
+}
+component main(go: 1, clk: 1, @go go0: 1, @clk clk0: 1, @reset reset: 1) -> (done: 1, @done done0: 1) {
+  cells {
+    x = std_reg(32);
+    add_x = std_add(32);
+    my_add = add();
+    y = std_reg(32);
+  }
+  wires {
+    group wr_x {
+      x.in = 32'd1;
+      x.write_en = 1'd1;
+      wr_x[done] = x.done;
+    }
+    group rd_x {
+      add_x.left = x.out;
+      add_x.right = x.out;
+      rd_x[done] = 1'd1;
+    }
+    group wr_y {
+      y.in = 32'd10;
+      y.write_en = 1'd1;
+      wr_y[done] = y.done;
+    }
+  }
+
+  control {
+    seq {
+      wr_x;
+      rd_x;
+      wr_y;
+      invoke my_add(
+        left = y.out,
+        right = 32'd1
+      )();
+    }
+  }
+}
+METADATA #{
+1:test
+2: test
+3: this is some test metadata
+(4, main): boop
+}#


### PR DESCRIPTION
This implements the proposal in #994, the only major difference with the described minimum proposal is that this uses `#{` and `}#` as the delimiting characters, rather than `{` and `}` as the latter are likely to appear in source positions.

This means that the metadata now appears at the end of the file like:
```
...
METADATA #{ 
 // Some stuff
}#
```

On the IR side the stuff between the brackets is treated as an opaque string so it only gets parsed as the metadata source map when given to Cider.

The main benefit is that this simplifies the user calls, so that the following now suffices to pass source position from the frontends
```
fud e --to debugger tests/frontend/systolic/array-3.systolic -s systolic.flags "--write-metadata " -q
```
```
fud e --to debugger lenet.relay -s relay.flags "--write-metadata " -q
```

If metadata is not present or an empty string it is not printed by the IR printer. 

There are also some minor changes to the language parser to accommodate the optional existence of metadata, mostly because `pest_consume` was fighting me