### PR TITLE
Fix WDATA and WSTRB alignment issues

### DIFF
--- a/src/backend/xilinx/xml.rs
+++ b/src/backend/xilinx/xml.rs
@@ -162,8 +162,9 @@ impl Backend for XilinxXmlBackend {
                 address_qualifier: 1,
                 id: (i + 1) as u64,
                 port: axi_name,
-                //XXX(nathanielnrn): This should probably be assigned dynamically and not
-                //hardcoded, need to figure out where this comes from
+                // XXX(nathanielnrn): This should probably be assigned dynamically
+                // and not hardcoded, need to figure out where this comes from
+                // One theory: this is an 8-byte pointer to our argument arrays
                 size: "0x8",
                 offset: &offsets[i],
                 typ: "int*",

--- a/src/backend/xilinx/xml.rs
+++ b/src/backend/xilinx/xml.rs
@@ -162,6 +162,8 @@ impl Backend for XilinxXmlBackend {
                 address_qualifier: 1,
                 id: (i + 1) as u64,
                 port: axi_name,
+                //XXX(nathanielnrn): This should probably be assigned dynamically and not
+                //hardcoded, need to figure out where this comes from
                 size: "0x8",
                 offset: &offsets[i],
                 typ: "int*",


### PR DESCRIPTION
Previously, data was always assigned to WDATA[31:0] (for 32-bit wide
data), with WSTRB being assigned accordingly. This caused dtaa to only
be written to the base address. Now, WDATA is shifted based on
data width for each write that is supposed to occur. WSTRB also changed
accordingly.