### PR TITLE
[Interpreter] Checkpoint for improving docs

### DIFF
--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -13,7 +13,7 @@ use crate::interpreter::{ComponentInterpreter, ConstCell, Interpreter};
 use crate::structures::names::{CompGroupName, ComponentQualifiedInstanceName};
 use crate::structures::state_views::StateView;
 use crate::utils::AsRaw;
-use crate::{interpreter_ir as iir, primitives::Serializeable};
+use crate::{interpreter_ir as iir, primitives::Serializable};
 use calyx::ir::{self, Id, RRC};
 use std::fmt::Write;
 
@@ -459,7 +459,7 @@ fn print_cell(
         PrintMode::State => {
             let code = code.as_ref().copied().unwrap_or(PrintCode::Binary);
             let cell_state = state.get_cell_state(&cell_ref, &code);
-            if matches!(&cell_state, &Serializeable::Empty) {
+            if matches!(&cell_state, &Serializable::Empty) {
                 format!(
                     "{} cell {} has no internal state",
                     SPACING,

--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -7,10 +7,11 @@ use super::{
     io_utils::Input,
 };
 use crate::debugger::source::SourceMap;
-use crate::environment::{InterpreterState, PrimitiveMap, StateView};
+use crate::environment::{InterpreterState, PrimitiveMap};
 use crate::errors::{InterpreterError, InterpreterResult};
 use crate::interpreter::{ComponentInterpreter, ConstCell, Interpreter};
 use crate::structures::names::{CompGroupName, ComponentQualifiedInstanceName};
+use crate::structures::state_views::StateView;
 use crate::utils::AsRaw;
 use crate::{interpreter_ir as iir, primitives::Serializeable};
 use calyx::ir::{self, Id, RRC};

--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -20,8 +20,8 @@ use std::fmt::Write;
 pub(super) const SPACING: &str = "    ";
 
 /// The interactive Calyx debugger. The debugger itself is run with the
-/// [main_loop] function while this struct holds auxilliary information used to
-/// coordinate the debugging process.
+/// [Debugger::main_loop] function while this struct holds auxilliary
+/// information used to coordinate the debugging process.
 pub struct Debugger {
     _context: iir::ComponentCtx,
     main_component: Rc<iir::Component>,

--- a/interp/src/interpreter/component_interpreter.rs
+++ b/interp/src/interpreter/component_interpreter.rs
@@ -9,13 +9,14 @@ use super::{
 };
 use crate::{
     debugger::{name_tree::ActiveTreeNode, PrintCode},
-    environment::{InterpreterState, MutStateView, StateView},
+    environment::InterpreterState,
     errors::InterpreterResult,
     interpreter_ir as iir,
     primitives::{Named, Primitive},
     structures::names::{
         ComponentQualifiedInstanceName, GroupQIN, GroupQualifiedInstanceName,
     },
+    structures::state_views::{MutStateView, StateView},
     utils::AsRaw,
     values::Value,
 };

--- a/interp/src/interpreter/component_interpreter.rs
+++ b/interp/src/interpreter/component_interpreter.rs
@@ -467,10 +467,10 @@ impl Primitive for ComponentInterpreter {
     fn serialize(
         &self,
         _signed: Option<PrintCode>,
-    ) -> crate::primitives::Serializeable {
-        crate::primitives::Serializeable::Full(
+    ) -> crate::primitives::Serializable {
+        crate::primitives::Serializable::Full(
             self.get_env()
-                .gen_serialzer(matches!(_signed, Some(PrintCode::Binary))),
+                .gen_serializer(matches!(_signed, Some(PrintCode::Binary))),
         )
     }
 

--- a/interp/src/interpreter/control_interpreter.rs
+++ b/interp/src/interpreter/control_interpreter.rs
@@ -10,12 +10,12 @@ use crate::structures::names::{
 };
 use crate::utils::AsRaw;
 use crate::{
-    environment::{
-        CompositeView, InterpreterState, MutCompositeView, MutStateView,
-        StateView,
-    },
+    environment::InterpreterState,
     errors::InterpreterResult,
     interpreter::utils::ConstPort,
+    structures::state_views::{
+        CompositeView, MutCompositeView, MutStateView, StateView,
+    },
     values::Value,
 };
 use calyx::errors::WithPos;

--- a/interp/src/interpreter/interpreter_trait.rs
+++ b/interp/src/interpreter/interpreter_trait.rs
@@ -23,7 +23,7 @@ pub trait Interpreter {
     /// conditions.
     fn converge(&mut self) -> InterpreterResult<()>;
 
-    /// Advance the interpreter until [is_done] is true. This comes with a
+    /// Advance the interpreter until [Interpreter::is_done] is true. This comes with a
     /// default implementation which calls step in a while loop, however it is
     /// usually more efficient to override this with run calls to the
     /// appropriate subcomponents.
@@ -37,7 +37,7 @@ pub trait Interpreter {
     /// Consumes the interpreter and returns the concluding [InterpreterState].
     ///
     /// # Panics
-    /// If [is_done] is false
+    /// If [Interpreter::is_done] is false
     fn deconstruct(self) -> InterpreterResult<InterpreterState>;
 
     /// Return whether the interpreter has finished executing

--- a/interp/src/interpreter/interpreter_trait.rs
+++ b/interp/src/interpreter/interpreter_trait.rs
@@ -7,11 +7,26 @@ use crate::{
     structures::names::GroupQIN,
 };
 
+/// The core interpreter trait which defines the methods each interpretation
+/// construct must support. This trait is implemented by each of the control
+/// interpreters and the component interpreter but not the
+/// [AssignmentInterpreter](interp::interpreter::group_interpreter::AssignmentInterpreter])
 pub trait Interpreter {
+    /// Advance the interpreter by a "clock" cycle. This should advance stateful
+    /// components and potentially change the state machines for control
+    /// structures.
     fn step(&mut self) -> InterpreterResult<()>;
 
+    /// Performs combinational convergence for the underlying interpreter
+    /// subtree. This updates the combinational paths of all cells in the active
+    /// subtree. This is primarially used for evaluating combinational groups in
+    /// conditions.
     fn converge(&mut self) -> InterpreterResult<()>;
 
+    /// Advance the interpreter until [is_done] is true. This comes with a
+    /// default implementation which calls step in a while loop, however it is
+    /// usually more efficient to override this with run calls to the
+    /// appropriate subcomponents.
     fn run(&mut self) -> InterpreterResult<()> {
         while !self.is_done() {
             self.step()?;
@@ -19,18 +34,32 @@ pub trait Interpreter {
         Ok(())
     }
 
+    /// Consumes the interpreter and returns the concluding [InterpreterState].
+    ///
+    /// # Panics
+    /// If [is_done] is false
     fn deconstruct(self) -> InterpreterResult<InterpreterState>;
 
+    /// Return whether the interpreter has finished executing
     fn is_done(&self) -> bool;
 
+    /// Returns an immutable handle to the environment underneath the given
+    /// interpreter.
     fn get_env(&self) -> StateView<'_>;
 
+    /// Returns the currently executing non-combinational groups
     fn currently_executing_group(&self) -> HashSet<GroupQIN>;
 
+    /// Returns a mutable handle to the environment underneath the given
+    /// interpreter
     fn get_env_mut(&mut self) -> MutStateView<'_>;
 
+    /// Returns the active sub-tree of interpreter nodes. Used in the debugging
+    /// flow.
     fn get_active_tree(&self) -> Vec<ActiveTreeNode>;
 
+    /// Utility method which runs the interpreter and deconstructs it all in one
+    /// step.
     fn run_and_deconstruct(mut self) -> InterpreterResult<InterpreterState>
     where
         Self: Sized,

--- a/interp/src/interpreter/interpreter_trait.rs
+++ b/interp/src/interpreter/interpreter_trait.rs
@@ -2,9 +2,10 @@ use std::collections::HashSet;
 
 use crate::{
     debugger::name_tree::ActiveTreeNode,
-    environment::{InterpreterState, MutStateView, StateView},
+    environment::InterpreterState,
     errors::InterpreterResult,
     structures::names::GroupQIN,
+    structures::state_views::{MutStateView, StateView},
 };
 
 /// The core interpreter trait which defines the methods each interpretation

--- a/interp/src/interpreter/mod.rs
+++ b/interp/src/interpreter/mod.rs
@@ -1,3 +1,5 @@
+//! The machinery for interpreting a Calyx program
+
 mod component_interpreter;
 mod control_interpreter;
 mod group_interpreter;

--- a/interp/src/macros.rs
+++ b/interp/src/macros.rs
@@ -13,11 +13,11 @@
 /// });
 ///
 /// ```
-/// The macro implementes the [[Primitive]] trait for the struct as well as
-/// `StdAdd::new(bindings: ir::Params)` and `StdAdd::from_constants(ports)`
+/// The macro implements the [Primitive](crate::primitives::Primitive) trait
+/// for the struct as well as `StdAdd::new(bindings: ir::Params)` and
+/// `StdAdd::from_constants(ports)`
 ///
-/// TODO(rachit): $out_width is never used.
-/// (TODO: Griffin) fix the copy-paste
+/// TODO(rachit): $out_width is never used. (TODO: Griffin) fix the copy-paste
 #[macro_export]
 macro_rules! comb_primitive {
     ($name:ident[

--- a/interp/src/primitives/combinational.rs
+++ b/interp/src/primitives/combinational.rs
@@ -77,9 +77,9 @@ impl Primitive for StdConst {
     fn serialize(
         &self,
         code: Option<crate::debugger::PrintCode>,
-    ) -> super::Serializeable {
+    ) -> super::Serializable {
         let code = code.unwrap_or(crate::debugger::PrintCode::Unsigned);
-        super::Serializeable::Val(super::Entry::from_val_code(
+        super::Serializable::Val(super::Entry::from_val_code(
             &self.value,
             &code,
         ))

--- a/interp/src/primitives/mod.rs
+++ b/interp/src/primitives/mod.rs
@@ -2,7 +2,7 @@ mod primitive;
 pub use primitive::Entry;
 pub use primitive::Named;
 pub use primitive::Primitive;
-pub use primitive::Serializeable;
+pub use primitive::Serializable;
 
 pub mod combinational;
 pub(super) mod prim_utils;

--- a/interp/src/primitives/primitive.rs
+++ b/interp/src/primitives/primitive.rs
@@ -54,8 +54,8 @@ pub trait Primitive: Named {
     ) -> InterpreterResult<Vec<(ir::Id, Value)>>;
 
     /// Serialize the state of this primitive, if any.
-    fn serialize(&self, _code: Option<PrintCode>) -> Serializeable {
-        Serializeable::Empty
+    fn serialize(&self, _code: Option<PrintCode>) -> Serializable {
+        Serializable::Empty
     }
 
     // more efficient to override this with true in stateful cases
@@ -175,43 +175,43 @@ impl Debug for Entry {
 }
 
 #[derive(Clone)]
-pub enum Serializeable {
+pub enum Serializable {
     Empty,
     Val(Entry),
     Array(Vec<Entry>, Shape),
     Full(FullySerialize),
 }
 
-impl Serializeable {
+impl Serializable {
     pub fn has_state(&self) -> bool {
-        !matches!(self, Serializeable::Empty)
+        !matches!(self, Serializable::Empty)
     }
 }
 
-impl Display for Serializeable {
+impl Display for Serializable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Serializeable::Empty => write!(f, ""),
-            Serializeable::Val(v) => write!(f, "{}", v),
-            Serializeable::Array(arr, shape) => {
+            Serializable::Empty => write!(f, ""),
+            Serializable::Val(v) => write!(f, "{}", v),
+            Serializable::Array(arr, shape) => {
                 write!(f, "{}", format_array(arr, shape))
             }
-            full @ Serializeable::Full(_) => {
+            full @ Serializable::Full(_) => {
                 write!(f, "{}", serde_json::to_string(full).unwrap())
             }
         }
     }
 }
 
-impl Serialize for Serializeable {
+impl Serialize for Serializable {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         match self {
-            Serializeable::Empty => serializer.serialize_unit(),
-            Serializeable::Val(u) => u.serialize(serializer),
-            Serializeable::Array(arr, shape) => {
+            Serializable::Empty => serializer.serialize_unit(),
+            Serializable::Val(u) => u.serialize(serializer),
+            Serializable::Array(arr, shape) => {
                 let arr: Vec<&Entry> = arr.iter().collect();
                 if shape.is_1d() {
                     return arr.serialize(serializer);
@@ -269,7 +269,7 @@ impl Serialize for Serializeable {
                     Shape::D1(_) => unreachable!(),
                 }
             }
-            Serializeable::Full(s) => s.serialize(serializer),
+            Serializable::Full(s) => s.serialize(serializer),
         }
     }
 }

--- a/interp/src/primitives/primitive.rs
+++ b/interp/src/primitives/primitive.rs
@@ -1,7 +1,7 @@
 use crate::{
-    environment::{FullySerialize, StateView},
     errors::InterpreterResult,
     interpreter::ComponentInterpreter,
+    structures::state_views::{FullySerialize, StateView},
     utils::PrintCode,
     values::Value,
 };

--- a/interp/src/primitives/stateful.rs
+++ b/interp/src/primitives/stateful.rs
@@ -1,6 +1,6 @@
 use super::prim_utils::{get_param, ShiftBuffer};
 use super::primitive::Named;
-use super::{Entry, Primitive, Serializeable};
+use super::{Entry, Primitive, Serializable};
 use crate::errors::{InterpreterError, InterpreterResult};
 use crate::logging::{self, warn};
 use crate::utils::{construct_bindings, PrintCode};
@@ -202,9 +202,9 @@ impl<const SIGNED: bool, const DEPTH: usize> Primitive
         ])
     }
 
-    fn serialize(&self, signed: Option<PrintCode>) -> Serializeable {
+    fn serialize(&self, signed: Option<PrintCode>) -> Serializable {
         let code = signed.unwrap_or_default();
-        Serializeable::Array(
+        Serializable::Array(
             vec![self.product.clone()]
                 .iter()
                 .map(|x| Entry::from_val_code(x, &code))
@@ -412,9 +412,9 @@ impl<const SIGNED: bool> Primitive for StdDivPipe<SIGNED> {
         ])
     }
 
-    fn serialize(&self, signed: Option<PrintCode>) -> Serializeable {
+    fn serialize(&self, signed: Option<PrintCode>) -> Serializable {
         let code = signed.unwrap_or_default();
-        Serializeable::Array(
+        Serializable::Array(
             //vec![self.left.clone(), self.right.clone(), self.product.clone()]
             vec![self.quotient.clone(), self.remainder.clone()]
                 .iter()
@@ -549,9 +549,9 @@ impl Primitive for StdReg {
         ])
     }
 
-    fn serialize(&self, signed: Option<PrintCode>) -> Serializeable {
+    fn serialize(&self, signed: Option<PrintCode>) -> Serializable {
         let code = signed.unwrap_or_default();
-        Serializeable::Val(Entry::from_val_code(&self.data[0], &code))
+        Serializable::Val(Entry::from_val_code(&self.data[0], &code))
     }
 }
 
@@ -777,9 +777,9 @@ impl Primitive for StdMemD1 {
         ])
     }
 
-    fn serialize(&self, signed: Option<PrintCode>) -> Serializeable {
+    fn serialize(&self, signed: Option<PrintCode>) -> Serializable {
         let code = signed.unwrap_or_default();
-        Serializeable::Array(
+        Serializable::Array(
             self.data
                 .iter()
                 .map(|x| Entry::from_val_code(x, &code))
@@ -1043,9 +1043,9 @@ impl Primitive for StdMemD2 {
         ])
     }
 
-    fn serialize(&self, signed: Option<PrintCode>) -> Serializeable {
+    fn serialize(&self, signed: Option<PrintCode>) -> Serializable {
         let code = signed.unwrap_or_default();
-        Serializeable::Array(
+        Serializable::Array(
             self.data
                 .iter()
                 .map(|x| Entry::from_val_code(x, &code))
@@ -1333,9 +1333,9 @@ impl Primitive for StdMemD3 {
         ])
     }
 
-    fn serialize(&self, signed: Option<PrintCode>) -> Serializeable {
+    fn serialize(&self, signed: Option<PrintCode>) -> Serializable {
         let code = signed.unwrap_or_default();
-        Serializeable::Array(
+        Serializable::Array(
             self.data
                 .iter()
                 .map(|x| Entry::from_val_code(x, &code))
@@ -1665,9 +1665,9 @@ impl Primitive for StdMemD4 {
         ])
     }
 
-    fn serialize(&self, signed: Option<PrintCode>) -> Serializeable {
+    fn serialize(&self, signed: Option<PrintCode>) -> Serializable {
         let code = signed.unwrap_or_default();
-        Serializeable::Array(
+        Serializable::Array(
             self.data
                 .iter()
                 .map(|x| Entry::from_val_code(x, &code))

--- a/interp/src/primitives/stateful.rs
+++ b/interp/src/primitives/stateful.rs
@@ -31,9 +31,9 @@ impl BinOpUpdate {
 /// How to use:
 /// [Primitive::execute] with the desired bindings.
 /// To capture these bindings into the internal (out) queue, [Primitive::do_tick].
-/// The product associated with a given input will be output on the third [do_tick()].
+/// The product associated with a given input will be output on the third [Primitive::do_tick()].
 /// Note: Calling [Primitive::execute] multiple times before [Primitive::do_tick] has no effect; only the last
-/// set of inputs prior to the [Primitve::do_tick] will be saved.
+/// set of inputs prior to the [Primitive::do_tick] will be saved.
 pub struct StdMultPipe<const SIGNED: bool, const DEPTH: usize> {
     width: u64,
     product: Value,
@@ -217,12 +217,12 @@ impl<const SIGNED: bool, const DEPTH: usize> Primitive
 ///Pipelined Division (3 cycles)
 ///Still bounded by u64.
 ///How to use:
-///[execute] with the desired bindings. To capture these bindings
-///into the internal (out_quotient, out_remainder) queue, [do_tick()].
+///[Primitive::execute] with the desired bindings. To capture these bindings
+///into the internal (out_quotient, out_remainder) queue, [Primitive::do_tick].
 ///The out_quotient and out_remainder associated with a given input will
-///be output on the third [do_tick()].
-///Note: Calling [execute] multiple times before [do_tick()] has no effect; only
-///the last set of inputs prior to the [do_tick()] will be saved.
+///be output on the third [Primitive::do_tick].
+///Note: Calling [Primitive::execute] multiple times before [Primitive::do_tick] has no effect; only
+///the last set of inputs prior to the [Primitive::do_tick] will be saved.
 pub struct StdDivPipe<const SIGNED: bool> {
     pub width: u64,
     pub quotient: Value,
@@ -561,7 +561,7 @@ impl Primitive for StdReg {
 /// * SIZE - Number of slots in the memory.
 /// * IDX_SIZE - The width of the index given to the memory.
 ///
-/// To write to a memory, the [write_en] must be high.
+/// To write to a memory, the `write_en` must be high.
 /// Inputs:
 /// * addr0: IDX_SIZE - The index to be accessed or updated.
 /// * write_data: WIDTH - Data to be written to the selected memory slot.
@@ -598,10 +598,11 @@ impl StdMemD1 {
         );
         Self::new(&bindings, full_name, false)
     }
-    /// Instantiates a new StdMemD1 storing data of width [width], containing [size]
-    /// slots for memory, accepting indecies (addr0) of width [idx_size].
-    /// Note: if [idx_size] is smaller than the length of [size]'s binary representation,
-    /// you will not be able to access the slots near the end of the memory.
+    /// Instantiates a new StdMemD1 storing data of width `width`, containing
+    /// `size` slots for memory, accepting indices (addr0) of width `idx_size`.
+    /// Note: if `idx_size` is smaller than the length of `size`'s binary
+    /// representation, you will not be able to access the slots near the end of
+    /// the memory.
     pub fn new(
         params: &ir::Binding,
         name: ir::Id,
@@ -806,7 +807,7 @@ impl Primitive for StdMemD1 {
 /// write_data: WIDTH - Data to be written to the selected memory slot
 /// write_en: 1 - One bit write enabled signal, causes the memory to write write_data to the slot indexed by addr0 and addr1
 /// Outputs:
-/// read_data: WIDTH - The value stored at mem[addr0][addr1]. This value is combinational with respect to addr0 and addr1.
+/// read_data: WIDTH - The value stored at mem\[addr0\]\[addr1\]. This value is combinational with respect to addr0 and addr1.
 /// done: 1: The done signal for the memory. This signal goes high for one cycle after finishing a write to the memory.
 #[derive(Clone, Debug)]
 pub struct StdMemD2 {
@@ -850,9 +851,9 @@ impl StdMemD2 {
         self.d0_size * self.d1_size
     }
 
-    /// Instantiates a new StdMemD2 storing data of width [width], containing
-    /// [d0_size] * [d1_size] slots for memory, accepting indecies [addr0][addr1] of widths
-    /// [d0_idx_size] and [d1_idx_size] respectively.
+    /// Instantiates a new StdMemD2 storing data of width `width`, containing
+    /// `d0_size` * `d1_size` slots for memory, accepting indices \[addr0\]\[addr1\] of widths
+    /// `d0_idx_size` and `d1_idx_size` respectively.
     /// Initially the memory is filled with all 0s.
     pub fn new(
         params: &ir::Binding,
@@ -1071,7 +1072,7 @@ impl Primitive for StdMemD2 {
 /// write_data: WIDTH - Data to be written to the selected memory slot
 /// write_en: 1 - One bit write enabled signal, causes the memory to write write_data to the slot indexed by addr0, addr1, and addr2
 /// Outputs:
-/// read_data: WIDTH - The value stored at mem[addr0][addr1][addr2]. This value is combinational with respect to addr0, addr1, and addr2.
+/// read_data: WIDTH - The value stored at mem\[addr0\]\[addr1\]\[addr2\]. This value is combinational with respect to addr0, addr1, and addr2.
 /// done: 1: The done signal for the memory. This signal goes high for one cycle after finishing a write to the memory.
 #[derive(Clone, Debug)]
 pub struct StdMemD3 {
@@ -1116,9 +1117,9 @@ impl StdMemD3 {
         );
         Self::new(&bindings, full_name, false)
     }
-    /// Instantiates a new StdMemD3 storing data of width [width], containing
-    /// [d0_size] * [d1_size] * [d2_size] slots for memory, accepting indecies [addr0][addr1][addr2] of widths
-    /// [d0_idx_size], [d1_idx_size], and [d2_idx_size] respectively.
+    /// Instantiates a new StdMemD3 storing data of width `width`, containing
+    /// `d0_size` * `d1_size` * `d2_size` slots for memory, accepting indices \[addr0\]\[addr1\]\[addr2\] of widths
+    /// \[d0_idx_size\], \[d1_idx_size\], and \[d2_idx_size\] respectively.
     /// Initially the memory is filled with all 0s.
     pub fn new(
         params: &ir::Binding,
@@ -1370,7 +1371,7 @@ impl Primitive for StdMemD3 {
 /// write_data: WIDTH - Data to be written to the selected memory slot
 /// write_en: 1 - One bit write enabled signal, causes the memory to write write_data to the slot indexed by addr0, addr1, addr2, and addr3
 /// Outputs:
-/// read_data: WIDTH - The value stored at mem[addr0][addr1][addr2][addr3]. This value is combinational with respect to addr0, addr1, addr2, and addr3.
+/// read_data: WIDTH - The value stored at mem\[addr0\]\[addr1\]\[addr2\]\[addr3\]. This value is combinational with respect to addr0, addr1, addr2, and addr3.
 /// done: 1: The done signal for the memory. This signal goes high for one cycle after finishing a write to the memory.
 #[derive(Clone, Debug)]
 pub struct StdMemD4 {
@@ -1421,9 +1422,9 @@ impl StdMemD4 {
         );
         Self::new(&bindings, full_name, false)
     }
-    // Instantiates a new StdMemD3 storing data of width [width], containing
-    /// [d0_size] * [d1_size] * [d2_size] * [d3_size] slots for memory, accepting indecies [addr0][addr1][addr2][addr3] of widths
-    /// [d0_idx_size], [d1_idx_size], [d2_idx_size] and [d3_idx_size] respectively.
+    // Instantiates a new StdMemD3 storing data of width `width`, containing
+    /// `d0_size` * `d1_size` * `d2_size` * `d3_size` slots for memory, accepting indecies `addr0``addr1``addr2``addr3` of widths
+    /// `d0_idx_size`, `d1_idx_size`, `d2_idx_size` and `d3_idx_size` respectively.
     /// Initially the memory is filled with all 0s.
     pub fn new(
         params: &ir::Binding,

--- a/interp/src/structures/environment.rs
+++ b/interp/src/structures/environment.rs
@@ -6,21 +6,19 @@ use super::names::{
 };
 use super::stk_env::StackMap;
 use crate::configuration::Config;
-use crate::debugger::{name_tree::ActiveTreeNode, PrintCode};
+use crate::debugger::name_tree::ActiveTreeNode;
 use crate::errors::{InterpreterError, InterpreterResult};
 use crate::interpreter::{ComponentInterpreter, Interpreter};
 use crate::interpreter_ir as iir;
-use crate::primitives::{
-    combinational, stateful, Entry, Primitive, Serializeable,
-};
+use crate::primitives::{combinational, stateful, Primitive};
+use crate::structures::state_views::StateView;
 use crate::{
     utils::{AsRaw, MemoryMap},
     values::Value,
 };
 use calyx::ir::{self, RRC};
-use serde::Serialize;
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::iter::once;
 use std::rc::Rc;
 
@@ -34,8 +32,7 @@ type ConstPort = *const ir::Port;
 
 /// A map defining primitive implementations for Cells. As it is keyed by
 /// ConstCell the lifetime of the keys is independent of the actual cells.
-pub(crate) type PrimitiveMap =
-    RRC<HashMap<ConstCell, Box<dyn crate::primitives::Primitive>>>;
+pub(crate) type PrimitiveMap = RRC<HashMap<ConstCell, Box<dyn Primitive>>>;
 
 /// A map defining values for ports. As it is keyed by ConstPort, the lifetime of
 /// the keys is independent of the ports. However as a result it is flat, rather
@@ -615,8 +612,9 @@ impl InterpreterState {
     }
 
     pub fn as_state_view(&self) -> StateView<'_> {
-        StateView::SingleView(self)
+        self.into()
     }
+
     pub fn get_active_tree(&self) -> Vec<ActiveTreeNode> {
         let lookup = self.cell_map.borrow();
 
@@ -626,298 +624,5 @@ impl InterpreterState {
                 lookup[x].get_comp_interpreter().unwrap().get_active_tree()
             })
             .collect()
-    }
-}
-
-impl Serialize for InterpreterState {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let sv: StateView = self.into();
-        sv.gen_serialzer(false).serialize(serializer)
-    }
-}
-#[allow(clippy::borrowed_box)]
-#[derive(Serialize, Clone)]
-/// Struct to fully serialize the internal state of the environment
-pub struct FullySerialize {
-    ports: BTreeMap<ir::Id, BTreeMap<ir::Id, BTreeMap<ir::Id, Entry>>>,
-    memories: BTreeMap<ir::Id, BTreeMap<ir::Id, Serializeable>>,
-}
-
-#[derive(Clone)]
-pub struct CompositeView<'a>(&'a InterpreterState, Vec<StateView<'a>>);
-
-impl<'a, 'outer> CompositeView<'a> {
-    pub fn new(state: &'a InterpreterState, vec: Vec<StateView<'a>>) -> Self {
-        Self(state, vec)
-    }
-}
-
-impl<'a> Serialize for StateView<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.gen_serialzer(false).serialize(serializer)
-    }
-}
-
-#[derive(Clone)]
-pub enum StateView<'inner> {
-    SingleView(&'inner InterpreterState),
-    Composite(CompositeView<'inner>),
-}
-
-impl<'a, 'outer> From<&'a InterpreterState> for StateView<'a> {
-    fn from(env: &'a InterpreterState) -> Self {
-        Self::SingleView(env)
-    }
-}
-
-impl<'a> From<CompositeView<'a>> for StateView<'a> {
-    fn from(cv: CompositeView<'a>) -> Self {
-        Self::Composite(cv)
-    }
-}
-
-impl<'a> StateView<'a> {
-    pub fn lookup<P: AsRaw<ir::Port>>(&self, target: P) -> &Value {
-        match self {
-            StateView::SingleView(sv) => sv.get_from_port(target),
-            StateView::Composite(cv) => match cv.1.len() {
-                0 => cv.0.get_from_port(target),
-                1 => cv.1[0].lookup(target),
-                _ => {
-                    let original = cv.0.get_from_port(target.as_raw());
-                    let new =
-                        cv.1.iter()
-                            .filter_map(|x| {
-                                let val = x.lookup(target.as_raw());
-                                if val == original {
-                                    None
-                                } else {
-                                    Some(val)
-                                }
-                            })
-                            .collect::<Vec<_>>();
-                    match new.len() {
-                        0 => original,
-                        1 => new[0],
-                        _ => panic!("conflicting parallel values"),
-                    }
-                }
-            },
-        }
-    }
-
-    pub fn sub_component_currently_executing(&self) -> HashSet<GroupQIN> {
-        match self {
-            StateView::SingleView(sv) => sv.sub_component_currently_executing(),
-            StateView::Composite(c) => c.0.sub_component_currently_executing(),
-        }
-    }
-
-    pub fn get_ctx(&self) -> &iir::ComponentCtx {
-        match self {
-            StateView::SingleView(sv) => &sv.context,
-            StateView::Composite(cv) => &cv.0.context,
-        }
-    }
-
-    pub fn get_cell_map(&self) -> &PrimitiveMap {
-        match self {
-            StateView::SingleView(sv) => &sv.cell_map,
-            StateView::Composite(cv) => &cv.0.cell_map,
-        }
-    }
-
-    pub fn get_comp(&self) -> &Rc<iir::Component> {
-        match self {
-            StateView::SingleView(c) => &c.component,
-            StateView::Composite(c) => &c.0.component,
-        }
-    }
-    pub fn get_active_tree(&self) -> Vec<ActiveTreeNode> {
-        match self {
-            StateView::SingleView(c) => c.get_active_tree(),
-            StateView::Composite(c) => c.0.get_active_tree(),
-        }
-    }
-
-    pub fn get_cell_state<R: AsRaw<ir::Cell>>(
-        &self,
-        cell: R,
-        print_code: &PrintCode,
-    ) -> Serializeable {
-        let map = self.get_cell_map();
-        let map_ref = map.borrow();
-        map_ref
-            .get(&cell.as_raw())
-            .map(|x| Primitive::serialize(&**x, Some(*print_code)))
-            .unwrap_or(Serializeable::Empty)
-    }
-
-    /// Returns a string representing the current state of the environment. This
-    /// just serializes the environment to a string and returns that string
-    pub fn state_as_str(&self) -> String {
-        serde_json::to_string_pretty(&self.gen_serialzer(false)).unwrap()
-    }
-
-    pub fn get_cells<S: AsRef<str> + Clone>(
-        &self,
-        name: &S,
-    ) -> Vec<RRC<ir::Cell>> {
-        let ctx_ref = self.get_ctx();
-        ctx_ref.iter().filter_map(|x| x.find_cell(name)).collect()
-    }
-
-    pub fn get_cell<S: AsRef<str> + Clone>(
-        &self,
-        name: S,
-    ) -> Option<RRC<ir::Cell>> {
-        match self {
-            StateView::SingleView(sv) => sv.component.find_cell(&name),
-            StateView::Composite(cv) => cv.0.component.find_cell(&name),
-        }
-    }
-
-    pub fn gen_serialzer(&self, raw: bool) -> FullySerialize {
-        let ctx = self.get_ctx();
-        let cell_prim_map = &self.get_cell_map().borrow();
-
-        let bmap: BTreeMap<_, _> = ctx
-            .iter()
-            .filter(|x| x.name == self.get_comp().name) // there should only be one such comp
-            .map(|comp| {
-                let inner_map: BTreeMap<_, _> = comp
-                    .cells
-                    .iter()
-                    .map(|cell| {
-                        let inner_map: BTreeMap<_, _> = cell
-                            .borrow()
-                            .ports
-                            .iter()
-                            .map(|port| {
-                                let value = self.lookup(port.as_raw());
-
-                                (
-                                    port.borrow().name.clone(),
-                                    if port
-                                        .borrow()
-                                        .attributes
-                                        .has("interp_signed")
-                                    {
-                                        value.as_i64().into()
-                                    } else {
-                                        value.as_u64().into()
-                                    },
-                                )
-                            })
-                            .collect();
-                        (cell.borrow().name().clone(), inner_map)
-                    })
-                    .collect();
-                (comp.name.clone(), inner_map)
-            })
-            .collect();
-        let cell_map: BTreeMap<_, _> = ctx
-            .iter()
-            .filter(|x| x.name == self.get_comp().name)
-            .map(|comp| {
-                let inner_map: BTreeMap<_, _> = comp
-                    .cells
-                    .iter()
-                    .filter_map(|cell_ref| {
-                        let cell = cell_ref.borrow();
-                        if cell.get_attribute("external").is_some() {
-                            if let Some(prim) = cell_prim_map
-                                .get(&(&cell as &ir::Cell as ConstCell))
-                            {
-                                if !prim.is_comb() {
-                                    return Some((
-                                        cell.name().clone(),
-                                        Primitive::serialize(
-                                            &**prim,
-                                            raw.then(|| PrintCode::Binary),
-                                        ), //TODO Griffin: Fix this
-                                    ));
-                                }
-                            }
-                        }
-                        None
-                    })
-                    .collect();
-                (comp.name.clone(), inner_map)
-            })
-            .collect();
-
-        FullySerialize {
-            ports: bmap,
-            memories: cell_map,
-        }
-    }
-}
-
-pub struct MutCompositeView<'a>(
-    &'a mut InterpreterState,
-    Vec<MutStateView<'a>>,
-);
-
-pub enum MutStateView<'inner> {
-    Single(&'inner mut InterpreterState),
-    Composite(MutCompositeView<'inner>),
-}
-
-impl<'inner> MutCompositeView<'inner> {
-    pub fn new(
-        state: &'inner mut InterpreterState,
-        vec: Vec<MutStateView<'inner>>,
-    ) -> Self {
-        Self(state, vec)
-    }
-    pub fn insert<P: AsRaw<ir::Port>>(&mut self, port: P, value: Value) {
-        let raw = port.as_raw();
-        self.0.insert(raw, value.clone());
-        for view in self.1.iter_mut() {
-            view.insert(raw, value.clone())
-        }
-    }
-}
-
-impl<'a> From<&'a mut InterpreterState> for MutStateView<'a> {
-    fn from(env: &'a mut InterpreterState) -> Self {
-        Self::Single(env)
-    }
-}
-
-impl<'a> From<MutCompositeView<'a>> for MutStateView<'a> {
-    fn from(mv: MutCompositeView<'a>) -> Self {
-        Self::Composite(mv)
-    }
-}
-
-impl<'a> MutStateView<'a> {
-    pub fn insert<P: AsRaw<ir::Port>>(&mut self, port: P, value: Value) {
-        match self {
-            MutStateView::Single(s) => s.insert(port, value),
-            MutStateView::Composite(c) => c.insert(port, value),
-        }
-    }
-}
-
-pub trait State {
-    fn lookup(&self, target: &*const ir::Port) -> &Value;
-    fn state_as_str(&self) -> String;
-}
-
-impl<'a> State for StateView<'a> {
-    fn lookup(&self, target: &*const ir::Port) -> &Value {
-        StateView::lookup(self, *target)
-    }
-
-    fn state_as_str(&self) -> String {
-        StateView::state_as_str(self)
     }
 }

--- a/interp/src/structures/environment.rs
+++ b/interp/src/structures/environment.rs
@@ -36,7 +36,7 @@ pub(crate) type PrimitiveMap = RRC<HashMap<ConstCell, Box<dyn Primitive>>>;
 
 /// A map defining values for ports. As it is keyed by ConstPort, the lifetime of
 /// the keys is independent of the ports. However as a result it is flat, rather
-/// than heirarchical which simplifies the access interface.
+/// than hierarchical which simplifies the access interface.
 type PortValMap = StackMap<ConstPort, Value>;
 
 /// The environment to interpret a Calyx program.

--- a/interp/src/structures/environment.rs
+++ b/interp/src/structures/environment.rs
@@ -465,7 +465,7 @@ impl InterpreterState {
         let sv: StateView = self.into();
         println!(
             "{}",
-            serde_json::to_string_pretty(&sv.gen_serialzer(true)).unwrap()
+            serde_json::to_string_pretty(&sv.gen_serializer(true)).unwrap()
         );
     }
     /// A predicate that checks if the given cell points to a combinational

--- a/interp/src/structures/mod.rs
+++ b/interp/src/structures/mod.rs
@@ -1,4 +1,5 @@
 pub mod environment;
 pub mod names;
+pub mod state_views;
 pub mod stk_env;
 pub mod values;

--- a/interp/src/structures/state_views.rs
+++ b/interp/src/structures/state_views.rs
@@ -226,14 +226,18 @@ impl<'a> StateView<'a> {
         serde_json::to_string_pretty(&self.gen_serializer(false)).unwrap()
     }
 
+    /// Return a vector RRCs for all cells (across any component) which have the given
+    /// name
     pub fn get_cells<S: AsRef<str> + Clone>(
         &self,
-        name: &S,
+        name: S,
     ) -> Vec<RRC<ir::Cell>> {
         let ctx_ref = self.get_ctx();
-        ctx_ref.iter().filter_map(|x| x.find_cell(name)).collect()
+        ctx_ref.iter().filter_map(|x| x.find_cell(&name)).collect()
     }
 
+    /// Return an RRC for the given cell if it exists within the root component
+    /// of the environment. Otherwise None
     pub fn get_cell<S: AsRef<str> + Clone>(
         &self,
         name: S,
@@ -244,6 +248,11 @@ impl<'a> StateView<'a> {
         }
     }
 
+    /// Generate a serializable representation of the environment. Used to
+    /// display the environment at the current component or to output at the end
+    /// of the program.
+    ///
+    /// Note this code is a complete nightmare and I apologize for it
     pub fn gen_serializer(&self, raw: bool) -> FullySerialize {
         let ctx = self.get_ctx();
         let cell_prim_map = &self.get_cell_map().borrow();
@@ -325,7 +334,10 @@ impl<'a> StateView<'a> {
 #[derive(Serialize, Clone)]
 /// Struct to fully serialize the internal state of the environment
 pub struct FullySerialize {
+    /// The serializable map of the port values
     ports: BTreeMap<ir::Id, BTreeMap<ir::Id, BTreeMap<ir::Id, Entry>>>,
+    /// The serializable map of the stateful cell values (generally just
+    /// memories and registers)
     memories: BTreeMap<ir::Id, BTreeMap<ir::Id, Serializable>>,
 }
 

--- a/interp/src/structures/state_views.rs
+++ b/interp/src/structures/state_views.rs
@@ -35,8 +35,7 @@ impl<'a, 'outer> CompositeView<'a> {
     }
 }
 
-/// An enum type wrapping the two possible concrete immutable state views. This
-/// type implements the [State] trait.
+/// An enum type wrapping the two possible concrete immutable state views.
 #[derive(Clone)]
 pub enum StateView<'inner> {
     /// Variant for a single [InterpreterState]
@@ -174,7 +173,7 @@ impl<'a> StateView<'a> {
         }
     }
 
-    /// A wrapper over [InterpreterState::get_ctx]
+    /// An accessor for the IR context
     pub fn get_ctx(&self) -> &iir::ComponentCtx {
         match self {
             StateView::SingleView(sv) => &sv.context,
@@ -206,7 +205,7 @@ impl<'a> StateView<'a> {
     }
 
     /// An accessor which looks up the representation of a the given cell's
-    /// state, defaulting to [Serializeable::Empty] if no state is present
+    /// state, defaulting to [Serializable::Empty] if no state is present
     pub fn get_cell_state<R: AsRaw<ir::Cell>>(
         &self,
         cell: R,

--- a/interp/src/structures/state_views.rs
+++ b/interp/src/structures/state_views.rs
@@ -22,14 +22,6 @@ use serde::Serialize;
 
 use super::names::GroupQIN;
 
-/// Trait for querying the state of ports
-pub trait State {
-    /// Retrieve the value of the given port
-    fn lookup(&self, target: &*const ir::Port) -> &Value;
-    /// Render the state of the program as a string
-    fn state_as_str(&self) -> String;
-}
-
 /// A concrete type wrapping a single borrowed reference and a vector of states.
 /// The former corresponds to the root environment of a par split while the
 /// latter contains the views for each par child.
@@ -115,16 +107,6 @@ impl<'a> MutStateView<'a> {
             MutStateView::Single(s) => s.insert(port, value),
             MutStateView::Composite(c) => c.insert(port, value),
         }
-    }
-}
-
-impl<'a> State for StateView<'a> {
-    fn lookup(&self, target: &*const ir::Port) -> &Value {
-        StateView::lookup(self, *target)
-    }
-
-    fn state_as_str(&self) -> String {
-        StateView::state_as_str(self)
     }
 }
 

--- a/interp/src/structures/state_views.rs
+++ b/interp/src/structures/state_views.rs
@@ -1,0 +1,346 @@
+//! Structures and Traits for viewing the state of the interpreter environment
+//!
+//! Unless you REALLY need to be here, all this irritating stuff is best left
+//! alone because it is fiddly and not all that interesting.
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    rc::Rc,
+};
+
+use crate::{
+    debugger::{name_tree::ActiveTreeNode, PrintCode},
+    environment::{InterpreterState, PrimitiveMap},
+    interpreter::ConstCell,
+    interpreter_ir as iir,
+    primitives::{Entry, Primitive, Serializeable},
+    utils::AsRaw,
+    values::Value,
+};
+use calyx::ir::{self, RRC};
+use serde::Serialize;
+
+use super::names::GroupQIN;
+
+/// Trait for querying the state of ports
+pub trait State {
+    /// Retrieve the value of the given port
+    fn lookup(&self, target: &*const ir::Port) -> &Value;
+    /// Render the state of the program as a string
+    fn state_as_str(&self) -> String;
+}
+
+/// A concrete type wrapping a single borrowed reference and a vector of states.
+/// The former corresponds to the root environment of a par split while the
+/// latter contains the views for each par child.
+#[derive(Clone)]
+pub struct CompositeView<'a>(&'a InterpreterState, Vec<StateView<'a>>);
+
+impl<'a, 'outer> CompositeView<'a> {
+    /// Basic constructor for the struct
+    pub fn new(state: &'a InterpreterState, vec: Vec<StateView<'a>>) -> Self {
+        Self(state, vec)
+    }
+}
+
+/// An enum type wrapping the two possible concrete immutable state views. This
+/// type implements the [State] trait.
+#[derive(Clone)]
+pub enum StateView<'inner> {
+    /// Variant for a single [InterpreterState]
+    SingleView(&'inner InterpreterState),
+    /// Variant for state views which correspond to multiple par branches
+    Composite(CompositeView<'inner>),
+}
+
+/// The mutable analogue to [CompositeView]. As with that struct, the first
+/// reference is the root environment of the par split and the latter vec is the
+/// environment for each of the par children.
+pub struct MutCompositeView<'a>(
+    &'a mut InterpreterState,
+    Vec<MutStateView<'a>>,
+);
+
+/// The mutable analogue to [StateView].
+pub enum MutStateView<'inner> {
+    /// Variant for a single [InterpreterState]
+    Single(&'inner mut InterpreterState),
+    /// Variant for a composite view corresponding to the state during the
+    /// execution of a par block
+    Composite(MutCompositeView<'inner>),
+}
+
+impl<'inner> MutCompositeView<'inner> {
+    /// Basic constructor for the struct
+    pub fn new(
+        state: &'inner mut InterpreterState,
+        vec: Vec<MutStateView<'inner>>,
+    ) -> Self {
+        Self(state, vec)
+    }
+
+    /// Updates the value of the given port to the given value in the
+    /// environment state. Note that this means updating the value in all arms
+    /// of the children and the root state (this latter point is needed to avoid
+    /// issues)
+    pub fn insert<P>(&mut self, port: P, value: Value)
+    where
+        P: AsRaw<ir::Port>,
+    {
+        let raw = port.as_raw();
+        self.0.insert(raw, value.clone());
+        for view in self.1.iter_mut() {
+            view.insert(raw, value.clone())
+        }
+    }
+}
+
+impl<'a> From<&'a mut InterpreterState> for MutStateView<'a> {
+    fn from(env: &'a mut InterpreterState) -> Self {
+        Self::Single(env)
+    }
+}
+
+impl<'a> From<MutCompositeView<'a>> for MutStateView<'a> {
+    fn from(mv: MutCompositeView<'a>) -> Self {
+        Self::Composite(mv)
+    }
+}
+
+impl<'a> MutStateView<'a> {
+    /// Updates the value of the given port to the given value for this state
+    /// view.
+    pub fn insert<P: AsRaw<ir::Port>>(&mut self, port: P, value: Value) {
+        match self {
+            MutStateView::Single(s) => s.insert(port, value),
+            MutStateView::Composite(c) => c.insert(port, value),
+        }
+    }
+}
+
+impl<'a> State for StateView<'a> {
+    fn lookup(&self, target: &*const ir::Port) -> &Value {
+        StateView::lookup(self, *target)
+    }
+
+    fn state_as_str(&self) -> String {
+        StateView::state_as_str(self)
+    }
+}
+
+impl<'a, 'outer> From<&'a InterpreterState> for StateView<'a> {
+    fn from(env: &'a InterpreterState) -> Self {
+        Self::SingleView(env)
+    }
+}
+
+impl<'a> From<CompositeView<'a>> for StateView<'a> {
+    fn from(cv: CompositeView<'a>) -> Self {
+        Self::Composite(cv)
+    }
+}
+
+impl<'a> StateView<'a> {
+    pub fn lookup<P: AsRaw<ir::Port>>(&self, target: P) -> &Value {
+        match self {
+            StateView::SingleView(sv) => sv.get_from_port(target),
+            StateView::Composite(cv) => match cv.1.len() {
+                0 => cv.0.get_from_port(target),
+                1 => cv.1[0].lookup(target),
+                _ => {
+                    let original = cv.0.get_from_port(target.as_raw());
+                    let new =
+                        cv.1.iter()
+                            .filter_map(|x| {
+                                let val = x.lookup(target.as_raw());
+                                if val == original {
+                                    None
+                                } else {
+                                    Some(val)
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                    match new.len() {
+                        0 => original,
+                        1 => new[0],
+                        _ => panic!("conflicting parallel values"),
+                    }
+                }
+            },
+        }
+    }
+
+    pub fn sub_component_currently_executing(&self) -> HashSet<GroupQIN> {
+        match self {
+            StateView::SingleView(sv) => sv.sub_component_currently_executing(),
+            StateView::Composite(c) => c.0.sub_component_currently_executing(),
+        }
+    }
+
+    pub fn get_ctx(&self) -> &iir::ComponentCtx {
+        match self {
+            StateView::SingleView(sv) => &sv.context,
+            StateView::Composite(cv) => &cv.0.context,
+        }
+    }
+
+    pub fn get_cell_map(&self) -> &PrimitiveMap {
+        match self {
+            StateView::SingleView(sv) => &sv.cell_map,
+            StateView::Composite(cv) => &cv.0.cell_map,
+        }
+    }
+
+    pub fn get_comp(&self) -> &Rc<iir::Component> {
+        match self {
+            StateView::SingleView(c) => &c.component,
+            StateView::Composite(c) => &c.0.component,
+        }
+    }
+    pub fn get_active_tree(&self) -> Vec<ActiveTreeNode> {
+        match self {
+            StateView::SingleView(c) => c.get_active_tree(),
+            StateView::Composite(c) => c.0.get_active_tree(),
+        }
+    }
+
+    pub fn get_cell_state<R: AsRaw<ir::Cell>>(
+        &self,
+        cell: R,
+        print_code: &PrintCode,
+    ) -> Serializeable {
+        let map = self.get_cell_map();
+        let map_ref = map.borrow();
+        map_ref
+            .get(&cell.as_raw())
+            .map(|x| Primitive::serialize(&**x, Some(*print_code)))
+            .unwrap_or(Serializeable::Empty)
+    }
+
+    /// Returns a string representing the current state of the environment. This
+    /// just serializes the environment to a string and returns that string
+    pub fn state_as_str(&self) -> String {
+        serde_json::to_string_pretty(&self.gen_serialzer(false)).unwrap()
+    }
+
+    pub fn get_cells<S: AsRef<str> + Clone>(
+        &self,
+        name: &S,
+    ) -> Vec<RRC<ir::Cell>> {
+        let ctx_ref = self.get_ctx();
+        ctx_ref.iter().filter_map(|x| x.find_cell(name)).collect()
+    }
+
+    pub fn get_cell<S: AsRef<str> + Clone>(
+        &self,
+        name: S,
+    ) -> Option<RRC<ir::Cell>> {
+        match self {
+            StateView::SingleView(sv) => sv.component.find_cell(&name),
+            StateView::Composite(cv) => cv.0.component.find_cell(&name),
+        }
+    }
+
+    pub fn gen_serialzer(&self, raw: bool) -> FullySerialize {
+        let ctx = self.get_ctx();
+        let cell_prim_map = &self.get_cell_map().borrow();
+
+        let bmap: BTreeMap<_, _> = ctx
+            .iter()
+            .filter(|x| x.name == self.get_comp().name) // there should only be one such comp
+            .map(|comp| {
+                let inner_map: BTreeMap<_, _> = comp
+                    .cells
+                    .iter()
+                    .map(|cell| {
+                        let inner_map: BTreeMap<_, _> = cell
+                            .borrow()
+                            .ports
+                            .iter()
+                            .map(|port| {
+                                let value = self.lookup(port.as_raw());
+
+                                (
+                                    port.borrow().name.clone(),
+                                    if port
+                                        .borrow()
+                                        .attributes
+                                        .has("interp_signed")
+                                    {
+                                        value.as_i64().into()
+                                    } else {
+                                        value.as_u64().into()
+                                    },
+                                )
+                            })
+                            .collect();
+                        (cell.borrow().name().clone(), inner_map)
+                    })
+                    .collect();
+                (comp.name.clone(), inner_map)
+            })
+            .collect();
+        let cell_map: BTreeMap<_, _> = ctx
+            .iter()
+            .filter(|x| x.name == self.get_comp().name)
+            .map(|comp| {
+                let inner_map: BTreeMap<_, _> = comp
+                    .cells
+                    .iter()
+                    .filter_map(|cell_ref| {
+                        let cell = cell_ref.borrow();
+                        if cell.get_attribute("external").is_some() {
+                            if let Some(prim) = cell_prim_map
+                                .get(&(&cell as &ir::Cell as ConstCell))
+                            {
+                                if !prim.is_comb() {
+                                    return Some((
+                                        cell.name().clone(),
+                                        Primitive::serialize(
+                                            &**prim,
+                                            raw.then(|| PrintCode::Binary),
+                                        ), //TODO Griffin: Fix this
+                                    ));
+                                }
+                            }
+                        }
+                        None
+                    })
+                    .collect();
+                (comp.name.clone(), inner_map)
+            })
+            .collect();
+
+        FullySerialize {
+            ports: bmap,
+            memories: cell_map,
+        }
+    }
+}
+
+#[allow(clippy::borrowed_box)]
+#[derive(Serialize, Clone)]
+/// Struct to fully serialize the internal state of the environment
+pub struct FullySerialize {
+    ports: BTreeMap<ir::Id, BTreeMap<ir::Id, BTreeMap<ir::Id, Entry>>>,
+    memories: BTreeMap<ir::Id, BTreeMap<ir::Id, Serializeable>>,
+}
+
+impl<'a> Serialize for StateView<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.gen_serialzer(false).serialize(serializer)
+    }
+}
+
+impl Serialize for InterpreterState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let sv: StateView = self.into();
+        sv.gen_serialzer(false).serialize(serializer)
+    }
+}

--- a/interp/src/structures/state_views.rs
+++ b/interp/src/structures/state_views.rs
@@ -13,7 +13,7 @@ use crate::{
     environment::{InterpreterState, PrimitiveMap},
     interpreter::ConstCell,
     interpreter_ir as iir,
-    primitives::{Entry, Primitive, Serializeable},
+    primitives::{Entry, Primitive, Serializable},
     utils::AsRaw,
     values::Value,
 };
@@ -211,19 +211,19 @@ impl<'a> StateView<'a> {
         &self,
         cell: R,
         print_code: &PrintCode,
-    ) -> Serializeable {
+    ) -> Serializable {
         let map = self.get_cell_map();
         let map_ref = map.borrow();
         map_ref
             .get(&cell.as_raw())
             .map(|x| Primitive::serialize(&**x, Some(*print_code)))
-            .unwrap_or(Serializeable::Empty)
+            .unwrap_or(Serializable::Empty)
     }
 
     /// Returns a string representing the current state of the environment. This
     /// just serializes the environment to a string and returns that string
     pub fn state_as_str(&self) -> String {
-        serde_json::to_string_pretty(&self.gen_serialzer(false)).unwrap()
+        serde_json::to_string_pretty(&self.gen_serializer(false)).unwrap()
     }
 
     pub fn get_cells<S: AsRef<str> + Clone>(
@@ -244,7 +244,7 @@ impl<'a> StateView<'a> {
         }
     }
 
-    pub fn gen_serialzer(&self, raw: bool) -> FullySerialize {
+    pub fn gen_serializer(&self, raw: bool) -> FullySerialize {
         let ctx = self.get_ctx();
         let cell_prim_map = &self.get_cell_map().borrow();
 
@@ -326,7 +326,7 @@ impl<'a> StateView<'a> {
 /// Struct to fully serialize the internal state of the environment
 pub struct FullySerialize {
     ports: BTreeMap<ir::Id, BTreeMap<ir::Id, BTreeMap<ir::Id, Entry>>>,
-    memories: BTreeMap<ir::Id, BTreeMap<ir::Id, Serializeable>>,
+    memories: BTreeMap<ir::Id, BTreeMap<ir::Id, Serializable>>,
 }
 
 impl<'a> Serialize for StateView<'a> {
@@ -334,7 +334,7 @@ impl<'a> Serialize for StateView<'a> {
     where
         S: serde::Serializer,
     {
-        self.gen_serialzer(false).serialize(serializer)
+        self.gen_serializer(false).serialize(serializer)
     }
 }
 
@@ -344,6 +344,6 @@ impl Serialize for InterpreterState {
         S: serde::Serializer,
     {
         let sv: StateView = self.into();
-        sv.gen_serialzer(false).serialize(serializer)
+        sv.gen_serializer(false).serialize(serializer)
     }
 }

--- a/interp/src/structures/stk_env.rs
+++ b/interp/src/structures/stk_env.rs
@@ -218,6 +218,10 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 }
 
+/// A type alias for the old name to preserve the functionality of the example
+/// code. This should be removed once the docs are modified accordingly
+pub type Smoosher<K, V> = StackMap<K, V>;
+
 ///A Stack of HashMaps that supports scoping
 ///
 ///Invariants:
@@ -1190,5 +1194,9 @@ mod priv_tests {
     }
 }
 
+/// An error for when multiple children maps disagree on a value.
 #[derive(Debug)]
-pub struct CollisionError<K: Eq + Hash, V: Eq>(pub K, pub V, pub V);
+pub struct CollisionError<K, V>(pub K, pub V, pub V)
+where
+    K: Eq + Hash,
+    V: Eq;

--- a/interp/src/structures/stk_env.rs
+++ b/interp/src/structures/stk_env.rs
@@ -57,14 +57,14 @@ impl<T> List<T> {
 
 /// The underlying, functional linked list used by the Smoosher.
 /// Taken from "Learning Rust with Entirely Too Many Linked Lists" (2018), Chapter 4.5
-/// Added the [same_head], [is_empty], and [split] functions.
+/// Added the [List::same_head], [List::is_empty], and [List::split] functions.
 impl<T> List<T> {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         List { head: None }
     }
 
-    /// Tests if the nodes at the head of [self] and [other] are equal;
+    /// Tests if the nodes at the head of `self` and `other` are equal;
     /// that is if the Rc points to the same location.
     /// # Example
     /// ```
@@ -89,7 +89,7 @@ impl<T> List<T> {
         Rc::as_ptr(self_head) == Rc::as_ptr(other_head)
     }
 
-    /// Tests if the head of [self] is [None], or [Some(nd)]
+    /// Tests if the head of `self` is [None], or [Some(nd)]
     ///
     /// # Example
     /// ```
@@ -103,7 +103,7 @@ impl<T> List<T> {
         self.head.is_none()
     }
 
-    /// Returns a list identical to [self], with [elem] pushed onto the front
+    /// Returns a list identical to `self`, with `elem` pushed onto the front
     pub fn push(&self, elem: T) -> List<T> {
         List {
             head: Some(Rc::new(Node {
@@ -113,19 +113,19 @@ impl<T> List<T> {
         }
     }
 
-    /// Returns a list identical to [self], with its head pointing to the second elem of [self]
+    /// Returns a list identical to `self`, with its head pointing to the second elem of `self`
     pub fn tail(&self) -> List<T> {
         List {
             head: self.head.as_ref().and_then(|node| node.next.clone()),
         }
     }
 
-    /// Consumes [self], returning a tuple of ([self.head : Option<T>], [self.tail : List<T>]),
-    /// where [tail] is all elements in [self] that are not [head]. If [self] is empty,
-    /// [split] will return ([None], [self])
+    /// Consumes self, returning a tuple of `(self.head : Option<T>, self.tail : List<T>)`,
+    /// where `tail` is all elements in `self` that are not `head`. If `self` is empty,
+    /// split will return (None, self)
     ///
     /// # Panics
-    /// Because [split] consumes [self], [split] panics if multiple lists exist that
+    /// Because [List::split] consumes self, split panics if multiple lists exist that
     /// share (references to the same) elements in their **tail**.
     /// # Example
     /// Good:
@@ -270,8 +270,8 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
         }
     }
 
-    /// If [self] and [other] share a fork point, returns a pair (depth_a, depth_b)
-    /// of the depth which the fork point can be found in [self] and [other], respectively.
+    /// If `self` and `other` share a fork point, returns a pair (depth_a, depth_b)
+    /// of the depth which the fork point can be found in `self` and `other`, respectively.
     /// NOTE: should be private, only public for testing!
     fn shared_fork_point(&self, other: &Self) -> Option<(u64, u64)> {
         //check head
@@ -304,7 +304,7 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
         //yea
     }
 
-    /// Returns an Option of a pointer to the highest-scoped binding to [k],
+    /// Returns an Option of a pointer to the highest-scoped binding to \[k\],
     /// if it exists. Else None.
     ///
     /// # Example
@@ -357,8 +357,8 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     }
 
     /// ```text
-    /// Returns a new Smoosher and mutates [self]. The new Smoosher has a new scope
-    /// as [head] and all of (pre-mutation) [self] as [tail]. [Self] has a fresh scope pushed onto
+    /// Returns a new Smoosher and mutates `self`. The new Smoosher has a new scope
+    /// as [head] and all of (pre-mutation) `self` as [tail]. `self` has a fresh scope pushed onto
     /// it. Invariant this method enforces: you cannot mutate a scope that has children
     /// forks (you can only mutate the fresh scope applied atop it)
     /// ```
@@ -412,7 +412,7 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     /// ```
     /// # Panics
     /// ```text
-    /// Panics if [self] has a non-empty head
+    /// Panics if `self` has a non-empty head
     ///```
     /// # Examples
     /// ## Pictorial Example
@@ -455,8 +455,8 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     }
 
     ///```text
-    ///Pushes a new, empty scope onto [self]. Doing so has no effect on the
-    ///bindings in [self], until a new [set] is called
+    ///Pushes a new, empty scope onto `self`. Doing so has no effect on the
+    ///bindings in `self`, until a new [set] is called
     ///```
     /// # Example
     /// ```rust
@@ -493,12 +493,12 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     }
 
     /// ```text
-    /// Consumes [self] and returns a Smoosher with all bindings in the topmost scope transposed
+    /// Consumes `self` and returns a Smoosher with all bindings in the topmost scope transposed
     /// onto the second-newest scope, with the topmost scope then discarded, and
     /// the second-newest scope now the topmost scope. Has no visible effect on
     /// methods like [get], as identical keys in different scopes are still shadowed,
     /// with only the newest key's binding visible.
-    /// Invariant: [self] must have at least 2 scopes, and neither scope may
+    /// Invariant: `self` must have at least 2 scopes, and neither scope may
     /// be the root of any fork:
     ///* [A]   [B]
     ///   |     |
@@ -516,14 +516,14 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     /// ```
     /// # Panics
     /// ```text
-    /// Panics if [self] has less than two scopes, or if any of the scopes are
+    /// Panics if `self` has less than two scopes, or if any of the scopes are
     /// the roots of any existing forks
     ///```
     /// # Examples
     /// ## Pictorial Example
-    ///  [A]
-    ///   |     => [smoosh_once(A, C)] => [A U C\A]
-    ///  [C]
+    ///  \[A\]
+    ///   |     => \[smoosh_once(A, C)\] => \[A U C\A\]
+    ///  \[C\]
     /// ## Code Example
     ///```
     /// use interp::stk_env::Smoosher;
@@ -566,14 +566,14 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     }
 
     /// ```text
-    /// Consumes [self] and returns a Smoosher in which
-    /// all bindings found in the top [levels] scopes of [self] to the [levels]th
+    /// Consumes `self` and returns a Smoosher in which
+    /// all bindings found in the top [levels] scopes of `self` to the [levels]th
     /// scope are merged. [smoosh(0)] has no effect, while [smoosh(1)] is equivalent to
     /// [smoosh_once].
     /// ```
     /// # Guarantees
-    ///  If [self] has **n** scopes, then
-    /// [self.get(K)] == [self.smoosh(n).get(K)] for all K bound in [self]
+    ///  If `self` has **n** scopes, then
+    /// [self.get(K)] == [self.smoosh(n).get(K)] for all K bound in `self`
     ///
     ///  # Invariant
     /// ```text
@@ -625,7 +625,7 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     }
 
     /// For internal use only
-    /// Set [new] as the topmost scope of [self]
+    /// Set [new] as the topmost scope of `self`
     fn push_scope(&mut self, new: HashMap<K, V>) {
         let old_head = mem::replace(&mut self.head, new);
         self.tail = self.tail.push(old_head);
@@ -644,7 +644,7 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     /// ```
     /// # Panics
     /// ```text
-    /// Panics if [self] and [other] do not share a common fork point, or if either is [empty], or
+    /// Panics if `self` and `other` do not share a common fork point, or if either is [empty], or
     /// if their bindings above the fork point are not disjoint.
     /// ```
     /// # Examples
@@ -699,7 +699,7 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
         let mut a = self;
         let mut b = other;
         if let Some((depth_a, depth_b)) = Smoosher::shared_fork_point(&a, &b) {
-            //smoosh [self] and [other] to right before that point
+            //smoosh `self` and `other` to right before that point
             a = a.smoosh(depth_a - 1);
             b = b.smoosh(depth_b - 1);
 
@@ -722,7 +722,7 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
                     tail: a_new_tail,
                 };
             } else {
-                panic!("trying to merge, but [self] is only 1 scope deep (this is impossible)")
+                panic!("trying to merge, but `self` is only 1 scope deep (this is impossible)")
             }
             //push_scope this new merged node onto A'
             a.push_scope(a_head);
@@ -887,7 +887,7 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
                 tail: a_new_tail,
             };
         } else {
-            panic!("trying to merge, but [self] is only 1 scope deep (this is impossible)")
+            panic!("trying to merge, but `self` is only 1 scope deep (this is impossible)")
         }
         //push_scope this new merged node onto A'
         a.push_scope(a_head);
@@ -899,7 +899,7 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     /// top [levels] levels of the Smoosher.
     /// [self.list_bound_vars(0)] returns all keys in the topmost scope
     /// [self.list.bound_vars(1)] returns all keys in the top two scopes
-    /// Undefined behavior if levels >= (# of scopes), or [self] is empty
+    /// Undefined behavior if levels >= (# of scopes), or `self` is empty
     /// ```
     /// # Example
     /// ```
@@ -935,18 +935,18 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
 
     /// ```text
     /// Returns a HashMap of all (&K, &V) (bindings of references) found in the top
-    /// [levels] levels of the Smoosher that differ from the bindings found
-    /// in the [levels]-th level of the Smoosher and below.
+    /// LEVEL levels of the Smoosher that differ from the bindings found
+    /// in the LEVEL-th level of the Smoosher and below.
     /// ```
     ///  # Requires
-    ///  0 < [levels] < # of scopes in this smoosher
+    ///  0 < LEVEL < # of scopes in this smoosher
     /// # Examples
     /// ## Pictoral Example
     /// ```text
     /// Say our Smoosher A looked as follows:
-    /// (lvl 3) [(a, 1), (b, 2)] -> [(a, 3)] -> [(c, 4)] -> [(d, 15)] (lvl 0)
+    /// (lvl 3) \[(a, 1), (b, 2)\] -> \[(a, 3)\] -> \[(c, 4)\] -> \[(d, 15)\] (lvl 0)
     /// A.diff(3) gives the following HashMap:
-    /// [(a, 3), (c, 4), (d, 15)]
+    /// \[(a, 3), (c, 4), (d, 15)\]
     /// ```
     /// ## Code Example
     /// ```
@@ -999,7 +999,7 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     }
 
     /// ```text
-    /// Returns a HM of all (&K, &V) (bindings of references) found in [self].
+    /// Returns a HM of all (&K, &V) (bindings of references) found in `self`.
     /// A use case would be when you want a HM representing a snapshot of the
     /// current state of the environment, which is easily iterable.
     /// ```
@@ -1023,14 +1023,14 @@ impl<K: Eq + std::hash::Hash, V: Eq> Smoosher<K, V> {
     }
 
     /// ```text
-    /// Returns a HM of all (&K, &V) (bindings of references) found in [self] and absent from
-    /// [other].
+    /// Returns a HM of all (&K, &V) (bindings of references) found in `self` and absent from
+    /// `other`.
     /// ```
     /// # Examples
     /// ## Text Example
     /// ```text
-    /// [self] : [(a, 1), (b, 2)], and
-    /// [other] : [(a, 1), (b, 3)], then
+    /// `self` : [(a, 1), (b, 2)], and
+    /// `other` : [(a, 1), (b, 3)], then
     /// [self.smoosher_diff(other)] produces the HM [(b, 2)].
     /// ```
     /// ## Code Example

--- a/interp/src/structures/stk_env.rs
+++ b/interp/src/structures/stk_env.rs
@@ -341,10 +341,6 @@ impl<K: Eq + Hash, V: Eq> StackMap<K, V> {
             None //do not share a fork point
         }
     }
-    // NOTE: shold be private, only public for testing!
-    pub fn drop(self) {
-        //yea
-    }
 
     /// Returns an Option of a pointer to the highest-scoped binding to \[k\],
     /// if it exists. Else None.

--- a/interp/src/structures/values.rs
+++ b/interp/src/structures/values.rs
@@ -408,7 +408,7 @@ impl Value {
         }
     }
 
-    /// Returns a Value truncated to length [new_size].
+    /// Returns a Value truncated to length new_size.
     ///
     /// # Example
     /// ```
@@ -425,7 +425,7 @@ impl Value {
         }
     }
 
-    /// Zero-extend the vector to length [ext].
+    /// Zero-extend the vector to length ext.
     ///
     /// # Example:
     /// ```
@@ -444,7 +444,7 @@ impl Value {
         }
     }
 
-    /// Sign-extend the vector to length [ext].
+    /// Sign-extend the vector to length ext.
     ///
     /// # Example:
     /// ```
@@ -686,7 +686,7 @@ impl Value {
         self.vec.len()
     }
 
-    /// Returns a value containing the sliced region [lower,upper], consumes the original
+    /// Returns a value containing the sliced region \[lower,upper\], consumes the original
     pub fn slice_out(self, upper_idx: usize, lower_idx: usize) -> Self {
         assert!(upper_idx >= lower_idx);
         assert!(upper_idx < self.vec.len());
@@ -699,7 +699,7 @@ impl Value {
         }
     }
 
-    /// Returns a value containing the sliced region [lower,upper]
+    /// Returns a value containing the sliced region \[lower,upper\]
     pub fn slice(self, upper_idx: usize, lower_idx: usize) -> Self {
         assert!(upper_idx >= lower_idx);
         assert!(upper_idx < self.vec.len());

--- a/interp/src/tests/stk_env.rs
+++ b/interp/src/tests/stk_env.rs
@@ -1,24 +1,24 @@
 #[cfg(test)]
-use crate::structures::stk_env::Smoosher;
+use crate::structures::stk_env::StackMap;
 #[allow(unused)]
 use std::collections::HashMap;
 
 #[test]
 fn smoosher_get_empty() {
-    let smoosher = Smoosher::<i32, i32>::new();
+    let smoosher = StackMap::<i32, i32>::new();
     assert_eq!(None, smoosher.get(&4));
 }
 
 #[test]
 fn smoosher_get_set() {
-    let mut smoosher = Smoosher::new();
+    let mut smoosher = StackMap::new();
     smoosher.set("hey", 2);
     assert_eq!(*smoosher.get(&"hey").unwrap(), 2);
 }
 
 #[test]
 fn smoosher_get_set_2_scopes() {
-    let mut smoosher = Smoosher::new();
+    let mut smoosher = StackMap::new();
     smoosher.set("hey", 2);
     smoosher.set("alma", 18);
     assert_eq!(*smoosher.get(&"hey").unwrap(), 2);
@@ -32,7 +32,7 @@ fn smoosher_get_set_2_scopes() {
 
 #[test]
 fn smoosher_smoosh_basic() {
-    let mut smoosher = Smoosher::new();
+    let mut smoosher = StackMap::new();
     smoosher.set("hey", 2);
     smoosher.set("alma", 18);
     smoosher.new_scope();
@@ -47,7 +47,7 @@ fn smoosher_smoosh_basic() {
 }
 #[test]
 fn smoosher_smoosh_many_lvls() {
-    let mut smoosher = Smoosher::new();
+    let mut smoosher = StackMap::new();
     smoosher.set("hey", 2);
     smoosher.set("alma", 18);
     smoosher.new_scope();
@@ -69,7 +69,7 @@ fn smoosher_smoosh_many_lvls() {
 
 #[test]
 fn smoosher_merge_basic() {
-    let mut smoosher = Smoosher::new();
+    let mut smoosher = StackMap::new();
     smoosher.set("alma", 18);
     smoosher.set("jonathan", 14);
     smoosher.set("jenny", 2);
@@ -77,7 +77,7 @@ fn smoosher_merge_basic() {
     let mut smoosher2 = smoosher.fork();
     smoosher2.set("alma", 19);
     smoosher.set("jonathan", 15);
-    let smoosher_merged = Smoosher::merge(smoosher, smoosher2);
+    let smoosher_merged = StackMap::merge(smoosher, smoosher2);
     assert_eq!(*smoosher_merged.get(&"alma").unwrap(), 19);
     assert_eq!(*smoosher_merged.get(&"jonathan").unwrap(), 15);
 }
@@ -85,7 +85,7 @@ fn smoosher_merge_basic() {
 //tests that we can merge different branch length. should fail now
 #[test]
 fn smoosher_merge_complex() {
-    let mut smoosher = Smoosher::new();
+    let mut smoosher = StackMap::new();
     smoosher.set("alma", 18);
     smoosher.set("jonathan", 14);
     smoosher.set("jenny", 2);
@@ -96,7 +96,7 @@ fn smoosher_merge_complex() {
     smoosher.set("jonathan", 15);
     smoosher.new_scope();
     smoosher.set("jenny", 3);
-    let smoosher_merged = Smoosher::merge(smoosher, smoosher2);
+    let smoosher_merged = StackMap::merge(smoosher, smoosher2);
     assert_eq!(*smoosher_merged.get(&"alma").unwrap(), 19);
     assert_eq!(*smoosher_merged.get(&"jonathan").unwrap(), 15);
     assert_eq!(*smoosher_merged.get(&"jenny").unwrap(), 3);
@@ -104,7 +104,7 @@ fn smoosher_merge_complex() {
 
 #[test]
 fn smoosher_list_b_vars() {
-    let mut smoosher = Smoosher::new();
+    let mut smoosher = StackMap::new();
     smoosher.set("alma", 18);
     smoosher.new_scope();
     smoosher.set("jonathan", 14);
@@ -113,8 +113,8 @@ fn smoosher_list_b_vars() {
     smoosher.set("ari", 12);
     //assert lbv 0 is joseph and ari
     //assert lbv1 is joseph, ari, jonathan
-    let hs0 = Smoosher::list_bound_vars(&smoosher, 0);
-    let hs1 = Smoosher::list_bound_vars(&smoosher, 1);
+    let hs0 = StackMap::list_bound_vars(&smoosher, 0);
+    let hs1 = StackMap::list_bound_vars(&smoosher, 1);
     assert!(hs0.contains(&"joseph"));
     assert!(hs0.contains(&"ari"));
     assert!(!hs0.contains(&"jonathan"));
@@ -128,7 +128,7 @@ fn smoosher_list_b_vars() {
 
 #[test]
 fn smoosher_to_hm() {
-    let mut smoosher = Smoosher::new();
+    let mut smoosher = StackMap::new();
     smoosher.set("alma", 18);
     smoosher.new_scope();
     smoosher.set("jonathan", 14);
@@ -148,7 +148,7 @@ fn smoosher_to_hm() {
 
 #[test]
 fn smoosher_from() {
-    let mut smoosher = Smoosher::new();
+    let mut smoosher = StackMap::new();
     smoosher.set("alma", 18);
     smoosher.new_scope();
     smoosher.set("jonathan", 14);
@@ -168,7 +168,7 @@ fn smoosher_from() {
 
 #[test]
 fn smoosher_diff_2() {
-    let mut smoosher = Smoosher::new();
+    let mut smoosher = StackMap::new();
     smoosher.set("alma", 18);
     smoosher.new_scope();
     smoosher.set("joseph", 19);
@@ -189,13 +189,13 @@ fn smoosher_diff_2() {
 
 #[test]
 fn smoosher_diff_other() {
-    let mut smoosher = Smoosher::new();
+    let mut smoosher = StackMap::new();
     smoosher.set("alma", 18);
     smoosher.new_scope();
     smoosher.set("joseph", 19);
     smoosher.new_scope();
     smoosher.set("jonathan", 14);
-    let mut smoosher2 = Smoosher::new();
+    let mut smoosher2 = StackMap::new();
     smoosher2.set("jonathan", 15);
     smoosher2.new_scope();
     smoosher2.set("alma", 19);
@@ -210,13 +210,13 @@ fn smoosher_diff_other() {
 
 mod values_stk_env_test {
     #[allow(unused)]
-    use crate::structures::stk_env::Smoosher;
+    use crate::structures::stk_env::StackMap;
     #[allow(unused)]
     use crate::values::Value;
 
     #[test]
     fn smoosher_val_get_set() {
-        let mut sm = Smoosher::new();
+        let mut sm = StackMap::new();
         let val = Value::from(8, 4);
         sm.set("reg_out", val);
         assert_eq!(sm.get(&"reg_out").unwrap().as_u64(), 8);
@@ -224,7 +224,7 @@ mod values_stk_env_test {
 
     #[test]
     fn smoosher_get_set_2_scopes() {
-        let mut smoosher = Smoosher::new();
+        let mut smoosher = StackMap::new();
         smoosher.set("hey", Value::from(2, 32));
         smoosher.set("alma", Value::from(18, 32));
         assert_eq!(smoosher.get(&"hey").unwrap().as_u64(), 2);
@@ -238,7 +238,7 @@ mod values_stk_env_test {
 
     #[test]
     fn value_eq_get_set() {
-        let mut smoosher = Smoosher::new();
+        let mut smoosher = StackMap::new();
         smoosher.set("hey", Value::from(2, 32));
         smoosher.set("alma", Value::from(18, 32));
         assert_eq!(*smoosher.get(&"hey").unwrap(), Value::from(2, 32));
@@ -252,7 +252,7 @@ mod values_stk_env_test {
 
     #[test]
     fn smoosher_smoosh_basic() {
-        let mut smoosher = Smoosher::new();
+        let mut smoosher = StackMap::new();
         smoosher.set("hey", Value::from(2, 32));
         smoosher.set("alma", Value::from(18, 32));
         smoosher.new_scope();
@@ -267,7 +267,7 @@ mod values_stk_env_test {
     }
     #[test]
     fn smoosher_smoosh_many_lvls() {
-        let mut smoosher = Smoosher::new();
+        let mut smoosher = StackMap::new();
         smoosher.set("hey", Value::from(2, 32));
         smoosher.set("alma", Value::from(18, 32));
         smoosher.new_scope();
@@ -289,7 +289,7 @@ mod values_stk_env_test {
 
     #[test]
     fn smoosher_merge_basic() {
-        let mut smoosher = Smoosher::new();
+        let mut smoosher = StackMap::new();
         smoosher.set("alma", Value::from(18, 32));
         smoosher.set("jonathan", Value::from(14, 32));
         smoosher.set("jenny", Value::from(2, 32));
@@ -297,7 +297,7 @@ mod values_stk_env_test {
         let mut smoosher2 = smoosher.fork();
         smoosher2.set("alma", Value::from(19, 32));
         smoosher.set("jonathan", Value::from(15, 32));
-        let smoosher_merged = Smoosher::merge(smoosher, smoosher2);
+        let smoosher_merged = StackMap::merge(smoosher, smoosher2);
         assert_eq!(smoosher_merged.get(&"alma").unwrap().as_u64(), 19);
         assert_eq!(smoosher_merged.get(&"jonathan").unwrap().as_u64(), 15);
     }
@@ -305,7 +305,7 @@ mod values_stk_env_test {
     //tests that we can merge different branch length. should fail now
     #[test]
     fn smoosher_merge_complex() {
-        let mut smoosher = Smoosher::new();
+        let mut smoosher = StackMap::new();
         smoosher.set("alma", Value::from(18, 32));
         smoosher.set("jonathan", Value::from(14, 32));
         smoosher.set("jenny", Value::from(2, 32));
@@ -316,7 +316,7 @@ mod values_stk_env_test {
         smoosher.set("jonathan", Value::from(15, 32));
         smoosher.new_scope();
         smoosher.set("jenny", Value::from(3, 32));
-        let smoosher_merged = Smoosher::merge(smoosher, smoosher2);
+        let smoosher_merged = StackMap::merge(smoosher, smoosher2);
         assert_eq!(smoosher_merged.get(&"alma").unwrap().as_u64(), 19);
         assert_eq!(smoosher_merged.get(&"jonathan").unwrap().as_u64(), 15);
         assert_eq!(smoosher_merged.get(&"jenny").unwrap().as_u64(), 3);
@@ -324,7 +324,7 @@ mod values_stk_env_test {
 
     #[test]
     fn smoosher_list_b_vars() {
-        let mut smoosher = Smoosher::new();
+        let mut smoosher = StackMap::new();
         smoosher.set("alma", Value::from(18, 32));
         smoosher.new_scope();
         smoosher.set("jonathan", Value::from(14, 32));
@@ -333,8 +333,8 @@ mod values_stk_env_test {
         smoosher.set("ari", Value::from(12, 32));
         //assert lbv 0 is joseph and ari
         //assert lbv1 is joseph, ari, jonathan
-        let hs0 = Smoosher::list_bound_vars(&smoosher, 0);
-        let hs1 = Smoosher::list_bound_vars(&smoosher, 1);
+        let hs0 = StackMap::list_bound_vars(&smoosher, 0);
+        let hs1 = StackMap::list_bound_vars(&smoosher, 1);
         assert!(hs0.contains(&"joseph"));
         assert!(hs0.contains(&"ari"));
         assert!(!hs0.contains(&"jonathan"));
@@ -348,7 +348,7 @@ mod values_stk_env_test {
 
     #[test]
     fn smoosher_to_hm() {
-        let mut smoosher = Smoosher::new();
+        let mut smoosher = StackMap::new();
         smoosher.set("alma", Value::from(18, 32));
         smoosher.new_scope();
         smoosher.set("jonathan", Value::from(14, 32));
@@ -369,7 +369,7 @@ mod values_stk_env_test {
     #[test]
     fn value_smoosher_hm_from() {
         use std::collections::HashMap;
-        let mut smoosher = Smoosher::new();
+        let mut smoosher = StackMap::new();
         smoosher.set("alma", Value::from(18, 32));
         smoosher.new_scope();
         smoosher.set("jonathan", Value::from(14, 32));
@@ -389,7 +389,7 @@ mod values_stk_env_test {
 
     #[test]
     fn smoosher_diff_2() {
-        let mut smoosher = Smoosher::new();
+        let mut smoosher = StackMap::new();
         smoosher.set("alma", Value::from(18, 32));
         smoosher.new_scope();
         smoosher.set("joseph", Value::from(19, 32));
@@ -410,13 +410,13 @@ mod values_stk_env_test {
 
     #[test]
     fn smoosher_diff_other() {
-        let mut smoosher = Smoosher::new();
+        let mut smoosher = StackMap::new();
         smoosher.set("alma", Value::from(18, 32));
         smoosher.new_scope();
         smoosher.set("joseph", Value::from(19, 32));
         smoosher.new_scope();
         smoosher.set("jonathan", Value::from(14, 32));
-        let mut smoosher2 = Smoosher::new();
+        let mut smoosher2 = StackMap::new();
         smoosher2.set("jonathan", Value::from(15, 32));
         smoosher2.new_scope();
         smoosher2.set("alma", Value::from(19, 32));


### PR DESCRIPTION
A whole bunch of documentation improvements for the interpreter with some mild refactoring.

Moves the stateviews into their own file and removes the useless `State` trait which was not actually doing anything.

Renames `Smoosher` to `StackMap` but retains `Smoosher` as an alias.

Fixes a few typos here and there.

This is far from exhaustive, there will be more documentation passes in the proximate future