### PR TITLE
[Cider] Some UX fixes and patching cider-side dahlia source bug

### DIFF
--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -250,6 +250,7 @@ impl Debugger {
                 Command::InfoWatch => self.debugging_ctx.print_watchpoints(),
                 Command::PrintPC => {
                     if let Some(map) = &self.source_map {
+                        let mut printed = false;
                         for x in component_interpreter
                             .get_active_tree()
                             .remove(0)
@@ -257,11 +258,23 @@ impl Debugger {
                             .into_iter()
                         {
                             if let Some(output) = map.lookup(x) {
+                                printed = true;
                                 println!("{}", output);
                             }
                         }
+
+                        if !printed {
+                            println!("Falling back to Calyx");
+                            print!(
+                                "{}",
+                                component_interpreter
+                                    .get_active_tree()
+                                    .remove(0)
+                                    .format_tree::<true>(0)
+                            )
+                        }
                     } else {
-                        println!(
+                        print!(
                             "{}",
                             component_interpreter
                                 .get_active_tree()

--- a/interp/src/debugger/name_tree.rs
+++ b/interp/src/debugger/name_tree.rs
@@ -76,6 +76,7 @@ impl ActiveTreeNode {
     }
 }
 
+#[derive(Debug)]
 pub struct ActiveVec(Vec<GroupQualifiedInstanceName>);
 
 impl From<Vec<GroupQualifiedInstanceName>> for ActiveVec {

--- a/interp/src/interpreter/group_interpreter.rs
+++ b/interp/src/interpreter/group_interpreter.rs
@@ -54,6 +54,7 @@ impl From<EnableHolder> for AssignmentHolder {
             EnableHolder::Group(grp) => AssignmentHolder::Group(grp),
             EnableHolder::CombGroup(cgrp) => AssignmentHolder::CombGroup(cgrp),
             EnableHolder::Vec(v) => AssignmentHolder::Vec(v),
+            EnableHolder::Enable(e) => AssignmentHolder::Group(e.group.clone()),
         }
     }
 }

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -9,6 +9,7 @@ use interp::{
 };
 
 use argh::FromArgs;
+use rustyline::error::ReadlineError;
 use slog::warn;
 use std::{
     path::{Path, PathBuf},
@@ -102,7 +103,11 @@ fn print_res(
             };
             Ok(())
         }
-        Err(InterpreterError::Exit) => Ok(()), // The exit command doesn't cause an error code
+        Err(InterpreterError::Exit)
+        | Err(InterpreterError::ReadlineError(ReadlineError::Eof)) => {
+            println!("Exiting.");
+            Ok(())
+        } // The exit command doesn't cause an error code
         Err(e) => Err(e),
     }
 }

--- a/interp/src/structures/names.rs
+++ b/interp/src/structures/names.rs
@@ -199,6 +199,7 @@ impl std::fmt::Debug for GroupQualifiedInstanceName {
         f.debug_struct("GroupQualifiedInstanceName")
             .field("prefix", &self.prefix.as_id())
             .field("group", &self.group)
+            .field("tag", &self.pos_tag)
             .finish()
     }
 }


### PR DESCRIPTION
Fixes a bug with the position tag extraction for group enables which closes the loop on Dahlia source position. Also cleans up some of the code around managing breakpoints and adds better feedback for those commands. Changes the way cider processes EOFs, so that it will be possible to build a runt test suite for the debugger behavior.