### PR TITLE
Fix Dockerfile not working with runt cocotb tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/ap
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list && \
     curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add && \
     apt-get update -y && \
-    apt-get install -y jq python3.9 python3-pip sbt make autoconf g++ flex bison libfl2 libfl-dev default-jdk ninja-build build-essential cmake gperf
+    apt-get install -y jq python3.9 python3-pip sbt make autoconf g++ flex bison libfl2 libfl-dev default-jdk ninja-build build-essential cmake autoconf gperf
 
 # Install python dependencies
 RUN python3 -m pip install numpy flit prettytable wheel hypothesis pytest simplejson cocotb==1.6.2
@@ -25,9 +25,6 @@ RUN autoconf && ./configure && make && make install
 
 # Install Icarus verilog
 WORKDIR /home
-RUN apt-get update && apt-get install -y \
-  autoconf \
-  gperf
 RUN git clone --depth 1 --branch v11_0 https://github.com/steveicarus/iverilog
 WORKDIR /home/iverilog
 RUN sh autoconf.sh && ./configure && make && make install
@@ -56,7 +53,7 @@ RUN sbt "; getHeaders; assembly"
 
 # Clone the Calyx repository
 WORKDIR /home
-RUN git clone --branch axi-test-harness https://github.com/cucapra/calyx.git calyx
+RUN git clone https://github.com/cucapra/calyx.git calyx
 
 # Install rust tools
 WORKDIR /home

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/ap
     apt-get install -y jq python3.9 python3-pip sbt make autoconf g++ flex bison libfl2 libfl-dev default-jdk ninja-build build-essential cmake gperf
 
 # Install python dependencies
-RUN python3 -m pip install numpy flit prettytable wheel hypothesis pytest simplejson cocotb
+RUN python3 -m pip install numpy flit prettytable wheel hypothesis pytest simplejson cocotb==1.6.2
+# Current cocotb-bus has a bug that is fixed in more up to date repo
+RUN python3 -m pip install git+https://github.com/cocotb/cocotb-bus.git cocotbext-axi
 
 # Install Verilator
 WORKDIR /home
@@ -23,6 +25,9 @@ RUN autoconf && ./configure && make && make install
 
 # Install Icarus verilog
 WORKDIR /home
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  gperf
 RUN git clone --depth 1 --branch v11_0 https://github.com/steveicarus/iverilog
 WORKDIR /home/iverilog
 RUN sh autoconf.sh && ./configure && make && make install
@@ -51,7 +56,7 @@ RUN sbt "; getHeaders; assembly"
 
 # Clone the Calyx repository
 WORKDIR /home
-RUN git clone https://github.com/cucapra/calyx.git calyx
+RUN git clone --branch axi-test-harness https://github.com/cucapra/calyx.git calyx
 
 # Install rust tools
 WORKDIR /home
@@ -82,3 +87,6 @@ WORKDIR /home/calyx/calyx-py
 RUN FLIT_ROOT_INSTALL=1 flit install --symlink
 
 WORKDIR /home/calyx
+
+# Used to make runt cocotb tests happy
+ENV LANG=C.UTF-8


### PR DESCRIPTION
Set cocotb-bus to be installed directly from its [repo](https://github.com/cocotb/cocotb-bus) to fix a bug they have in published version.

Can confirm that this docker image built from this works out of the box on my machine for the cocotb runt tests. Unfortunately running _all_ of the runt tests was too much for my measly 8 GB of ram and froze my os (twice).

Only thing that might affect other tests should be the change of LANG env variable which is set to `utf-8` to make cocotb happy.

This should (finally! 🤞) allow #1153 to be merged