### PR TITLE
[fpga] Docs & tweaks for saving WDB traces

### DIFF
--- a/docs/fud/xilinx.md
+++ b/docs/fud/xilinx.md
@@ -136,7 +136,12 @@ and you need to tell XRT whether you want `hw_emu` (emulation) or `hw` (actual o
 Of course, it would be better if all this could come from fud's configuration itself instead of requiring you to set it up ahead of time;
 [issue #872](https://github.com/cucapra/calyx/issues/872) covers this work.
 
+In emulation mode, this stage can produce a waveform trace in Xilinx's proprietary [WDB][] file format.
+Use `-s fpga.waveform true -s fpga.save_temps true` to collect a WDB.
+The first option instructs XRT to use [the `batch` debug mode][xrt-debug], and the second asks fud not to delete the directory where the WDB file will appear.
+
 [emconfig.json]: https://docs.xilinx.com/r/en-US/ug1393-vitis-application-acceleration/emconfigutil-Utility
+[xrt-debug]: https://xilinx.github.io/Vitis_Accel_Examples/2021.1/html/debug_profile.html
 
 ### Emulate
 

--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -87,8 +87,9 @@ DEFAULT_CONFIGURATION = {
         },
         "fpga": {
             "data": None,
-            "waveform" : None,
-            },
+            "save_temps": None,
+            "waveform": None,
+        },
     },
 }
 

--- a/fud/fud/stages/xilinx/execution.py
+++ b/fud/fud/stages/xilinx/execution.py
@@ -25,7 +25,8 @@ class HwExecutionStage(Stage):
     def _define_steps(self, input, builder, config):
         data_path = config["stages", self.name, "data"]
         
-        save_wdb = bool(config["stages", self.name, "waveform"]) and config["stages", self.name, "waveform"] == "true"
+        save_temps = bool(config["stages", self.name, "save_temps"])
+        gen_wdb = bool(config["stages", self.name, "waveform"])
         
         @builder.step()
         def import_libs():
@@ -51,7 +52,7 @@ class HwExecutionStage(Stage):
             # the runtime log to a file so that we can control how it's printed.
             # This is hacky, but it's the only way to do it. (The `xrt.ini`
             # file we currently have in `fud/bitstream` is not used here.)
-            new_dir = FreshDir() if save_wdb else TmpDir()
+            new_dir = FreshDir() if save_temps else TmpDir()
             os.chdir(new_dir.name)
 
             xrt_output_logname = "output.log"
@@ -62,7 +63,7 @@ class HwExecutionStage(Stage):
                     "[Emulation]\n",
                     "print_infos_in_console=false\n",
                 ]
-               if save_wdb:
+               if gen_wdb:
                    xrt_ini_config.append("debug_mode=batch\n")
 
                f.writelines(xrt_ini_config)

--- a/fud/fud/stages/xilinx/execution.py
+++ b/fud/fud/stages/xilinx/execution.py
@@ -27,6 +27,12 @@ class HwExecutionStage(Stage):
         
         save_temps = bool(config["stages", self.name, "save_temps"])
         gen_wdb = bool(config["stages", self.name, "waveform"])
+        if gen_wdb and not save_temps:
+            log.warn(
+                f"{self.name}.waveform is enabled, but {self.name}.save_temps "
+                f"is not. This will generate a WDB file but then immediately "
+                f"delete it. Consider adding `-s {self.name}.save_temps true`."
+            )
         
         @builder.step()
         def import_libs():

--- a/fud/fud/stages/xilinx/execution.py
+++ b/fud/fud/stages/xilinx/execution.py
@@ -47,23 +47,22 @@ class HwExecutionStage(Stage):
             data = sjson.load(open(data_path), use_decimal=True)
             xclbin_source = xclbin.open("rb").read()
 
-            # create a temporary directory with an xrt.ini file that redirects
+            # Create a temporary directory with an xrt.ini file that redirects
             # the runtime log to a file so that we can control how it's printed.
-            # This is hacky, but it's the only way to do it
-            # As a result the xrt.init in fud/bitstream is ignored
-
+            # This is hacky, but it's the only way to do it. (The `xrt.ini`
+            # file we currently have in `fud/bitstream` is not used here.)
             new_dir = FreshDir() if save_wdb else TmpDir()
             os.chdir(new_dir.name)
 
             xrt_output_logname = "output.log"
             with open("xrt.ini", "w") as f:
                xrt_ini_config = [
-                                    "[Runtime]\n",
-                                    f"runtime_log={xrt_output_logname}\n",
-                                    "[Emulation]\n",
-                                    "print_infos_in_console=false\n"
-                                ]
-               if(save_wdb):
+                    "[Runtime]\n",
+                    f"runtime_log={xrt_output_logname}\n",
+                    "[Emulation]\n",
+                    "print_infos_in_console=false\n",
+                ]
+               if save_wdb:
                    xrt_ini_config.append("debug_mode=batch\n")
 
                f.writelines(xrt_ini_config)
@@ -125,8 +124,6 @@ class HwExecutionStage(Stage):
                 with open(emu_log, "r") as f:
                     for line in f.readlines():
                         log.debug(line.strip())
-
-
 
             return sjson.dumps(output, indent=2, use_decimal=True)
 


### PR DESCRIPTION
This is just a quick follow-up to @nathanielnrn's work in #1036! I wanted to add some documentation for the new option to save WDB files so we don't forget how to use this useful new functionality. While I was at it, I found it was easier to explain a slightly different version of the feature.

Namely, previously, the `fpga.waveform` fud option would have two effects: don't delete the temporary directory (like `save_temps` elsewhere), and ask XRT/xsim to produce a waveform trace. I think it's a little friendlier to keep these separate, even if just doing `fpga.waveform` by itself now is useless: it will create a WDB file and then immediately delete it! Hopefully this makes sense, and `fpga.save_temps` is useful for other purposes that might have to do with those temporary files.

Anyway, I tried this out and it seemed to work for me. If it works for @nathanielnrn too, that's good enough for me. :smiley: