### PR TITLE
Make Sharing Faster (Again)

### DIFF
--- a/calyx/src/passes/mod.rs
+++ b/calyx/src/passes/mod.rs
@@ -65,7 +65,6 @@ pub use par_to_seq::ParToSeq;
 pub use register_unsharing::RegisterUnsharing;
 pub use remove_comb_groups::RemoveCombGroups;
 pub use reset_insertion::ResetInsertion;
-pub use sharing_components::ShareComponents;
 pub use simplify_guards::SimplifyGuards;
 pub use static_par_conv::StaticParConv;
 pub use synthesis_papercut::SynthesisPapercut;

--- a/calyx/src/passes/sharing_components.rs
+++ b/calyx/src/passes/sharing_components.rs
@@ -4,7 +4,10 @@ use ir::{
     traversal::{Action, VisResult, Visitor},
     CloneName, RRC,
 };
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Instant,
+};
 
 /// A trait for implementing passes that want to share components
 /// by building a conflict graph and performing graph coloring
@@ -80,7 +83,9 @@ impl<T: ShareComponents> Visitor for T {
         sigs: &ir::LibrarySignatures,
         _comps: &[ir::Component],
     ) -> VisResult {
+        let start = Instant::now();
         self.initialize(comp, sigs);
+        log::info!("{} ms", start.elapsed().as_millis());
 
         let cells = comp.cells.iter().filter(|c| self.cell_filter(&c.borrow()));
 

--- a/calyx/src/passes/sharing_components.rs
+++ b/calyx/src/passes/sharing_components.rs
@@ -1,13 +1,9 @@
 //! Defines common traits for methods that attempt to share components.
-use crate::{
-    analysis::{GraphColoring, ScheduleConflicts},
-    ir,
-};
+use crate::{analysis::GraphColoring, ir};
 use ir::{
     traversal::{Action, VisResult, Visitor},
     CloneName, RRC,
 };
-use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 
 /// A trait for implementing passes that want to share components
@@ -65,6 +61,16 @@ pub trait ShareComponents {
 
     /// Get the list of rewrites.
     fn get_rewrites(&self) -> &HashMap<ir::Id, RRC<ir::Cell>>;
+
+    fn set_id_to_type(&mut self, id_to_type: HashMap<ir::Id, ir::CellType>);
+
+    ///
+    fn build_conflict_graph(
+        &self,
+        graphs_by_type: &mut HashMap<ir::CellType, GraphColoring<ir::Id>>,
+        c: &ir::Control,
+        is_in_par: bool,
+    ) -> HashMap<&ir::CellType, HashSet<&ir::Id>>;
 }
 
 impl<T: ShareComponents> Visitor for T {
@@ -103,7 +109,7 @@ impl<T: ShareComponents> Visitor for T {
                 })
                 .collect();
 
-        // get all of the invokes and enables.
+        /*// get all of the invokes and enables.
         let mut invokes_enables = HashSet::new();
         get_invokes_enables(&comp.control.borrow(), &mut invokes_enables);
 
@@ -213,7 +219,15 @@ impl<T: ShareComponents> Visitor for T {
                     }
                 }
             }
-        }
+        }*/
+
+        self.set_id_to_type(id_to_type);
+
+        self.build_conflict_graph(
+            &mut graphs_by_type,
+            &*comp.control.borrow(),
+            false,
+        );
 
         // perform graph coloring to rename the cells
         let mut coloring: ir::rewriter::CellRewriteMap = HashMap::new();
@@ -246,7 +260,7 @@ impl<T: ShareComponents> Visitor for T {
     }
 }
 
-//Gets the names of all the cells invoked (using an invoke control statement)
+/*//Gets the names of all the cells invoked (using an invoke control statement)
 //in control c, and adds them to hs.
 fn get_invokes_enables(c: &ir::Control, hs: &mut HashSet<ir::Id>) {
     match c {
@@ -273,4 +287,4 @@ fn get_invokes_enables(c: &ir::Control, hs: &mut HashSet<ir::Id>) {
             get_invokes_enables(body, hs);
         }
     }
-}
+}*/

--- a/calyx/src/passes/sharing_components.rs
+++ b/calyx/src/passes/sharing_components.rs
@@ -2,90 +2,29 @@
 use crate::{analysis::GraphColoring, ir};
 use ir::{
     traversal::{Action, VisResult, Visitor},
-    CloneName, RRC,
+    CloneName,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    time::Instant,
-};
+use std::collections::HashMap;
 
-/// A trait for implementing passes that want to share components
-/// by building a conflict graph and performing graph coloring
-/// to minimize the number of used components.
-///
-/// You must implement the functions:
-///  - [ShareComponents::lookup_node_conflicts]
-///  - [ShareComponents::cell_filter]
-///  - [ShareComponents::set_rewrites]
-///  - [ShareComponents::get_rewrites]
-///
-/// Given these functions, the trait [Visitor] will automatically be
-/// implemented for your struct.
-///
+use crate::passes::CellShare;
+
 /// The algorithm that runs is:
 ///  - instantiate conflict graph using all component cells that satisfy `cell_filter`
 ///  - use [ScheduleConflicts] to find groups/invokes that run in parallel with each other
 ///  - for each group/invoke, `G` that runs in parallel with another group/invoke `H`, add edges between each
 ///  cell in the sets `lookup_node_conflicts(G)` and `lookup_node_conflicts(H)`.
+///  - for each group/invoke `G` add edges between cells in `G` of the same type
 ///  - add conflicts between cells where for `c0 != c1`
-///  - call `custom_conflicts` to insert pass specific conflict edges
 ///  - perform graph coloring using `self.ordering` to define the order of the greedy coloring
 ///  - use coloring to rewrite group assignments, continuous assignments, and conditional ports.
-pub trait ShareComponents {
-    /// Initialize the structure. This function is called at the very beginning of the traversal
-    /// before anything else.
-    fn initialize(
-        &mut self,
-        _component: &ir::Component,
-        _library_signatures: &ir::LibrarySignatures,
-    ) {
-        // nothing
-    }
-
-    /// Return a vector of conflicting cell names for a the group `group_name`.
-    /// These are the names of the cells that conflict if their groups are
-    /// run in parallel.
-    fn lookup_node_conflicts(&self, node_name: &ir::Id) -> Vec<&ir::Id>;
-
-    /// Given a cell and the library signatures, this function decides if
-    /// this cell is relevant to the current sharing pass or not. This
-    /// is used to filter out irrelevant cells.
-    fn cell_filter(&self, cell: &ir::Cell) -> bool;
-
-    /// The definition of cell equality. Cells will only be replaced with
-    /// a cell that is equal to it according to this function. The default
-    /// implementation is to compare the prototypes of the cell.
-    fn cell_equality(&self, cell0: &ir::Cell, cell1: &ir::Cell) -> bool {
-        cell0.prototype == cell1.prototype
-    }
-
-    /// Set the list of rewrites.
-    fn set_rewrites(&mut self, rewrites: HashMap<ir::Id, RRC<ir::Cell>>);
-
-    /// Get the list of rewrites.
-    fn get_rewrites(&self) -> &HashMap<ir::Id, RRC<ir::Cell>>;
-
-    fn set_id_to_type(&mut self, id_to_type: HashMap<ir::Id, ir::CellType>);
-
-    ///
-    fn build_conflict_graph(
-        &self,
-        graphs_by_type: &mut HashMap<ir::CellType, GraphColoring<ir::Id>>,
-        c: &ir::Control,
-        is_in_par: bool,
-    ) -> HashMap<&ir::CellType, HashSet<&ir::Id>>;
-}
-
-impl<T: ShareComponents> Visitor for T {
+impl Visitor for CellShare {
     fn start(
         &mut self,
         comp: &mut ir::Component,
         sigs: &ir::LibrarySignatures,
         _comps: &[ir::Component],
     ) -> VisResult {
-        let start = Instant::now();
         self.initialize(comp, sigs);
-        log::info!("{} ms", start.elapsed().as_millis());
 
         let cells = comp.cells.iter().filter(|c| self.cell_filter(&c.borrow()));
 
@@ -114,121 +53,9 @@ impl<T: ShareComponents> Visitor for T {
                 })
                 .collect();
 
-        /*// get all of the invokes and enables.
-        let mut invokes_enables = HashSet::new();
-        get_invokes_enables(&comp.control.borrow(), &mut invokes_enables);
-
-        // Maps node to map. node is an invoke/enable. map holds
-        // the name of all the cells live at node, organized by
-        // cell type. All nodes should be accounted for in this map.
-        // Ex: if std_reg(32) r and std_add(32) a are alive at group G,
-        // then the map would have entry: G: {std_reg(32): r, std_add(32): a}
-        let mut node_by_type_map: HashMap<
-            ir::Id,
-            HashMap<&ir::CellType, HashSet<&ir::Id>>,
-        > = HashMap::new();
-
-        // Build node_by_type_map.
-        for node in &invokes_enables {
-            let node_conflicts = self.lookup_node_conflicts(node);
-            if node_conflicts.is_empty() {
-                // If node has no live cells, add an empty Map as its entry,
-                // since we want to have all invokes/enables accounted for.
-                node_by_type_map.insert(node.clone(), HashMap::new());
-            } else {
-                let live_at_node =
-                    node_by_type_map.entry(node.clone()).or_default();
-                for conflict in node_conflicts {
-                    live_at_node
-                        .entry(&id_to_type[conflict])
-                        .or_default()
-                        .insert(conflict);
-                }
-            }
-        }
-
-        // Closure so that we can take a group/invoke, and get all of the cells live
-        // at that group/invoke, *organized by type* in the form of a HashMap.
-        let lookup_conflicts_by_type =
-            |node: &ir::Id| -> &HashMap<&ir::CellType, HashSet<&ir::Id>> {
-                node_by_type_map.get(node).unwrap_or_else(|| {
-                    unreachable!("no node conflict map for {}", node)
-                })
-            };
-
-        // conflict (a,b) is in par_conflicts if a and b run in parallel w/ each other
-        let par_conflicts = ScheduleConflicts::from(&*comp.control.borrow());
-
-        // Building node_conflicts,which is a map from nodes to another map.
-        // nodes are inovkes/enables. maps are the cells live at nodes that may be run in
-        // parrallel with node, and these cells are again organized by cell type.
-        let mut node_conflicts = par_conflicts
-            .all_conflicts()
-            .into_grouping_map_by(|(g1, _)| g1.clone())
-            .fold(
-                HashMap::<&ir::CellType, HashSet<&ir::Id>>::new(),
-                |mut acc, _, (_, conflicted_group)| {
-                    let new_conflicts =
-                        lookup_conflicts_by_type(&conflicted_group);
-                    for (cell_type, nodes) in new_conflicts {
-                        acc.entry(cell_type).or_default().extend(nodes);
-                    }
-                    acc
-                },
-            );
-
-        // add conflicts
-        for node_name in &invokes_enables {
-            let node_confs_by_type = lookup_conflicts_by_type(node_name);
-            match node_conflicts.get_mut(node_name) {
-                None => {
-                    // There are no nodes running in parallel to node_name. In
-                    // this case, all we have to do is add conflicts within node_name
-                    for (cell_type, confs) in node_confs_by_type {
-                        let g = graphs_by_type.get_mut(cell_type).unwrap();
-                        // notice how we only perform tuple_combinations on cells that we
-                        // know are the same type. This is faster than creating
-                        // tuple_combinations, and then checking whether they're the
-                        // same type.
-                        for (a, b) in confs.iter().tuple_combinations() {
-                            g.insert_conflict(a, b)
-                        }
-                    }
-                }
-                Some(conflict_map) => {
-                    // There are some cells that are live in parallel to node_name
-                    for (cell_type, a_confs) in node_confs_by_type {
-                        let g = graphs_by_type.get_mut(cell_type).unwrap();
-                        if let Some(b_confs) = conflict_map.get_mut(cell_type) {
-                            // Since we know a and b are the same type, we can add conflicts w/o
-                            // checking type.
-                            for &a in a_confs {
-                                for &b in b_confs.iter() {
-                                    if a != b {
-                                        g.insert_conflict(a, b);
-                                    }
-                                }
-                                // so that there are conflicts between each cell
-                                // in a_confs. We do this instead of doing
-                                // tuple_combinations() on a_confs.
-                                b_confs.insert(a);
-                            }
-                        } else {
-                            // If there are no cells of type cell_type that coudl be run in parallel
-                            // with node_name, then all we have to do is add conflicts
-                            // within a_confs
-                            for (a, b) in a_confs.iter().tuple_combinations() {
-                                g.insert_conflict(a, b)
-                            }
-                        }
-                    }
-                }
-            }
-        }*/
-
         self.set_id_to_type(id_to_type);
 
-        self.build_conflict_graph(
+        self.insert_conflicts(
             &mut graphs_by_type,
             &*comp.control.borrow(),
             false,
@@ -264,32 +91,3 @@ impl<T: ShareComponents> Visitor for T {
         Ok(Action::Stop)
     }
 }
-
-/*//Gets the names of all the cells invoked (using an invoke control statement)
-//in control c, and adds them to hs.
-fn get_invokes_enables(c: &ir::Control, hs: &mut HashSet<ir::Id>) {
-    match c {
-        ir::Control::Empty(_) => (),
-        ir::Control::Enable(ir::Enable { group, .. }) => {
-            hs.insert(group.borrow().name().clone());
-        }
-        ir::Control::Invoke(ir::Invoke { comp, .. }) => {
-            hs.insert(comp.borrow().name().clone());
-        }
-        ir::Control::Par(ir::Par { stmts, .. })
-        | ir::Control::Seq(ir::Seq { stmts, .. }) => {
-            for stmt in stmts {
-                get_invokes_enables(stmt, hs);
-            }
-        }
-        ir::Control::If(ir::If {
-            tbranch, fbranch, ..
-        }) => {
-            get_invokes_enables(tbranch, hs);
-            get_invokes_enables(fbranch, hs);
-        }
-        ir::Control::While(ir::While { body, .. }) => {
-            get_invokes_enables(body, hs);
-        }
-    }
-}*/


### PR DESCRIPTION
This time I made some more dramatic changes to the structure of Cell Sharing. 

- Since `CellShare` was the only thing that used `ShareComponents` there are is no longer a `CellShare` trait that needs to be implemented .
- I restructured the way I insert the conflicts. Now it is basically performed all in one function that recursively visits each control statement, and inserts the conflicts as it goes through the control statement. 

Another note: I tried to make live ranges be in terms of HashMaps (from cell types to sets of cell names) rather than a HashSet. It wasn't really improving performance all that much, although that may be due to the way I was implementing it. I still have these changes on a separate branch (that I haven't merged), and could play around with it more tomorrow to see if I could get some improvement). 

Improvement Times 
debug
gemm2: .099 s -> .101 s
gemm3: 2.627s -> 2.003 s
gemm4: .905s -> .866 s
gemm6: 104s -> 60 s
gemm8: 28s ->  25 s

release
gemm2: .010 -> .009 s
gemm3: .184s -> .145 s
gemm4: .083s ->  .074 s
gemm6: 5.816s -> 3.025 s
(For some reason I thought that gemm6 was faster when I was testing it in the previous PR but when I tried to run the master branch I got 5.816s). 
gemm8: 1.544s -> 1.303 s