### PR TITLE
Disable canonicalization: `a = g ? 1` -> `a = g`

### DIFF
--- a/examples/futil/dot-product.expect
+++ b/examples/futil/dot-product.expect
@@ -94,7 +94,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     let1_go.in = !let1_done.out & fsm.out == 4'd3 & tdcc_go.out ? 1'd1;
     let2_done.in = dot_0.done;
     let2_go.in = !let2_done.out & fsm.out == 4'd4 & tdcc_go.out ? 1'd1;
-    msp_done.in = A_read0_0.done & B_read0_0.done ? 1'd1;
+    msp_done.in = 1'b1 & A_read0_0.done & 1'b1 & B_read0_0.done ? 1'd1;
     msp_go.in = !msp_done.out & fsm.out == 4'd2 & tdcc_go.out ? 1'd1;
     mult_pipe0.clk = clk;
     mult_pipe0.go = !mult_pipe0.done & let1_go.out ? 1'd1;
@@ -103,9 +103,9 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     mult_pipe0.right = let1_go.out ? B_read0_0.out;
     tdcc_done.in = fsm.out == 4'd8 ? 1'd1;
     tdcc_go.in = go;
-    upd2_done.in = v0.done;
+    upd2_done.in = v0.done ? 1'd1;
     upd2_go.in = !upd2_done.out & fsm.out == 4'd5 & tdcc_go.out ? 1'd1;
-    upd3_done.in = i0.done;
+    upd3_done.in = i0.done ? 1'd1;
     upd3_go.in = !upd3_done.out & fsm.out == 4'd6 & tdcc_go.out ? 1'd1;
     v0.addr0 = upd2_go.out ? const2.out;
     v0.clk = clk;

--- a/examples/futil/vectorized-add.expect
+++ b/examples/futil/vectorized-add.expect
@@ -75,13 +75,13 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     le0.right = cond00_go.out ? const1.out;
     let0_done.in = i0.done;
     let0_go.in = !let0_done.out & fsm.out == 3'd0 & tdcc_go.out ? 1'd1;
-    msp_done.in = A_read0_0.done & B_read0_0.done ? 1'd1;
+    msp_done.in = 1'b1 & A_read0_0.done & 1'b1 & B_read0_0.done ? 1'd1;
     msp_go.in = !msp_done.out & fsm.out == 3'd2 & tdcc_go.out ? 1'd1;
     tdcc_done.in = fsm.out == 3'd6 ? 1'd1;
     tdcc_go.in = go;
-    upd2_done.in = Sum0.done;
+    upd2_done.in = Sum0.done ? 1'd1;
     upd2_go.in = !upd2_done.out & fsm.out == 3'd3 & tdcc_go.out ? 1'd1;
-    upd3_done.in = i0.done;
+    upd3_done.in = i0.done ? 1'd1;
     upd3_go.in = !upd3_done.out & fsm.out == 3'd4 & tdcc_go.out ? 1'd1;
   }
 

--- a/tests/passes/canonical/guard.expect
+++ b/tests/passes/canonical/guard.expect
@@ -6,15 +6,15 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 1, @done done: 
   }
   wires {
     group b {
-      r.write_en = r.out;
+      r.write_en = r.out ? 1'd1;
       r.in = r.out;
-      b[done] = r.done;
+      b[done] = r.done ? 1'd1;
     }
     comb group c {
-      r.write_en = r.out;
+      r.write_en = r.out ? 1'd1;
       r.in = r.out;
     }
-    r.write_en = r.out;
+    r.write_en = r.out ? 1'd1;
     r.in = r.out;
   }
 


### PR DESCRIPTION
Fixes #1010.
