### PR TITLE
Add newline b/w imported verilog files

### DIFF
--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -97,16 +97,19 @@ impl Backend for VerilogBackend {
         ctx: &ir::Context,
         file: &mut OutputFile,
     ) -> CalyxResult<()> {
+        let fw = &mut file.get_write();
         for extern_path in ctx.lib.extern_paths() {
             // The extern file is guaranteed to exist by the frontend.
             let mut ext = File::open(extern_path).unwrap();
-            io::copy(&mut ext, &mut file.get_write()).map_err(|err| {
+            io::copy(&mut ext, fw).map_err(|err| {
                 let std::io::Error { .. } = err;
                 Error::write_error(format!(
                     "File not found: {}",
                     file.as_path_string()
                 ))
             })?;
+            // Add a newline after appending a library file
+            writeln!(fw)?;
         }
         Ok(())
     }

--- a/tests/backend/verilog/big-const.expect
+++ b/tests/backend/verilog/big-const.expect
@@ -448,6 +448,7 @@ module std_mem_d4 #(
 endmodule
 
 `default_nettype wire
+
 module main (
     input logic go,
     input logic clk,

--- a/tests/backend/verilog/memory-with-external-attribute.expect
+++ b/tests/backend/verilog/memory-with-external-attribute.expect
@@ -448,6 +448,7 @@ module std_mem_d4 #(
 endmodule
 
 `default_nettype wire
+
 module main (
     input logic go,
     input logic clk,


### PR DESCRIPTION
If verilog files did not end with a newline, the generated file would clobber together the first and last lines of two files.
