### PR TITLE
Fix std_fp_mult_pipe Primitive

### DIFF
--- a/primitives/binary_operators.sv
+++ b/primitives/binary_operators.sv
@@ -42,9 +42,9 @@ module std_fp_mult_pipe #(
   logic [WIDTH-1:0]          ltmp;
   logic [(WIDTH << 1) - 1:0] out_tmp;
   // Buffer used to walk through the 3 cycles of the pipeline.
-  logic done_buf[2:0];
+  logic done_buf[1:0];
 
-  assign done = done_buf[2];
+  assign done = done_buf[1];
 
   assign out = out_tmp[(WIDTH << 1) - INT_WIDTH - 1 : WIDTH - INT_WIDTH];
 
@@ -64,10 +64,8 @@ module std_fp_mult_pipe #(
   // Push the done signal through the pipeline.
   always_ff @(posedge clk) begin
     if (go) begin
-      done_buf[2] <= done_buf[1];
       done_buf[1] <= done_buf[0];
     end else begin
-      done_buf[2] <= 0;
       done_buf[1] <= 0;
     end
   end


### PR DESCRIPTION
The current std_fp_mult_pipe primitive is marked as `@static(3)` in futil and generates correct outputs after 3 cycles, but the done signal is asserted after 4 cycles. This breaks designs that actually use the multiplier in a pipelined way and change inputs every cycle. I fixed this so the done signal is asserted after 3 cycles as expected.