### PR TITLE
Small Changes to bounded sharing

### DIFF
--- a/calyx/src/analysis/graph_coloring.rs
+++ b/calyx/src/analysis/graph_coloring.rs
@@ -46,12 +46,12 @@ where
 
     /// Given an `ordering` of `T`s, find a mapping from nodes to `T`s such
     /// that no node has a neighbor with the same `T`.
-    pub fn color_greedy(&self, bound: Option<&u64>) -> HashMap<T, T> {
-        let mut all_colors: BTreeMap<Idx, u64> = BTreeMap::new();
+    pub fn color_greedy(&self, bound: Option<i64>) -> HashMap<T, T> {
+        let mut all_colors: BTreeMap<Idx, i64> = BTreeMap::new();
         let mut coloring: HashMap<Idx, Idx> = HashMap::new();
         let always_share = bound.is_none();
         // if we always_share is true, then we don't care about bound
-        let bound_if_exists = if always_share { 0 } else { *bound.unwrap() };
+        let bound_if_exists = if always_share { 0 } else { bound.unwrap() };
 
         // get strongly get components of graph
         let sccs = algo::tarjan_scc(&self.graph.graph);

--- a/tests/passes/cell-share/bounded.expect
+++ b/tests/passes/cell-share/bounded.expect
@@ -3,23 +3,11 @@ import "primitives/binary_operators.futil";
 component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     a = std_reg(32);
-    b = std_reg(32);
-    c = std_reg(32);
     d = std_reg(32);
-    e = std_reg(32);
-    f = std_reg(32);
     add1 = std_add(32);
-    add2 = std_add(32);
     add3 = std_add(32);
-    add4 = std_add(32);
     add5 = std_add(32);
-    add6 = std_add(32);
     mult0 = std_mult_pipe(32);
-    mult1 = std_mult_pipe(32);
-    mult2 = std_mult_pipe(32);
-    mult3 = std_mult_pipe(32);
-    mult4 = std_mult_pipe(32);
-    mult5 = std_mult_pipe(32);
   }
   wires {
     group let0 {
@@ -89,16 +77,16 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       m3[done] = mult0.done;
     }
     group m4 {
-      mult4.go = 1'd1;
-      mult4.left = 32'd1;
-      mult4.right = 32'd2;
-      m4[done] = mult4.done;
+      mult0.go = 1'd1;
+      mult0.left = 32'd1;
+      mult0.right = 32'd2;
+      m4[done] = mult0.done;
     }
     group m5 {
-      mult4.go = 1'd1;
-      mult4.left = 32'd1;
-      mult4.right = 32'd2;
-      m5[done] = mult4.done;
+      mult0.go = 1'd1;
+      mult0.left = 32'd1;
+      mult0.right = 32'd2;
+      m5[done] = mult0.done;
     }
   }
 

--- a/tests/passes/cell-share/bounded.futil
+++ b/tests/passes/cell-share/bounded.futil
@@ -1,4 +1,4 @@
-// -p cell-share -x cell-share:bounds=2,3,4 -p remove-ids
+// -p cell-share -x cell-share:bounds=2,3,-1 -p dead-cell-removal -p remove-ids
 // share adders twice, registers 3 times, and mults 4 times 
 import "primitives/core.futil";
 import "primitives/binary_operators.futil";


### PR DESCRIPTION
Gives more flexibility to the bound settings. 

(For example now we can not share combinational cells, share registers 5 times, and always share other components). 