### PR TITLE
Vivado Maps seq-mems to Urams

### DIFF
--- a/fud/fud/stages/vivado/extract.py
+++ b/fud/fud/stages/vivado/extract.py
@@ -61,7 +61,7 @@ def futil_extract(directory):
                 break
 
     # The resource information is extracted first for the implementation files, and
-    # then for the synthesis files. This is dones separately in case users want to
+    # then for the synthesis files. This is done separately in case users want to
     # solely use one or the other.
     resource_info = {}
 
@@ -146,9 +146,11 @@ def futil_extract(directory):
             cell_lut5 = find_row(cell_usage_tbl, "Cell", "LUT5", False)
             cell_lut6 = find_row(cell_usage_tbl, "Cell", "LUT6", False)
             cell_fdre = find_row(cell_usage_tbl, "Cell", "FDRE", False)
+            uram_usage = find_row(cell_usage_tbl, "Cell", "URAM288", False)
 
             resource_info.update(
                 {
+                    "uram": to_int(safe_get(uram_usage, "Count")),
                     "cell_lut1": to_int(safe_get(cell_lut1, "Count")),
                     "cell_lut2": to_int(safe_get(cell_lut2, "Count")),
                     "cell_lut3": to_int(safe_get(cell_lut3, "Count")),

--- a/fud/synth/synth.tcl
+++ b/fud/synth/synth.tcl
@@ -16,7 +16,8 @@ set outdir ./out
 # set partname xc7z020clg484-1
 # You can also use part name "xcu250-figd2104-2-e", which we get on havarti. 
 # This is a bigger device (larger memory, etc.) and also supports URAM memory, which 
-# "xczu3eg-sbva484-1-e" does not support. 
+# "xczu3eg-sbva484-1-e" does not support. For more information on 
+# this part type look here: https://docs.xilinx.com/r/en-US/ds962-u200-u250/Summary
 set partname "xczu3eg-sbva484-1-e"
 
 # Create the project (forcibly overwriting) and add sources SystemVerilog

--- a/fud/synth/synth.tcl
+++ b/fud/synth/synth.tcl
@@ -13,7 +13,10 @@
 # Settings: the output directory and the part number (which is a Zynq
 # XC7Z020, found on our ZedBoard).
 set outdir ./out
-#set partname xc7z020clg484-1
+# set partname xc7z020clg484-1
+# You can also use part name "xcu250-figd2104-2-e", which we get on havarti. 
+# This is a bigger device (larger memory, etc.) and also supports URAM memory, which 
+# "xczu3eg-sbva484-1-e" does not support. 
 set partname "xczu3eg-sbva484-1-e"
 
 # Create the project (forcibly overwriting) and add sources SystemVerilog

--- a/primitives/memories.sv
+++ b/primitives/memories.sv
@@ -26,7 +26,7 @@ module seq_mem_d1 #(
    output logic write_done
 );
   // Internal memory
-  logic [WIDTH-1:0] mem[SIZE-1:0];
+  (* ram_style = "ultra" *)  logic [WIDTH-1:0] mem[SIZE-1:0];
 
   // Register for the read output
   logic [WIDTH-1:0] read_out;


### PR DESCRIPTION
I kept the synth.tcl file the same, but left a comment in case anyone else wanted a bigger board while using havarti. Very few changes overall though. 