### PR TITLE
Disable unused static timing tests

### DIFF
--- a/runt.toml
+++ b/runt.toml
@@ -153,18 +153,18 @@ fud exec --to jq \
       {} -q
 """
 
-[[tests]]
-name = "correctness static timing"
-paths = [ "tests/correctness/*.futil", "tests/correctness/ref-cells/*.futil", "tests/correctness/sync/*.futil" ]
-cmd = """
-fud exec --to jq \
-         --through dat \
-         -s futil.exec './target/debug/futil' \
-         -s verilog.cycle_limit 500 \
-         -s verilog.data {}.data \
-         -s jq.expr ".memories" \
-         {} -q
-"""
+# [[tests]]
+# name = "correctness static timing"
+# paths = [ "tests/correctness/*.futil", "tests/correctness/ref-cells/*.futil", "tests/correctness/sync/*.futil" ]
+# cmd = """
+# fud exec --to jq \
+#          --through dat \
+#          -s futil.exec './target/debug/futil' \
+#          -s verilog.cycle_limit 500 \
+#          -s verilog.data {}.data \
+#          -s jq.expr ".memories" \
+#          {} -q
+# """
 
 [[tests]]
 name = "[frontend] systolic array correctness"


### PR DESCRIPTION
The static timing tests don't currently do anything meaningful because `top-down-st` is disabled by default anyways. We can re-enable them once `top-down-st` is fixed.
