### PR TITLE
define config.ROOT instead of magic "futil_directory" key

### DIFF
--- a/fud/fud/check.py
+++ b/fud/fud/check.py
@@ -4,6 +4,7 @@ import shutil
 import subprocess
 from packaging import version
 import sys
+from fud import config
 
 # Dictionary that defines how to check the version for different tools.
 # Maps names of stage to the command needed to check the tool.
@@ -115,7 +116,7 @@ def check(cfg):
     cfg.launch_wizard()
 
     # check global
-    futil_root = Path(cfg["global", "futil_directory"])
+    futil_root = Path(cfg["global", config.ROOT])
     futil_str = colored(str(futil_root), "yellow")
     cprint("global:", attrs=["bold"])
     if futil_root.exists():

--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -12,10 +12,13 @@ from . import stages
 from .utils import eprint
 from . import errors, external, registry
 
+# Key for the root folder
+ROOT = "futil_directory"
+
 # keys to prompt the user for
 WIZARD_DATA = {
     "global": {
-        "futil_directory": "Root Directory of Calyx repository",
+        ROOT: "Root Directory of Calyx repository",
     }
 }
 
@@ -212,8 +215,8 @@ class Configuration:
         self.config = DynamicDict(toml.load(self.config_file))
         self.wizard_data = DynamicDict(WIZARD_DATA)
         self.fill_missing(DEFAULT_CONFIGURATION, self.config.data)
-        if ("global", "futil_directory") not in self.config:
-            log.warn("global.futil_directory is not set in the configuration")
+        if ("global", ROOT) not in self.config:
+            log.warn(f"global.{ROOT} is not set in the configuration")
 
     def commit(self):
         """

--- a/fud/fud/stages/futil.py
+++ b/fud/fud/stages/futil.py
@@ -1,4 +1,5 @@
 from fud.stages import SourceType, Stage
+from fud import config as cfg
 
 from ..utils import shell, unwrap_or
 
@@ -26,7 +27,7 @@ class FutilStage(Stage):
             [
                 calyx_exec,
                 "-l",
-                config["global", "futil_directory"],
+                config["global", cfg.ROOT],
                 self.flags,
                 unwrap_or(config["stages", self.name, "flags"], ""),
             ]

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -7,6 +7,7 @@ from fud.stages.verilator.numeric_types import FixedPoint, Bitnum
 from fud.errors import InvalidNumericType
 from fud.stages.verilator.json_to_dat import parse_fp_widths, float_to_fixed
 from fud.utils import shell, TmpDir, unwrap_or, transparent_shell
+from fud import config as cfg
 
 # A local constant used only within this file largely for organizational
 # purposes and to avoid magic strings
@@ -65,7 +66,7 @@ class InterpreterStage(Stage):
             self.flags,
             unwrap_or(config["stages", self.name, "flags"], ""),
             "-l",
-            config["global", "futil_directory"],
+            config["global", cfg.ROOT],
             "--data" if data_path else "",
             "{data_file}" if data_path else "",
             "{target}",

--- a/fud/fud/stages/relay.py
+++ b/fud/fud/stages/relay.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from fud.stages import SourceType, Stage
 from fud.utils import shell, unwrap_or
+from fud import config as cfg
 
 
 class RelayStage(Stage):
@@ -22,7 +23,7 @@ class RelayStage(Stage):
 
     def _define_steps(self, input, builder, config):
         script = (
-            Path(config["global", "futil_directory"])
+            Path(config["global", cfg.ROOT])
             / "frontends"
             / "relay"
             / "relay_visitor.py"

--- a/fud/fud/stages/systolic.py
+++ b/fud/fud/stages/systolic.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from fud import config as cfg
 from fud.stages import SourceType, Stage
 from fud.utils import shell, unwrap_or
 
@@ -24,7 +25,7 @@ class SystolicStage(Stage):
 
     def _define_steps(self, input, builder, config):
         script = (
-            Path(config["global", "futil_directory"])
+            Path(config["global", cfg.ROOT])
             / "frontends"
             / "systolic-lang"
             / "gen-systolic.py"

--- a/fud/fud/stages/verilator/stage.py
+++ b/fud/fud/stages/verilator/stage.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from fud import errors
 from fud.stages import Source, SourceType, Stage
 from fud.utils import TmpDir, shell, unwrap_or
+from fud import config as cfg
 
 from .json_to_dat import convert2dat, convert2json
 
@@ -30,7 +31,7 @@ class VerilatorStage(Stage):
 
         testbench_files = [
             str(
-                Path(config["global", "futil_directory"])
+                Path(config["global", cfg.ROOT])
                 / "fud"
                 / "sim"
                 / "testbench.cpp"

--- a/fud/fud/stages/vivado/stage.py
+++ b/fud/fud/stages/vivado/stage.py
@@ -5,6 +5,7 @@ import os
 from fud.stages import SourceType, Stage
 from fud.stages.remote_context import RemoteExecution
 from fud.utils import TmpDir, shell
+from fud import config as cfg
 
 from .extract import futil_extract, hls_extract
 
@@ -113,9 +114,10 @@ class VivadoStage(VivadoBaseStage):
         )
 
     def device_files(self, config):
+        root = Path(config["global", cfg.ROOT])
         return [
-            Path(config["global", "futil_directory"]) / "fud" / "synth" / "synth.tcl",
-            Path(config["global", "futil_directory"]) / "fud" / "synth" / "device.xdc",
+            root / "fud" / "synth" / "synth.tcl",
+            root / "fud" / "synth" / "device.xdc",
         ]
 
 
@@ -133,16 +135,10 @@ class VivadoHLSStage(VivadoBaseStage):
         )
 
     def device_files(self, config):
+        root = Path(config["global", cfg.ROOT])
         return [
-            str(
-                Path(config["global", "futil_directory"]) / "fud" / "synth" / "hls.tcl"
-            ),
-            str(
-                Path(config["global", "futil_directory"])
-                / "fud"
-                / "synth"
-                / "fxp_sqrt.h"
-            ),
+            str(root / "fud" / "synth" / "hls.tcl"),
+            str(root / "fud" / "synth" / "fxp_sqrt.h"),
         ]
 
 

--- a/fud/fud/stages/xilinx/emulation.py
+++ b/fud/fud/stages/xilinx/emulation.py
@@ -6,6 +6,7 @@ from fud.stages import Stage, SourceType, Source
 from fud import errors
 from fud.stages.remote_context import RemoteExecution, LocalSandbox
 from fud.utils import shell
+from fud import config as cfg
 
 
 class HwEmulationStage(Stage):
@@ -46,10 +47,10 @@ class HwEmulationStage(Stage):
         host_cpp = config["stages", self.name, "host"]
         save_temps = bool(config["stages", self.name, "save_temps"]) and config["stages", self.name, "save_temps"] == "true"
         xrt = (
-            Path(config["global", "futil_directory"]) / "fud" / "bitstream" / "xrt.ini"
+            Path(config["global", cfg.ROOT]) / "fud" / "bitstream" / "xrt.ini"
         )
         sim_script = (
-            Path(config["global", "futil_directory"])
+            Path(config["global", cfg.ROOT])
             / "fud"
             / "bitstream"
             / "sim_script.tcl"

--- a/fud/fud/stages/xilinx/xclbin.py
+++ b/fud/fud/stages/xilinx/xclbin.py
@@ -6,6 +6,7 @@ from fud.stages import Source, SourceType, Stage
 from fud.stages.remote_context import RemoteExecution, LocalSandbox
 from fud.stages.futil import FutilStage
 from fud.utils import shell
+from fud import config as cfg
 
 
 def get_ports(kernel_xml):
@@ -63,7 +64,7 @@ class XilinxStage(Stage):
 
         # tcl files
         self.gen_xo_tcl = (
-            Path(config["global", "futil_directory"])
+            Path(config["global", cfg.ROOT])
             / "fud"
             / "bitstream"
             / "gen_xo.tcl"


### PR DESCRIPTION
Another PR will rename `futil_directory` to something like `base_directory`. This just centralizes the logic for `futil_directory` to the configuration itself of being a magic string.
