### PR TITLE
Generate source maps by default in frontends

### DIFF
--- a/calyx-py/calyx/py_ast.py
+++ b/calyx-py/calyx/py_ast.py
@@ -1,6 +1,6 @@
 from __future__ import annotations  # Used for circular dependencies.
 from dataclasses import dataclass, field
-from typing import List, Union, Any, Tuple, Optional
+from typing import List, Any, Tuple, Optional
 from calyx.utils import block
 
 
@@ -26,11 +26,18 @@ class Import(Emittable):
 class Program(Emittable):
     imports: List[Import]
     components: List[Component]
+    meta: dict[Any, str] = field(default_factory=dict)
 
     def doc(self) -> str:
-        imports = "\n".join([i.doc() for i in self.imports])
-        components = "\n".join([c.doc() for c in self.components])
-        return f"{imports}\n{components}"
+        out = ""
+        out += "\n".join([i.doc() for i in self.imports])
+        out += "\n".join([c.doc() for c in self.components])
+        if len(self.meta) > 0:
+            out = "\nmetadata #{\n"
+            for key, val in self.meta.items():
+                out += f"{key}: {val}\n"
+            out += "}#"
+        return out
 
 
 # Component
@@ -255,7 +262,7 @@ class Control(Emittable):
 
 
 @dataclass
-class Enable(Emittable):
+class Enable(Control):
     stmt: str
 
     def doc(self) -> str:
@@ -263,17 +270,8 @@ class Enable(Emittable):
 
 
 @dataclass
-class ControlOrEnable(Emittable):
-    ControlOrEnableType = Union[Control, Enable]
-    stmt: ControlOrEnableType
-
-    def doc(self) -> str:
-        return self.doc()
-
-
-@dataclass
 class SeqComp(Control):
-    stmts: list[ControlOrEnable]
+    stmts: list[Control]
 
     def doc(self) -> str:
         return block("seq", [s.doc() for s in self.stmts])
@@ -281,7 +279,7 @@ class SeqComp(Control):
 
 @dataclass
 class ParComp(Control):
-    stmts: list[ControlOrEnable]
+    stmts: list[Control]
 
     def doc(self) -> str:
         return block("par", [s.doc() for s in self.stmts])
@@ -364,18 +362,6 @@ class If(Control):
         else:
             false_branch = block(" else", self.false_branch.doc(), sep="")
         return block(cond, true_branch, sep="") + false_branch
-
-
-@dataclass
-class Metadata:
-    metadata_map: dict[Any, str]
-
-    def doc(self) -> str:
-        out = "metadata #{\n"
-        for key, val in self.metadata_map.items():
-            out += f"{key}: {val}\n"
-        out += "}#"
-        return out
 
 
 # Standard Library

--- a/frontends/systolic-lang/gen-systolic.py
+++ b/frontends/systolic-lang/gen-systolic.py
@@ -361,9 +361,7 @@ def index_update_at(row, col):
     return updates
 
 
-def generate_control(
-    top_length, top_depth, left_length, left_depth, gen_metadata=False
-):
+def generate_control(top_length, top_depth, left_length, left_depth):
     """
     Logically, control performs the following actions:
     1. Initialize all the memory indexors at the start.
@@ -442,13 +440,9 @@ def generate_control(
                 out_connects=[],
             )
 
-            if gen_metadata:
-                tag = counter()
-                more_control.append(invoke.with_attr("pos", tag))
-
-                source_map[tag] = f"pe_{r}_{c} running. Iteration {idx}"
-            else:
-                more_control.append(invoke)
+            tag = counter()
+            more_control.append(invoke.with_attr("pos", tag))
+            source_map[tag] = f"pe_{r}_{c} running. Iteration {idx}"
 
         control.append(py_ast.ParComp(more_control))
 
@@ -464,9 +458,7 @@ def generate_control(
     return py_ast.SeqComp(stmts=control), source_map
 
 
-def create_systolic_array(
-    top_length, top_depth, left_length, left_depth, gen_metadata=False
-):
+def create_systolic_array(top_length, top_depth, left_length, left_depth):
     """
     top_length: Number of PEs in each row.
     top_depth: Number of elements processed by each PE in a row.
@@ -522,7 +514,7 @@ def create_systolic_array(
             wires.append(s)
 
     control, source_map = generate_control(
-        top_length, top_depth, left_length, left_depth, gen_metadata=gen_metadata
+        top_length, top_depth, left_length, left_depth
     )
 
     main = py_ast.Component(
@@ -533,15 +525,13 @@ def create_systolic_array(
         controls=control,
     )
 
-    return (
-        py_ast.Program(
-            imports=[
-                py_ast.Import("primitives/core.futil"),
-                py_ast.Import("primitives/binary_operators.futil"),
-            ],
-            components=[main],
-        ),
-        source_map,
+    return py_ast.Program(
+        imports=[
+            py_ast.Import("primitives/core.futil"),
+            py_ast.Import("primitives/binary_operators.futil"),
+        ],
+        components=[main],
+        meta=source_map
     )
 
 
@@ -555,12 +545,6 @@ if __name__ == "__main__":
     parser.add_argument("-td", "--top-depth", type=int)
     parser.add_argument("-ll", "--left-length", type=int)
     parser.add_argument("-ld", "--left-depth", type=int)
-
-    parser.add_argument(
-        "--write-metadata",
-        action="store_true",
-        dest="write_metadata",
-    )
 
     args = parser.parse_args()
 
@@ -581,21 +565,16 @@ if __name__ == "__main__":
             left_depth = spec["left_depth"]
     else:
         parser.error(
-            "Need to pass either `-f FILE` or all of `"
+            "Need to pass either `FILE` or all of `"
             "-tl TOP_LENGTH -td TOP_DEPTH -ll LEFT_LENGTH -ld LEFT_DEPTH`"
         )
 
-    program, metadata = create_systolic_array(
+    program = create_systolic_array(
         top_length=top_length,
         top_depth=top_depth,
         left_length=left_length,
         left_depth=left_depth,
-        gen_metadata=args.write_metadata,
     )
 
-    program.emit()
     print(PE_DEF)
-
-    if args.write_metadata:
-        metadata = py_ast.Metadata(metadata)
-        print(metadata.doc())
+    program.emit()


### PR DESCRIPTION
Seems like we always add the `@pos` stuff to might as well generate the metadata as well. Removes `calyx_py.Metadata` and make `meta` a field on `calyx_py.Program`.
