### PR TITLE
[fud] FPGA stage produces VCD files when waveform is enabled

### DIFF
--- a/docs/fud/xilinx.md
+++ b/docs/fud/xilinx.md
@@ -136,12 +136,20 @@ and you need to tell XRT whether you want `hw_emu` (emulation) or `hw` (actual o
 Of course, it would be better if all this could come from fud's configuration itself instead of requiring you to set it up ahead of time;
 [issue #872](https://github.com/cucapra/calyx/issues/872) covers this work.
 
-In emulation mode, this stage can produce a waveform trace in Xilinx's proprietary [WDB][] file format.
-Use `-s fpga.waveform true -s fpga.save_temps true` to collect a WDB.
-The first option instructs XRT to use [the `batch` debug mode][xrt-debug], and the second asks fud not to delete the directory where the WDB file will appear.
+#### Waveform Debugging
+
+In emulation mode, this stage can produce a waveform trace in Xilinx's proprietary [WDB][] file format as well as a standard [VCD][] file.
+
+Use the fud options `-s fpga.waveform true -s fpga.save_temps true` when emulating your program.
+The first option instructs XRT to use [the `batch` debug mode][xrt-debug] and to dump a VCD, and the second asks fud not to delete the directory where the waveform files will appear.
+
+Then, look in the resulting directory, which will be named `fud-out-*` for some `*`.
+In there, the Xilinx trace files you want are named `*.wdb` and `*.wcfg`.
+The VCD file is at `.run/*/hw_em/device0/binary_0/behav_waveform/xsim/dump.vcd` or similar.
 
 [emconfig.json]: https://docs.xilinx.com/r/en-US/ug1393-vitis-application-acceleration/emconfigutil-Utility
 [xrt-debug]: https://xilinx.github.io/Vitis_Accel_Examples/2021.1/html/debug_profile.html
+[vcd]: https://en.wikipedia.org/wiki/Value_change_dump
 
 ### Emulate
 


### PR DESCRIPTION
The Xilinx simulator produces WDB traces by default. We now can also produce VCD files, which may be more convenient to use. This makes the `-s fpga.waveform` config option produce both and documents where to find the resulting files.

The way this works is to add options like this to `xrt.ini`:

```
[Emulation]
debug_mode=batch
user_pre_sim_script=/scratch/adrian/pynq-ex/pre_sim.tcl
user_post_sim_script=/scratch/adrian/pynq-ex/post_sim.tcl
```

(Note the absolute paths! fud generates these itself, of course.) The `user_*_sim_script` options let you run arbitrary Tcl commands as part of the xsim simulation. `pre_sim.tcl` contains:

```tcl
open_vcd
log_vcd *
```

And `post_sim.tcl` just has:

```tcl
close_vcd
```

And that's all there is to it.

This may be of interest to @nathanielnrn to avoid the need for X forwarding when viewing waveforms (combined with [GTKWave](http://gtkwave.sourceforge.net) to view the file locally).