### PR TITLE
[FUD] Interpreter-data utility

### DIFF
--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -140,6 +140,7 @@ def register_stages(registry):
     # Interpreter
     registry.register(interpreter.InterpreterStage("", "", "Run the interpreter"))
     registry.register(interpreter.InterpreterStage.debugger("", "", "Run the debugger"))
+    registry.register(interpreter.InterpreterStage.data_converter())
 
 
 def register_external_stages(cfg, registry):

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -33,7 +33,10 @@ class InterpreterStage(Stage):
         self = cls(
             flags="",
             debugger_flags="",
-            desc="convert data files for the interpreter use. Meant for internal interp dev use.",
+            desc=(
+                "convert data files for the interpreter use. ",
+                "Meant for internal interp dev use.",
+            ),
             output_type=SourceType.Path,
             output_name="interpreter-data",
         )


### PR DESCRIPTION
A small PR from last week which adds an `interpreter-data` target to fud which just outputs the converted datafile for the interpreter. This is pretty much just for me, but in the future it might be worth thinking about if there are smoother ways to make it possible to keep intermediate files.