### PR TITLE
Make TVM-to-Calyx files share components

### DIFF
--- a/calyx/src/analysis/domination_analysis/dominator_map.rs
+++ b/calyx/src/analysis/domination_analysis/dominator_map.rs
@@ -157,7 +157,7 @@ fn matches_key(c: &ir::Control, key: u64) -> bool {
     }
 }
 // Gets the "final" nodes in control c. Used to build exits_map.
-fn get_final(c: &ir::Control, prnt: bool) -> HashSet<u64> {
+fn get_final(c: &ir::Control) -> HashSet<u64> {
     let mut hs = HashSet::new();
     match c {
         ir::Control::Empty(_) => (),
@@ -170,16 +170,13 @@ fn get_final(c: &ir::Control, prnt: bool) -> HashSet<u64> {
             hs.insert(ControlId::get_guaranteed_attribute(c, END_ID));
         }
         ir::Control::Seq(ir::Seq { stmts, .. }) => {
-            return get_final(
-                (&stmts[..]).last().unwrap_or_else(|| {
-                    panic!("error: empty Seq block. Run collapse-control pass.")
-                }),
-                prnt,
-            );
+            return get_final((&stmts[..]).last().unwrap_or_else(|| {
+                panic!("error: empty Seq block. Run collapse-control pass.")
+            }));
         }
         ir::Control::Par(ir::Par { stmts, .. }) => {
             for stmt in stmts {
-                let stmt_final = get_final(stmt, false);
+                let stmt_final = get_final(stmt);
                 hs = hs.union(&stmt_final).copied().collect()
             }
         }
@@ -231,8 +228,7 @@ impl DominatorMap {
                     self.build_exit_map(stmt);
                 }
                 let id = ControlId::get_guaranteed_attribute(c, NODE_ID);
-                let prnt = id == 25;
-                self.exits_map.insert(id, get_final(c, prnt));
+                self.exits_map.insert(id, get_final(c));
             }
         }
     }

--- a/calyx/src/analysis/domination_analysis/node_analysis.rs
+++ b/calyx/src/analysis/domination_analysis/node_analysis.rs
@@ -58,7 +58,8 @@ fn add_assignment_reads(
             .iter()
             .filter(|assign| !reads_only_dones(assign)),
     ) {
-        if share.is_shareable_component(&cell) {
+        if share.is_shareable_component(&cell) && !cell.borrow().is_reference()
+        {
             reads.insert(cell.borrow().clone_name());
         }
     }

--- a/calyx/src/passes/infer_share.rs
+++ b/calyx/src/passes/infer_share.rs
@@ -82,7 +82,7 @@ impl Visitor for InferShare {
         // cannot contain any ref cells, or any cells of a "non-shareable" type
         // (i.e. not shareable, state_shareable, const or This component)
         if comp.cells.iter().any(|cell| {
-            cell.borrow().is_reference() || !type_is_shareable(cell)
+            !type_is_shareable(cell) && !cell.borrow().is_reference()
         }) {
             return Ok(Action::Stop);
         }
@@ -92,6 +92,8 @@ impl Visitor for InferShare {
             &mut comp.control.borrow_mut(),
             comp.name.id.clone(),
         );
+
+        // print the domination map if command line argument says so
         if self.print_dmap {
             println!("{dmap:?}");
         }

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -44,6 +44,7 @@
 # Tools
 
 - [Runt](./tools/runt.md)
+- [Data Gen](./tools/data-gen.md)
 - [`exp` Generator](./tools/exp-generator.md)
 - [Editor Highlighting](./tools/editor-highlighting.md)
 

--- a/frontends/relay/relay_utils.py
+++ b/frontends/relay/relay_utils.py
@@ -73,7 +73,7 @@ def get_addr_ports(c: CompInst):
     return [(f"addr{i}", c.args[n]) for (i, n) in zip(addresses, indices)]
 
 
-def emit_invoke_control(decl: CompVar, dest: Cell, args: List[Cell]) -> Invoke:
+def emit_invoke_control(decl: CompVar, dest: Cell, args: List[Cell], old_args=[], old_dest=None) -> Invoke:
     """Returns the Invoke control."""
     ref_cells = []
     inputs = []
@@ -90,9 +90,35 @@ def emit_invoke_control(decl: CompVar, dest: Cell, args: List[Cell]) -> Invoke:
         else:
             ref_cells.append((param, arg))
 
-    for cell in args:
-        add_arg(cell)
-    add_arg(dest)
+    # this function is similar to add_arg, but is for the case when we are
+    # "reusing" a Dahlia Function (which will later be a Calyx component)
+    # and therefore need to use the same parameter names as the previous invoke
+    def add_arg2(arg_cell, param_cell):
+        assert arg_cell.comp == param_cell.comp, "arg cell and param cell must be same component"
+        comp = arg_cell.comp
+        assert comp.id in DahliaSuffix, f"{comp.id} supported yet."
+        param = f"{param_cell.id.name}{DahliaSuffix[comp.id]}"
+        arg = CompVar(arg_cell.id.name)
+
+        # If this is a constant or a register, connect the ports
+        if any(p in comp.id for p in ["reg", "const"]):
+            inputs.append((f"{param}", CompPort(arg, "out")))
+        else:
+            ref_cells.append((param, arg))
+
+    if len(old_args) == 0:
+        for cell in args:
+            add_arg(cell)
+        add_arg(dest)
+    else:
+        # case for when we are "reusing" a Dahlia Function/Calyx component and
+        # therefore need to make sure we're using the previous parameter names
+        assert len(old_args) == len(
+            args), "we are reusing a dahlia function but the args are different lengths"
+        assert old_dest is not None, "if using old_args must provide an old_dest too"
+        for (cell1, cell2) in zip(args, old_args):
+            add_arg2(cell1, cell2)
+        add_arg2(dest, old_dest)
 
     return Invoke(decl, inputs, [], ref_cells)
 

--- a/tests/frontend/relay/duplicate-relay-call.expect
+++ b/tests/frontend/relay/duplicate-relay-call.expect
@@ -1,10 +1,10 @@
 import "primitives/core.futil";
 import "primitives/binary_operators.futil";
 import "primitives/math.futil";
-component negative_2x2_1() -> () {
+component negative_2x2() -> () {
   cells {
+    ref x0_0 = std_mem_d2(32,2,2,2,2);
     ref x10_0 = std_mem_d2(32,2,2,2,2);
-    ref x20_0 = std_mem_d2(32,2,2,2,2);
     __i0 = std_reg(2);
     __j0 = std_reg(2);
     add0 = std_add(2);
@@ -19,7 +19,7 @@ component negative_2x2_1() -> () {
     le0 = std_le(2);
     le1 = std_le(2);
     sub0 = std_ssub(32);
-    x1_read0_0 = std_reg(32);
+    x_read0_0 = std_reg(32);
   }
   wires {
     comb group cond0 {
@@ -41,20 +41,20 @@ component negative_2x2_1() -> () {
       let1[done] = __j0.done;
     }
     group upd0<"static"=1> {
-      x1_read0_0.write_en = 1'd1;
-      x10_0.addr1 = __j0.out;
-      x10_0.addr0 = __i0.out;
-      x1_read0_0.in = x10_0.read_data;
-      upd0[done] = x1_read0_0.done;
+      x_read0_0.write_en = 1'd1;
+      x0_0.addr1 = __j0.out;
+      x0_0.addr0 = __i0.out;
+      x_read0_0.in = x0_0.read_data;
+      upd0[done] = x_read0_0.done;
     }
     group upd1<"static"=1> {
-      x20_0.addr1 = __j0.out;
-      x20_0.addr0 = __i0.out;
-      x20_0.write_en = 1'd1;
+      x10_0.addr1 = __j0.out;
+      x10_0.addr0 = __i0.out;
+      x10_0.write_en = 1'd1;
       sub0.left = const4.out;
-      sub0.right = x1_read0_0.out;
-      x20_0.write_data = sub0.out;
-      upd1[done] = x20_0.done;
+      sub0.right = x_read0_0.out;
+      x10_0.write_data = sub0.out;
+      upd1[done] = x10_0.done;
     }
     group upd2<"static"=1> {
       __j0.write_en = 1'd1;
@@ -90,95 +90,6 @@ component negative_2x2_1() -> () {
     }
   }
 }
-component negative_2x2() -> () {
-  cells {
-    ref x0_0 = std_mem_d2(32,2,2,2,2);
-    ref x10_0 = std_mem_d2(32,2,2,2,2);
-    __i1 = std_reg(2);
-    __j1 = std_reg(2);
-    add2 = std_add(2);
-    add3 = std_add(2);
-    const10 = std_const(2,1);
-    const11 = std_const(32,0);
-    const12 = std_const(2,1);
-    const13 = std_const(2,1);
-    const7 = std_const(2,0);
-    const8 = std_const(2,1);
-    const9 = std_const(2,0);
-    le2 = std_le(2);
-    le3 = std_le(2);
-    sub1 = std_ssub(32);
-    x_read0_0 = std_reg(32);
-  }
-  wires {
-    comb group cond2 {
-      le2.left = __i1.out;
-      le2.right = const8.out;
-    }
-    comb group cond3 {
-      le3.left = __j1.out;
-      le3.right = const10.out;
-    }
-    group let2<"static"=1> {
-      __i1.in = const7.out;
-      __i1.write_en = 1'd1;
-      let2[done] = __i1.done;
-    }
-    group let3<"static"=1> {
-      __j1.in = const9.out;
-      __j1.write_en = 1'd1;
-      let3[done] = __j1.done;
-    }
-    group upd4<"static"=1> {
-      x_read0_0.write_en = 1'd1;
-      x0_0.addr1 = __j1.out;
-      x0_0.addr0 = __i1.out;
-      x_read0_0.in = x0_0.read_data;
-      upd4[done] = x_read0_0.done;
-    }
-    group upd5<"static"=1> {
-      x10_0.addr1 = __j1.out;
-      x10_0.addr0 = __i1.out;
-      x10_0.write_en = 1'd1;
-      sub1.left = const11.out;
-      sub1.right = x_read0_0.out;
-      x10_0.write_data = sub1.out;
-      upd5[done] = x10_0.done;
-    }
-    group upd6<"static"=1> {
-      __j1.write_en = 1'd1;
-      add2.left = __j1.out;
-      add2.right = const12.out;
-      __j1.in = add2.out;
-      upd6[done] = __j1.done;
-    }
-    group upd7<"static"=1> {
-      __i1.write_en = 1'd1;
-      add3.left = __i1.out;
-      add3.right = const13.out;
-      __i1.in = add3.out;
-      upd7[done] = __i1.done;
-    }
-  }
-  control {
-    seq {
-      @pos(4) let2;
-      @bound(2) while le2.out with cond2 {
-        seq {
-          @pos(5) let3;
-          @bound(2) while le3.out with cond3 {
-            seq {
-              @pos(6) upd4;
-              @pos(7) upd5;
-              @pos(5) upd6;
-            }
-          }
-          @pos(4) upd7;
-        }
-      }
-    }
-  }
-}
 
 component main() -> () {
   cells {
@@ -186,7 +97,6 @@ component main() -> () {
     @external(1) x1 = std_mem_d2(32, 2, 2, 2, 2);
     negative_2x2_ = negative_2x2();
     @external(1) x2 = std_mem_d2(32, 2, 2, 2, 2);
-    negative_2x2_1_ = negative_2x2_1();
   }
   wires {
 
@@ -194,7 +104,7 @@ component main() -> () {
   control {
     seq {
       @pos(0) invoke negative_2x2_[x0_0=x, x10_0=x1]()();
-      @pos(1) invoke negative_2x2_1_[x10_0=x1, x20_0=x2]()();
+      @pos(1) invoke negative_2x2_[x0_0=x1, x10_0=x2]()();
     }
   }
 }

--- a/tests/passes/domination-map/nested-seq.expect
+++ b/tests/passes/domination-map/nested-seq.expect
@@ -1,0 +1,46 @@
+The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
+that are attached to each non-empty control statement when the domination map is built. 
+To see which ID's refer to which control statement, look at the Calyx Program, which should 
+be printed along with the map when it is printed.
+Domination Map for component "example"  {
+Node: 2 -- Dominators: [2]
+Node: 3 -- Dominators: [2, 3]
+Node: 4 -- Dominators: [2, 3, 4]
+}
+import "primitives/core.futil";
+component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    lt = std_lt(4);
+  }
+  wires {
+    group A {
+    }
+    group B {
+    }
+    group C {
+    }
+    group D {
+    }
+  }
+
+  control {
+    @NODE_ID(0) seq {
+      @NODE_ID seq {
+        @NODE_ID(2) A;
+        @NODE_ID(3) B;
+      }
+      @NODE_ID(4) C;
+    }
+  }
+}
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    e = example();
+  }
+  wires {
+  }
+
+  control {
+    invoke e()();
+  }
+}

--- a/tests/passes/domination-map/nested-seq.futil
+++ b/tests/passes/domination-map/nested-seq.futil
@@ -1,0 +1,39 @@
+// -p infer-share -x infer-share:print-dmap
+import "primitives/core.futil";
+component example() -> () {
+  cells {
+    lt = std_lt(4); 
+  }
+  wires {
+    group A{
+    }
+    group B{
+    }
+    group C{
+    }
+    group D{
+    }
+  }
+  control {
+    seq{
+      seq{
+        A;
+        B;
+      }
+      C;
+    }
+  }
+}
+
+
+component main() -> () {
+  cells {
+    e = example();
+  }
+  wires {
+  }
+  control {
+    invoke e() (); 
+  }
+  
+}

--- a/tests/passes/infer-share-pass/uses_ref.expect
+++ b/tests/passes/infer-share-pass/uses_ref.expect
@@ -1,0 +1,37 @@
+import "primitives/core.futil";
+component uses_ref<"state_share"=1>(i: 3, j: 3, @go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 32, @done done: 1) {
+  cells {
+    ref mem = std_mem_d2(32, 5, 5, 3, 3);
+    r = std_reg(32);
+  }
+  wires {
+    group read_mem {
+      r.in = mem.read_data;
+      r.write_en = 1'd1;
+      read_mem[done] = r.done;
+    }
+    group write_mem {
+      mem.addr0 = j;
+      mem.addr1 = i;
+      mem.write_data = 32'd9;
+      mem.write_en = 1'd1;
+      write_mem[done] = mem.done;
+    }
+    out = r.out;
+  }
+
+  control {
+    seq {
+      read_mem;
+      write_mem;
+    }
+  }
+}
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+  }
+  wires {
+  }
+
+  control {}
+}

--- a/tests/passes/infer-share-pass/uses_ref.futil
+++ b/tests/passes/infer-share-pass/uses_ref.futil
@@ -1,0 +1,39 @@
+//-p infer-share -p remove-ids
+import "primitives/core.futil";
+
+component uses_ref(i: 3, j:3) -> (out: 32) {
+  cells {
+    ref mem = std_mem_d2(32, 5,5, 3,3);
+    r = std_reg(32);
+  }
+  wires {
+    group read_mem {
+      r.in = mem.read_data; 
+      r.write_en = 1'd1; 
+      read_mem[done] = r.done; 
+    }
+    group write_mem{
+      mem.addr0 = j;
+      mem.addr1 = i; 
+      mem.write_data = 32'd9;
+      mem.write_en = 1'd1; 
+      write_mem[done] = mem.done; 
+    }
+    out = r.out; 
+  }
+  control {
+    seq{
+      read_mem;
+      write_mem;
+    }
+  }
+}
+
+component main() -> () {
+  cells {
+  }
+  wires {
+  }
+  control {
+  }
+}


### PR DESCRIPTION
Currently, TVM generated Calyx files do not share any components. 

We think this is for two reasons: 

1. Previously Calyx components with ref cells in them could not be shared. However, talking in the Calyx meeting, it seems like almost the exact opposite is true: ref cells, it seems, are never an impediment to sharing. (I've been thinking a bit about it by myself, and I think this is correct. If you think about it, ref-cells have the exact same behavior as passing a bunch of signals to the input/output ports of the component which we know will never be an impediment to sharing. This is because all of the "state" of ref cells are located outside the component they're used in. For example, if we have 2 instances of a component `c1` and `c2` that use ref cells and have a std_mem `mem` that we want to pass as a ref cell, and we invoke `c1[mem]()()` and then later on in the control we are trying to decide whether to invoke `c2[mem]()()` or invoke `c1[mem]()()`. Regardless of whether the second invoke is of `c1` or `c2`, we are still going to have knowledge of the effect that first invoke of `c1` had on the  "internal state" of `mem` when we are doing the second invoke). 
2. Currently, for every operation (even for the exact same operation and exact same memory dimensions), Calyx generates a new component. I think this has to do with the fact that Dahlia generates a new function definition, even for the same operation on a memory with the exact same dimensions. 

I've just added 1). I can work on adding 2) to the current PR as well. 