### PR TITLE
Backend cleanup

### DIFF
--- a/tests/backend/verilog/big-const.expect
+++ b/tests/backend/verilog/big-const.expect
@@ -469,7 +469,6 @@ module main (
     ) c (
         .out(c_out)
     );
-    assign done =
-     1'b1 ? 1'd1 : 1'd0;
+    assign done = 1'd1;
     
 endmodule

--- a/tests/backend/verilog/memory-with-external-attribute.expect
+++ b/tests/backend/verilog/memory-with-external-attribute.expect
@@ -510,11 +510,8 @@ module main (
         .write_data(m1_write_data),
         .write_en(m1_write_en)
     );
-    assign done =
-     1'b1 ? m1_done : 1'd0;
-    assign m0_clk =
-     1'b1 ? clk : 1'd0;
-    assign m1_clk =
-     1'b1 ? clk : 1'd0;
+    assign done = m1_done;
+    assign m0_clk = clk;
+    assign m1_clk = clk;
     
 endmodule

--- a/tests/errors/multiple-done.expect
+++ b/tests/errors/multiple-done.expect
@@ -1,0 +1,6 @@
+---CODE---
+1
+---STDERR---
+Error: tests/errors/multiple-done.futil
+11 |      do_r[done] = !r.done ? 1'd1;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Malformed Structure: Group `do_r` has multiple done conditions

--- a/tests/errors/multiple-done.futil
+++ b/tests/errors/multiple-done.futil
@@ -1,0 +1,17 @@
+import "primitives/core.futil";
+component main() -> () {
+  cells {
+    r = std_reg(32);
+  }
+  wires {
+    group do_r {
+      r.write_en = 1'd1;
+      r.in = 32'd1;
+      do_r[done] = r.done;
+      do_r[done] = !r.done ? 1'd1;
+    }
+  }
+  control {
+    do_r;
+  }
+}


### PR DESCRIPTION
Simple backend code generation changes that don't emit mux expressions when there is exactly one assignment. Also adds the missing test for multiple done conditions for #1014.
