### PR TITLE
Create flag option to create .wdb and .wcfg files

### DIFF
--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -85,7 +85,10 @@ DEFAULT_CONFIGURATION = {
             "xilinx_location": "/scratch/opt/Xilinx/Vitis/2020.2",
             "xrt_location": "/opt/xilinx/xrt",
         },
-        "fpga": {"data": None},
+        "fpga": {
+            "data": None,
+            "waveform" : None,
+            },
     },
 }
 

--- a/fud/fud/stages/xilinx/emulation.py
+++ b/fud/fud/stages/xilinx/emulation.py
@@ -44,7 +44,7 @@ class HwEmulationStage(Stage):
         )
 
         host_cpp = config["stages", self.name, "host"]
-        save_temps = bool(config["stages", self.name, "save_temps"])
+        save_temps = bool(config["stages", self.name, "save_temps"]) and config["stages", self.name, "save_temps"] == "true"
         xrt = (
             Path(config["global", "futil_directory"]) / "fud" / "bitstream" / "xrt.ini"
         )

--- a/fud/fud/stages/xilinx/execution.py
+++ b/fud/fud/stages/xilinx/execution.py
@@ -8,7 +8,6 @@ import simplejson as sjson
 from fud import errors
 from fud.stages import SourceType, Stage
 from fud.utils import FreshDir, TmpDir
-from shutil import rmtree
 
 
 class HwExecutionStage(Stage):

--- a/fud/fud/stages/xilinx/execution.py
+++ b/fud/fud/stages/xilinx/execution.py
@@ -26,11 +26,8 @@ class HwExecutionStage(Stage):
     def _define_steps(self, input, builder, config):
         data_path = config["stages", self.name, "data"]
         
-        # Has same problem as emulation.py: any input of form
-        # '-s fpga.save_temps <any non-empty string>' is True
         save_wdb = bool(config["stages", self.name, "waveform"]) and config["stages", self.name, "waveform"] == "true"
         
-        # TODO: delete print("\ncwd is: " + os.getcwd())    
         @builder.step()
         def import_libs():
             """Import optional libraries"""
@@ -48,7 +45,6 @@ class HwExecutionStage(Stage):
             if data_path is None:
                 raise errors.MissingDynamicConfiguration("fpga.data")
 
-            #TODO: delete print("cwd2 is: " + os.getcwd())    
             data = sjson.load(open(data_path), use_decimal=True)
             xclbin_source = xclbin.open("rb").read()
 
@@ -138,37 +134,4 @@ class HwExecutionStage(Stage):
         import_libs()
         res = run(input)
         return res
-
-#        # cleanup fud_out if flagged
-#        # TODO: fix this, at the moment runs too soon and is not capable
-#        # of cleaning anything up
-#        if(save_wdb):
-#            
-#            print(self._latest_dir(os.getcwd()))
-#            entries = os.scandir(self._latest_dir(os.getcwd()))
-#            for entry in entries:
-#                print(entry.name)
-#                # if(not ".wdb" in entry.path or not ".wcfg" in entry.path):
-#                #     if entry.is_dir():
-#                #         rmtree(entry.path)
-#                #     else:
-#                #         print("here")
-#                #         os.remove(entry.path)
-#        return res
-#
-#
-#    # returns path of most recent directory created by
-#    # FreshDir() (see fud/fud/utils.py)
-#    def _latest_dir(self, cwd):
-#        
-#        i = 0
-#        file_convention = "fud-out-{}"
-#        name = file_convention.format(i + 1)
-#        path = os.path.join(cwd, name)
-#        while os.path.exists(path):
-#            i += 1
-#            name = file_convention.format(i + 1)
-#            path = os.path.join(cwd,name)
-#        name = file_convention.format(i)
-#        return os.path.join(cwd, name)    
 

--- a/fud/fud/stages/xilinx/execution.py
+++ b/fud/fud/stages/xilinx/execution.py
@@ -7,7 +7,8 @@ import simplejson as sjson
 
 from fud import errors
 from fud.stages import SourceType, Stage
-from fud.utils import TmpDir
+from fud.utils import FreshDir, TmpDir
+from shutil import rmtree
 
 
 class HwExecutionStage(Stage):
@@ -24,7 +25,12 @@ class HwExecutionStage(Stage):
 
     def _define_steps(self, input, builder, config):
         data_path = config["stages", self.name, "data"]
-
+        
+        # Has same problem as emulation.py: any input of form
+        # '-s fpga.save_temps <any non-empty string>' is True
+        save_wdb = bool(config["stages", self.name, "waveform"]) and config["stages", self.name, "waveform"] == "true"
+        
+        # TODO: delete print("\ncwd is: " + os.getcwd())    
         @builder.step()
         def import_libs():
             """Import optional libraries"""
@@ -42,24 +48,30 @@ class HwExecutionStage(Stage):
             if data_path is None:
                 raise errors.MissingDynamicConfiguration("fpga.data")
 
+            #TODO: delete print("cwd2 is: " + os.getcwd())    
             data = sjson.load(open(data_path), use_decimal=True)
             xclbin_source = xclbin.open("rb").read()
 
             # create a temporary directory with an xrt.ini file that redirects
             # the runtime log to a file so that we can control how it's printed.
             # This is hacky, but it's the only way to do it
-            tmp_dir = TmpDir()
-            os.chdir(tmp_dir.name)
+            # As a result the xrt.init in fud/bitstream is ignored
+
+            new_dir = FreshDir() if save_wdb else TmpDir()
+            os.chdir(new_dir.name)
+
             xrt_output_logname = "output.log"
             with open("xrt.ini", "w") as f:
-                f.writelines(
-                    [
-                        "[Runtime]\n",
-                        f"runtime_log={xrt_output_logname}\n",
-                        "[Emulation]\n",
-                        "print_infos_in_console=false\n",
-                    ]
-                )
+               xrt_ini_config = [
+                                    "[Runtime]\n",
+                                    f"runtime_log={xrt_output_logname}\n",
+                                    "[Emulation]\n",
+                                    "print_infos_in_console=false\n"
+                                ]
+               if(save_wdb):
+                   xrt_ini_config.append("debug_mode=batch\n")
+
+               f.writelines(xrt_ini_config)
 
             ctx = self.cl.create_some_context(0)
             dev = ctx.devices[0]
@@ -79,12 +91,16 @@ class HwExecutionStage(Stage):
                 buf = self.cl.Buffer(
                     ctx,
                     self.cl.mem_flags.READ_WRITE | self.cl.mem_flags.COPY_HOST_PTR,
+                    # TODO: use real type information
                     hostbuf=np.array(data[mem]["data"]).astype(np.uint32),
                 )
                 # TODO: use real type information
                 buffers[mem] = buf
 
             start_time = time.time()
+            #Note that this is the call on v++. This uses global USER_ENV variables
+            #EMCONFIG_PATH=`pwd`
+            #XCL_EMULATION_MODE=hw_emu
             kern(cmds, (1,), (1,), np.uint32(10000), *buffers.values())
             end_time = time.time()
             log.debug(f"Emulation time: {end_time - start_time} sec")
@@ -115,8 +131,44 @@ class HwExecutionStage(Stage):
                     for line in f.readlines():
                         log.debug(line.strip())
 
+
+
             return sjson.dumps(output, indent=2, use_decimal=True)
 
         import_libs()
         res = run(input)
         return res
+
+#        # cleanup fud_out if flagged
+#        # TODO: fix this, at the moment runs too soon and is not capable
+#        # of cleaning anything up
+#        if(save_wdb):
+#            
+#            print(self._latest_dir(os.getcwd()))
+#            entries = os.scandir(self._latest_dir(os.getcwd()))
+#            for entry in entries:
+#                print(entry.name)
+#                # if(not ".wdb" in entry.path or not ".wcfg" in entry.path):
+#                #     if entry.is_dir():
+#                #         rmtree(entry.path)
+#                #     else:
+#                #         print("here")
+#                #         os.remove(entry.path)
+#        return res
+#
+#
+#    # returns path of most recent directory created by
+#    # FreshDir() (see fud/fud/utils.py)
+#    def _latest_dir(self, cwd):
+#        
+#        i = 0
+#        file_convention = "fud-out-{}"
+#        name = file_convention.format(i + 1)
+#        path = os.path.join(cwd, name)
+#        while os.path.exists(path):
+#            i += 1
+#            name = file_convention.format(i + 1)
+#            path = os.path.join(cwd,name)
+#        name = file_convention.format(i)
+#        return os.path.join(cwd, name)    
+


### PR DESCRIPTION
.wdb and .wcfg files can be created in `fud-out-<N>` directories by passing in `-s fpga.waveform true` as part of the fud invocation. Fud invocation must be `--to fpga` or go through the fpga stage.

Clean up doesn't currently work because of out of order operations.
(In practice, the `fud-out-<N>` directory is ~0.5 gigs due to a big hidden `.run/` directory. If I understand correctly this is an artifact of the debug mode required to output the files we want and can safely be deleted.)