### PR TITLE
dump ports should inline clk and reset after lowering

### DIFF
--- a/calyx/src/passes/compile_ref.rs
+++ b/calyx/src/passes/compile_ref.rs
@@ -61,6 +61,7 @@ impl Visitor for CompileRef {
         dump_ports::dump_ports_to_signature(
             comp,
             is_external_cell,
+            true,
             &mut self.port_names,
         );
         Ok(Action::Continue)

--- a/calyx/src/passes/dump_ports.rs
+++ b/calyx/src/passes/dump_ports.rs
@@ -1,39 +1,45 @@
-use std::collections::HashMap;
-
 use crate::ir::{self, RRC, WRC};
+use std::collections::HashMap;
 
 /// Formats name of a port given the id of the cell and the port
 pub(super) fn format_port_name(comp: &ir::Id, port: &ir::Id) -> ir::Id {
     format!("{}_{}", comp.id, port.id).into()
 }
 
-/// Remove all the cells matching the given criterion(f evaluates to true) from
+/// Remove all the cells matching the given criterion (f evaluates to true) from
 /// the component and inline all the ports of the removed cells to the component
-/// signature
+/// signature.
+///
+/// If remove_signals is true, does not inline ports marked with @clk and @reset.
 pub(super) fn dump_ports_to_signature(
     component: &mut ir::Component,
-    f: fn(&RRC<ir::Cell>) -> bool,
+    cell_filter: fn(&RRC<ir::Cell>) -> bool,
+    remove_signals: bool,
     port_names: &mut HashMap<ir::Id, HashMap<ir::Id, HashMap<ir::Id, ir::Id>>>,
 ) {
     let comp_name = component.name.clone();
     let (ext_cells, cells): (Vec<_>, Vec<_>) =
-        component.cells.drain().partition(f);
-
+        component.cells.drain().partition(cell_filter);
     component.cells.append(cells.into_iter());
 
     for cell_ref in ext_cells {
         let mut cell = cell_ref.borrow_mut();
         let name = cell.name().clone();
-        let (ports_inline, _): (Vec<_>, Vec<_>) =
-            cell.ports.drain(..).partition(|p_ref| {
-                let p = p_ref.borrow();
-                p.attributes.get("clk").is_none()
-                    && p.attributes.get("reset").is_none()
-            });
+
         // If we do not eliminate the @clk and @reset ports, we may
         // get signals conflicting the original @clk and @reset signals of
         // the component, see https://github.com/cucapra/calyx/issues/1034
-        for port_ref in ports_inline.into_iter() {
+        let ports_inline = cell.ports.drain(..).filter(|pr| {
+            let p = pr.borrow();
+            if remove_signals {
+                p.attributes.get("clk").is_none()
+                    && p.attributes.get("reset").is_none()
+            } else {
+                true
+            }
+        });
+
+        for port_ref in ports_inline {
             let port_name = port_ref.borrow().name.clone();
             // Change the name and the parent of this port.
             port_names

--- a/calyx/src/passes/externalize.rs
+++ b/calyx/src/passes/externalize.rs
@@ -80,6 +80,7 @@ impl Visitor for Externalize {
         dump_ports::dump_ports_to_signature(
             comp,
             has_external_attribute,
+            false,
             &mut port_names,
         );
 

--- a/tests/passes/externalize.expect
+++ b/tests/passes/externalize.expect
@@ -1,5 +1,5 @@
 import "primitives/core.futil";
-component main(@go go: 1, @clk clk: 1, @reset reset: 1, A_read_data: 32, A_done: 1) -> (@done done: 1, A_addr0: 4, A_write_data: 32, A_write_en: 1) {
+component main(@go go: 1, @clk clk: 1, @reset reset: 1, A_read_data: 32, A_done: 1) -> (@done done: 1, A_addr0: 4, A_write_data: 32, A_write_en: 1, A_clk: 1) {
   cells {
     B = std_mem_d1(32, 16, 4);
     state = std_reg(32);


### PR DESCRIPTION
Another weird problem with the cell interface inlining problem in #1034. In this case, the externalize pass used by the synthesis pipeline needs the `@clk` and `@reset` ports to be inlined in the main component interface because otherwise they are not usable.

This is different from `ref` cells because they occur in non-`main` components and can implicitly use the clk of the context.
