### PR TITLE
Disable terminal spinner for Terminal states like --to debugger

### DIFF
--- a/fud/fud/executor.py
+++ b/fud/fud/executor.py
@@ -90,6 +90,10 @@ class Executor:
 
     # Control spinner behavior
     def disable_spinner(self):
+        """
+        Stop and disable the spinner
+        """
+        self._spinner.stop()
         self._no_spinner = True
 
     def enable_spinner(self):
@@ -120,12 +124,6 @@ class Executor:
                 self._spinner.succeed(msg)
         self.ctx = None
         self._update()
-
-    def _stop(self):
-        """
-        Stops the spinner associated with this executor.
-        """
-        self._spinner.stop()
 
 
 class ContextExecutor(object):

--- a/fud/fud/stages/xilinx/xclbin.py
+++ b/fud/fud/stages/xilinx/xclbin.py
@@ -19,9 +19,9 @@ def get_ports(kernel_xml):
     """
     tree = ET.parse(kernel_xml)
     root = tree.getroot()
-    for port in root.iter('port'):
-        if port.attrib['mode'] == 'master':
-            yield port.attrib['name']
+    for port in root.iter("port"):
+        if port.attrib["mode"] == "master":
+            yield port.attrib["name"]
 
 
 class XilinxStage(Stage):
@@ -81,13 +81,17 @@ class XilinxStage(Stage):
         @builder.step(package_cmd)
         def package_xo(client: SourceType.UnTyped, tmpdir: SourceType.String):
             # Get the AXI port names.
-            port_names = list(get_ports(Path(tmpdir) / 'kernel.xml'))
+            port_names = list(get_ports(Path(tmpdir) / "kernel.xml"))
 
             # Run the .xo packager Vivado script.
-            self._shell(client, package_cmd.format(
-                tmpdir=tmpdir,
-                port_names=' '.join(port_names),
-            ), remote_exec)
+            self._shell(
+                client,
+                package_cmd.format(
+                    tmpdir=tmpdir,
+                    port_names=" ".join(port_names),
+                ),
+                remote_exec,
+            )
 
         xclbin_cmd = (
             "cd {tmpdir} && "


### PR DESCRIPTION
Fixes the problem with `fud` spinner when using `--to debugger`.
