### PR TITLE
Add markers at the start and end of the component

### DIFF
--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -161,6 +161,12 @@ fn emit_component(
         }
     }
 
+    // Add a COMPONENT START: <name> anchor before any code in the component
+    module.add_stmt(v::Stmt::new_rawstr(format!(
+        "// COMPONENT START: {}",
+        comp.name
+    )));
+
     // Add memory initial and final blocks
     if !synthesis_mode {
         memory_read_write(comp).into_iter().for_each(|stmt| {
@@ -229,6 +235,13 @@ fn emit_component(
     if !synthesis_mode {
         module.add_process(checks);
     }
+
+    // Add COMPONENT END: <name> anchor
+    module.add_stmt(v::Stmt::new_rawstr(format!(
+        "// COMPONENT END: {}",
+        comp.name
+    )));
+
     module
 }
 

--- a/tests/backend/verilog/big-const.expect
+++ b/tests/backend/verilog/big-const.expect
@@ -454,6 +454,7 @@ module main (
     input logic reset,
     output logic done
 );
+    // COMPONENT START: main
     logic [35:0] c_out;
     
     std_const # (
@@ -464,4 +465,5 @@ module main (
     );
     assign done = 1'd1;
     
+    // COMPONENT END: main
 endmodule

--- a/tests/backend/verilog/memory-with-external-attribute.expect
+++ b/tests/backend/verilog/memory-with-external-attribute.expect
@@ -454,6 +454,7 @@ module main (
     input logic reset,
     output logic done
 );
+    // COMPONENT START: main
     string DATA;
     int CODE;
     initial begin
@@ -514,4 +515,5 @@ module main (
     assign m0_clk = clk;
     assign m1_clk = clk;
     
+    // COMPONENT END: main
 endmodule


### PR DESCRIPTION
Add `COMPONENT START/END: <name>` markers within generated verilog modules. This is giant hack but sometimes we need a way to splice some verilog code into a module for simulation purposes.

Specifically, COCOTB waveform generation requires the main module to have some extra code.