### PR TITLE
[CIDR] Misc tweaks & help message changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,9 +528,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fraction"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba3510011eee8825018be07f08d9643421de007eaf62a3bde58d89b058abfa7"
+checksum = "317322288e76bb0c2dde9106975a0ba1f8a1ef18205ba2a5b8ef0ba6a638ca79"
 dependencies = [
  "lazy_static",
  "num",
@@ -660,6 +660,7 @@ dependencies = [
  "fraction",
  "ibig",
  "itertools 0.10.3",
+ "lazy_static",
  "once_cell",
  "pest",
  "pest_consume",
@@ -786,15 +787,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -1265,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790487c3881a63489ae77126f57048b42d62d3b2bafbf37453ea19eedb6340d6"
+checksum = "1d1cd5ae51d3f7bf65d7969d579d502168ef578f289452bd8ccc91de28fda20e"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1280,7 +1279,6 @@ dependencies = [
  "nix",
  "radix_trie",
  "scopeguard",
- "smallvec",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",

--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -32,7 +32,7 @@ DEFAULT_CONFIGURATION = {
         },
         "interpreter": {
             "exec": "./target/debug/interp",
-            "flags": None,
+            "flags": "--raw ",
             "data": None,
             "round_float_to_fixed": True,
         },

--- a/interp/Cargo.toml
+++ b/interp/Cargo.toml
@@ -22,13 +22,14 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 itertools = "0.10.1"
 argh = "0.1.5"
-rustyline = "=9.0.0"
-fraction = { version = "0.9.0", features = ["with-serde-support"] }
+rustyline = "=10.0.0"
+fraction = { version = "0.11.0", features = ["with-serde-support"] }
 thiserror = "1.0.26"
 ibig = { version = "0.3.4", features = ["serde"] }
 pest = "2.1.3"
 pest_derive = "2.1.0"
 pest_consume = "1.1.1"
+lazy_static = "1.4.0"
 
 slog = "2.7.0"
 slog-term = "2.8.0"

--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -308,6 +308,7 @@ impl Debugger {
                         )
                     }
                 }
+                Command::Explain => print!("{}", Command::get_explain_string()),
             }
         }
 
@@ -354,6 +355,7 @@ impl Debugger {
                     print!("{}", Command::get_help_string())
                 }
                 Command::Exit => return Err(InterpreterError::Exit),
+                Command::Explain => print!("{}", Command::get_explain_string()),
                 _ => {
                     println!(
                         "This command is unavailable after program termination"

--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -477,14 +477,10 @@ fn print_cell(
 
     match mode {
         PrintMode::State => {
-            let code = code.as_ref().copied().unwrap_or(PrintCode::Binary);
-            let cell_state = state.get_cell_state(&cell_ref, &code);
+            let actual_code = code.as_ref().copied().unwrap_or(PrintCode::Binary);
+            let cell_state = state.get_cell_state(&cell_ref, &actual_code);
             if matches!(&cell_state, &Serializable::Empty) {
-                format!(
-                    "{} cell {} has no internal state",
-                    SPACING,
-                    cell_ref.name()
-                )
+                print_cell(target, state, code, &PrintMode::Port)
             } else {
                 format!("{}{} = {}", SPACING, cell_ref.name(), cell_state)
             }

--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -477,7 +477,8 @@ fn print_cell(
 
     match mode {
         PrintMode::State => {
-            let actual_code = code.as_ref().copied().unwrap_or(PrintCode::Binary);
+            let actual_code =
+                code.as_ref().copied().unwrap_or(PrintCode::Binary);
             let cell_state = state.get_cell_state(&cell_ref, &actual_code);
             if matches!(&cell_state, &Serializable::Empty) {
                 print_cell(target, state, code, &PrintMode::Port)

--- a/interp/src/debugger/cidr.rs
+++ b/interp/src/debugger/cidr.rs
@@ -61,7 +61,7 @@ impl Debugger {
 
         component_interpreter.converge()?;
 
-        let mut input_stream = Input::default();
+        let mut input_stream = Input::new()?;
         println!("== Calyx Interactive Debugger ==");
         while !component_interpreter.is_done() {
             let comm = input_stream.next_command();

--- a/interp/src/debugger/commands.rs
+++ b/interp/src/debugger/commands.rs
@@ -189,6 +189,7 @@ pub enum Command {
         PrintMode,
     ),
     PrintPC,
+    Explain,
 }
 
 type Description = &'static str;
@@ -207,6 +208,23 @@ impl Command {
             writeln!(out, "    {: <20}{}", names.join(", "), message).unwrap();
         }
 
+        out
+    }
+
+    pub fn get_explain_string() -> String {
+        let mut out = String::new();
+        for CommandInfo {
+            invocation,
+            description,
+            usage_example,
+        } in COMMAND_INFO.iter().filter(|x| !x.usage_example.is_empty())
+        {
+            writeln!(out).unwrap();
+            writeln!(out, "{}", invocation.join(", ")).unwrap();
+            writeln!(out, "   {}", description).unwrap();
+            writeln!(out, "     {}", usage_example.join("\n     ")).unwrap();
+        }
+        writeln!(out).unwrap();
         out
     }
 }
@@ -278,10 +296,13 @@ lazy_static! {
             CIBuilder::new().invocation("disable")
                 .description("Disable target breakpoint")
                 .usage("> disable 4").usage("> disable do_mult").build(),
+            // explain
+            CIBuilder::new().invocation("explain")
+                .description("Show examples of commands which take arguments").build(),
             // exit/quit
             CIBuilder::new().invocation("exit")
                 .invocation("quit")
-                .description("Exit the debugger").build()
+                .description("Exit the debugger").build(),
         ]
     };
 }

--- a/interp/src/debugger/commands.rs
+++ b/interp/src/debugger/commands.rs
@@ -1,6 +1,10 @@
 use calyx::ir::Id;
 use itertools::{self, Itertools};
-use std::fmt::{Display, Write};
+use lazy_static::lazy_static;
+use std::{
+    fmt::{Display, Write},
+    marker::PhantomData,
+};
 
 use crate::structures::names::CompGroupName;
 
@@ -191,35 +195,191 @@ type Description = &'static str;
 type UsageExample = &'static str;
 type CommandName = &'static str;
 
-type HelpInfo = (Vec<CommandName>, Description, Vec<UsageExample>);
-
 impl Command {
     pub fn get_help_string() -> String {
         let mut out = String::new();
-        for (names, message, _) in Command::help_string() {
+        for CommandInfo {
+            invocation: names,
+            description: message,
+            ..
+        } in COMMAND_INFO.iter()
+        {
             writeln!(out, "    {: <20}{}", names.join(", "), message).unwrap();
         }
 
         out
     }
+}
 
-    fn help_string() -> Vec<HelpInfo> {
+// I wouldn't recommend looking at this
+
+lazy_static! {
+    /// A (lazy) static list of [CommandInfo] objects used for the help and
+    /// explain messages
+    static ref COMMAND_INFO: Vec<CommandInfo> = {
         vec![
-            (vec!["step", "s"], "Advance the execution by a step. If provided a number, it will advance by that many steps (skips breakpoints).", vec!["> s", "> s 5"]),
-            (vec!["step-over"], "Advance the execution over a given group.", vec!["> step-over this_group"]),
-            (vec!["continue", "c"], "Continue until the program finishes executing or hits a breakpoint", vec![]),
-            (vec!["display"], "Display the full state", vec![]),
-            (vec!["print", "p"], "Print target value. Takes an optional print code before the target. Valid print codes are \\u (unsigned), \\s (signed), \\u.X (unsigned fixed-point, X frac bits), \\s.X (signed fixed-point)", vec!["> p reg.write_en", "> p \\u mult1"]),
-            (vec!["print-state"], "Print the internal state of the target cell. Takes an optional print code before the target", vec!["> print-state my_register", "> print-state \\s.16 mem"]),
-            (vec!["watch"], "Watch a given group with a print statement. Takes an optional position (before/after)", vec!["> watch GROUP with p \\u reg.in", "> watch after GROUP with print-state \\s mem"] ),
-            (vec!["where", "pc"], "Displays the current program location using source metadata if applicable otherwise showing the calyx tree.", vec![]),
-            (vec!["help", "h"], "Print this message", vec![]),
-            (vec!["break", "br"], "Create a breakpoint", vec!["> br do_add", "> br subcomp::let0"]),
-            (vec!["info break", "ib"], "List all breakpoints", vec![]),
-            (vec!["delete","del"], "Delete target breakpoint", vec!["> del 1", "> del do_add"]),
-            (vec!["enable"], "Enable target breakpoint", vec!["> enable 1", "> enable do_add"]),
-            (vec!["disable"], "Disable target breakpoint", vec!["> disable 4", "> disable do_mult"]),
-            (vec!["exit", "quit"], "Exit the debugger", vec![])
+            // step
+            CIBuilder::new().invocation("step")
+                .invocation("s")
+                .description("Advance the execution by a step. If provided a number, it will advance by that many steps (skips breakpoints).")
+                .usage("> s").usage("> s 5").build(),
+            // step-over
+            CIBuilder::new().invocation("step-over")
+                .description("Advance the execution over a given group.")
+                .usage("> step-over this_group").build(),
+            // continue
+            CIBuilder::new().invocation("continue")
+                .invocation("c")
+                .description("Continue until the program finishes executing or hits a breakpoint").build(),
+            // display
+            CIBuilder::new().invocation("display")
+                .invocation("d")
+                .description("Display the full state of the main component").build(),
+            // print
+            CIBuilder::new().invocation("print")
+                .invocation("p")
+                .description("Print target value. Takes an optional print code before the target. Valid print codes are \\u (unsigned), \\s (signed), \\u.X (unsigned fixed-point, X frac bits), \\s.X (signed fixed-point)")
+                .usage("> p reg.write_en").usage("> p \\u mult1").build(),
+            // print-state
+            CIBuilder::new().invocation("print-state")
+                .description("Print the internal state of the target cell. Takes an optional print code before the target")
+                .usage("> watch after GROUP with print-state \\s mem").build(),
+            // watch
+            CIBuilder::new().invocation("watch")
+                .description("Watch a given group with a print statement. Takes an optional position (before/after)")
+                .usage("> watch GROUP with p \\u reg.in").usage("> watch after GROUP with print-state \\s mem").build(),
+            // where
+            CIBuilder::new().invocation("where")
+                .invocation("pc")
+                .description("Displays the current program location using source metadata if applicable otherwise showing the calyx tree").build(),
+            // help
+            CIBuilder::new().invocation("help")
+                .invocation("h")
+                .description("Print this message").build(),
+            // break
+            CIBuilder::new().invocation("break")
+                .invocation("br")
+                .description("Create a breakpoint")
+                .usage("> br do_add",).usage("> br subcomp::let0").build(),
+            // info break
+            CIBuilder::new().invocation("info break")
+                .invocation("ib")
+                .description("List all breakpoints").build(),
+            // delete
+            CIBuilder::new().invocation("delete")
+                .invocation("del")
+                .description("Delete target breakpoint")
+                .usage("> del 1").usage("> del do_add").build(),
+            // enable
+            CIBuilder::new().invocation("enable")
+                .description("Enable target breakpoint")
+                .usage("> enable 1").usage("> enable do_add").build(),
+            // disable
+            CIBuilder::new().invocation("disable")
+                .description("Disable target breakpoint")
+                .usage("> disable 4").usage("> disable do_mult").build(),
+            // exit/quit
+            CIBuilder::new().invocation("exit")
+                .invocation("quit")
+                .description("Exit the debugger").build()
         ]
+    };
+}
+
+#[derive(Clone, Debug)]
+pub struct CommandInfo {
+    invocation: Vec<CommandName>,
+    description: Description,
+    usage_example: Vec<UsageExample>,
+}
+
+// type shenanigans
+
+trait BuildState {}
+struct Missing;
+impl BuildState for Missing {}
+struct Present;
+impl BuildState for Present {}
+
+#[derive(Default, Clone, Debug)]
+struct CommandInfoBuilder<I, D>
+where
+    I: BuildState,
+    D: BuildState,
+{
+    invocation: Vec<CommandName>,
+    description: Option<Description>,
+    usage_example: Vec<UsageExample>,
+    phantom_i: PhantomData<I>,
+    phantom_d: PhantomData<D>,
+}
+
+type CIBuilder = CommandInfoBuilder<Missing, Missing>;
+
+impl CommandInfoBuilder<Missing, Missing> {
+    fn new() -> Self {
+        Self {
+            invocation: Default::default(),
+            description: Default::default(),
+            usage_example: Default::default(),
+            phantom_i: PhantomData,
+            phantom_d: PhantomData,
+        }
+    }
+}
+
+impl<I, D> CommandInfoBuilder<I, D>
+where
+    I: BuildState,
+    D: BuildState,
+{
+    fn invocation(
+        mut self,
+        val: CommandName,
+    ) -> CommandInfoBuilder<Present, D> {
+        self.invocation.push(val);
+
+        CommandInfoBuilder {
+            invocation: self.invocation,
+            description: self.description,
+            usage_example: self.usage_example,
+            phantom_i: PhantomData::<Present>,
+            phantom_d: self.phantom_d,
+        }
+    }
+
+    fn description(
+        mut self,
+        desc: Description,
+    ) -> CommandInfoBuilder<I, Present> {
+        self.description = Some(desc);
+        CommandInfoBuilder {
+            invocation: self.invocation,
+            description: self.description,
+            usage_example: self.usage_example,
+            phantom_i: self.phantom_i,
+            phantom_d: PhantomData::<Present>,
+        }
+    }
+
+    fn usage(mut self, usage: UsageExample) -> CommandInfoBuilder<I, D> {
+        self.usage_example.push(usage);
+        CommandInfoBuilder {
+            invocation: self.invocation,
+            description: self.description,
+            usage_example: self.usage_example,
+            phantom_i: self.phantom_i,
+            phantom_d: self.phantom_d,
+        }
+    }
+}
+
+impl CommandInfoBuilder<Present, Present> {
+    fn build(self) -> CommandInfo {
+        CommandInfo {
+            invocation: self.invocation,
+            description: self.description.unwrap(),
+            usage_example: self.usage_example,
+        }
     }
 }

--- a/interp/src/debugger/io_utils.rs
+++ b/interp/src/debugger/io_utils.rs
@@ -11,16 +11,13 @@ pub struct Input {
     command_buffer: VecDeque<Command>,
 }
 
-impl Default for Input {
-    fn default() -> Self {
-        Self {
-            buffer: Editor::new(),
-            command_buffer: VecDeque::default(),
-        }
-    }
-}
-
 impl Input {
+    pub fn new() -> InterpreterResult<Self> {
+        Ok(Self {
+            buffer: Editor::new()?,
+            command_buffer: VecDeque::default(),
+        })
+    }
     pub fn next_command(&mut self) -> InterpreterResult<Command> {
         if !self.command_buffer.is_empty() {
             return Ok(self.command_buffer.pop_front().unwrap());

--- a/interp/src/debugger/parser/command_parser.rs
+++ b/interp/src/debugger/parser/command_parser.rs
@@ -197,6 +197,10 @@ impl CommandParser {
         ))
     }
 
+    fn explain(_input: Node) -> ParseResult<Command> {
+        Ok(Command::Explain)
+    }
+
     fn watch(input: Node) -> ParseResult<Command> {
         Ok(match_nodes!(input.into_children();
         [watch_position(wp), group(g), print_state(p)] => {
@@ -250,6 +254,7 @@ impl CommandParser {
             [enable(e), EOI(_)] => e,
             [disable(dis), EOI(_)] => dis,
             [exit(exit), EOI(_)] => exit,
+            [explain(ex), EOI(_)] => ex,
             [EOI(_)] => Command::Empty,
         ))
     }

--- a/interp/src/debugger/parser/commands.pest
+++ b/interp/src/debugger/parser/commands.pest
@@ -72,6 +72,8 @@ exit = { ^"exit" | ^"quit" }
 
 comm_where = { ^"where" | ^"pc" }
 
+explain = { ^"explain" }
+
 command = {
     SOI ~
     (
@@ -94,6 +96,7 @@ command = {
      | info_watch
      | display
      | exit
+     | explain
     )?
     ~ EOI
 }


### PR DESCRIPTION
Nothing too excited, mostly just some stuff I cooked up in between illness induced naps. This is just clearing out a few smaller things from my backlog:
- add `raw` flag to fud's defaults for the interpreter
- make `print-state` fall back to printing out all the ports on a cell when given a cell without internal state, rather than giving an error message
- replaced some of the backend for Cider's help messages. It is horribly over-engineered and includes phantom types but I am allowed those once in a while as a treat. I think it is marginally easier to maintain.
- introduced a new `explain` command which shows snippets for Cider's commands which take arguments

Unless told otherwise I am going to consider this a closure of #1133, per the change to fud's default behavior.