### PR TITLE
Add ability to parse empty control with attributes

### DIFF
--- a/calyx/src/frontend/ast.rs
+++ b/calyx/src/frontend/ast.rs
@@ -74,7 +74,7 @@ impl ComponentDef {
             cells: Vec::new(),
             groups: Vec::new(),
             continuous_assignments: Vec::new(),
-            control: Control::Empty {},
+            control: Control::empty(),
             attributes: ir::Attributes::default(),
             is_comb,
         }
@@ -299,5 +299,16 @@ pub enum Control {
         ref_cells: Vec<(ir::Id, ir::Id)>,
     },
     /// Control statement that does nothing.
-    Empty {},
+    Empty {
+        /// Attributes
+        attributes: ir::Attributes,
+    },
+}
+
+impl Control {
+    pub fn empty() -> Control {
+        Control::Empty {
+            attributes: ir::Attributes::default(),
+        }
+    }
 }

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -625,6 +625,16 @@ impl CalyxParser {
         ))
     }
 
+    fn empty(input: Node) -> ParseResult<ast::Control> {
+        let span = Self::get_span(&input);
+        Ok(match_nodes!(
+            input.into_children();
+            [at_attributes(attrs)] => ast::Control::Empty {
+                attributes: attrs.add_span(span)
+            }
+        ))
+    }
+
     fn enable(input: Node) -> ParseResult<ast::Control> {
         let span = Self::get_span(&input);
         Ok(match_nodes!(
@@ -674,7 +684,7 @@ impl CalyxParser {
                 port,
                 cond,
                 tbranch: Box::new(stmt),
-                fbranch: Box::new(ast::Control::Empty{}),
+                fbranch: Box::new(ast::Control::Empty { attributes: ir::Attributes::default() }),
                 attributes: attrs.add_span(span),
             },
             [at_attributes(attrs), port_with((port, cond)), block(tbranch), block(fbranch)] =>
@@ -714,6 +724,7 @@ impl CalyxParser {
         Ok(match_nodes!(
             input.into_children();
             [enable(data)] => data,
+            [empty(data)] => data,
             [invoke(data)] => data,
             [seq(data)] => data,
             [par(data)] => data,
@@ -742,7 +753,7 @@ impl CalyxParser {
         Ok(match_nodes!(
             input.into_children();
             [block(stmt)] => stmt,
-            [] => ast::Control::Empty{}
+            [] => ast::Control::empty()
         ))
     }
 
@@ -776,7 +787,7 @@ impl CalyxParser {
                 cells,
                 groups,
                 continuous_assignments,
-                control: Control::Empty {},
+                control: Control::empty(),
                 attributes: attributes.add_span(span),
                 is_comb: true,
             })

--- a/calyx/src/frontend/syntax.pest
+++ b/calyx/src/frontend/syntax.pest
@@ -227,6 +227,8 @@ connections = {
 
 // ====== control ======
 
+empty = { at_attributes ~ ";" }
+
 enable = { at_attributes ~ identifier ~ ";" }
 
 invoke_arg = { identifier ~ "=" ~ (port | num_lit) }
@@ -269,7 +271,8 @@ while_stmt = {
 }
 
 stmt = {
-      enable
+      empty
+    | enable
     | invoke
     | seq
     | par

--- a/calyx/src/ir/attribute.rs
+++ b/calyx/src/ir/attribute.rs
@@ -48,10 +48,10 @@ impl WithPos for Attributes {
 /// Structs that can return an [`Attributes`] instance.
 pub trait GetAttributes {
     /// Returns an [`Attributes`] instance
-    fn get_attributes(&self) -> Option<&Attributes>;
+    fn get_attributes(&self) -> &Attributes;
 
     /// Returns a mutable [`Attributes`] instance
-    fn get_mut_attributes(&mut self) -> Option<&mut Attributes>;
+    fn get_mut_attributes(&mut self) -> &mut Attributes;
 }
 
 impl Attributes {
@@ -106,7 +106,7 @@ impl Attributes {
 
 impl<T: GetAttributes> WithPos for T {
     fn copy_span(&self) -> Option<Span> {
-        self.get_attributes().and_then(|attrs| attrs.copy_span())
+        self.get_attributes().copy_span()
     }
 }
 

--- a/calyx/src/ir/control.rs
+++ b/calyx/src/ir/control.rs
@@ -84,8 +84,10 @@ pub struct Invoke {
 }
 
 /// Data for the `empty` control statement.
-#[derive(Debug)]
-pub struct Empty {}
+#[derive(Debug, Default)]
+pub struct Empty {
+    pub attributes: Attributes,
+}
 
 /// Control AST nodes.
 #[derive(Debug)]
@@ -119,27 +121,27 @@ impl From<Enable> for Control {
 }
 
 impl GetAttributes for Control {
-    fn get_mut_attributes(&mut self) -> Option<&mut Attributes> {
+    fn get_mut_attributes(&mut self) -> &mut Attributes {
         match self {
             Self::Seq(Seq { attributes, .. })
             | Self::Par(Par { attributes, .. })
             | Self::If(If { attributes, .. })
             | Self::While(While { attributes, .. })
             | Self::Invoke(Invoke { attributes, .. })
-            | Self::Enable(Enable { attributes, .. }) => Some(attributes),
-            Self::Empty(..) => None,
+            | Self::Enable(Enable { attributes, .. })
+            | Self::Empty(Empty { attributes }) => attributes,
         }
     }
 
-    fn get_attributes(&self) -> Option<&Attributes> {
+    fn get_attributes(&self) -> &Attributes {
         match self {
             Self::Seq(Seq { attributes, .. })
             | Self::Par(Par { attributes, .. })
             | Self::If(If { attributes, .. })
             | Self::While(While { attributes, .. })
             | Self::Invoke(Invoke { attributes, .. })
-            | Self::Enable(Enable { attributes, .. }) => Some(attributes),
-            Self::Empty(..) => None,
+            | Self::Enable(Enable { attributes, .. })
+            | Self::Empty(Empty { attributes }) => attributes,
         }
     }
 }
@@ -148,7 +150,7 @@ impl Control {
     // ================ Constructor methods ================
     /// Convience constructor for empty.
     pub fn empty() -> Self {
-        Control::Empty(Empty {})
+        Control::Empty(Empty::default())
     }
 
     /// Convience constructor for seq.
@@ -222,7 +224,7 @@ impl Control {
     where
         S: std::fmt::Display + AsRef<str>,
     {
-        self.get_attributes().and_then(|attrs| attrs.get(attr))
+        self.get_attributes().get(attr)
     }
 
     /// Returns true if the node has a specific attribute
@@ -230,9 +232,7 @@ impl Control {
     where
         S: std::fmt::Display + AsRef<str>,
     {
-        self.get_attributes()
-            .map(|attrs| attrs.has(attr))
-            .unwrap_or(false)
+        self.get_attributes().has(attr)
     }
 }
 

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -478,7 +478,7 @@ fn build_control(
                     Error::undefined(component.clone(), "group".to_string())
                 })?,
             ));
-            *(en.get_mut_attributes().unwrap()) = attributes;
+            *en.get_mut_attributes() = attributes;
             en
         }
         ast::Control::Invoke {
@@ -552,7 +552,7 @@ fn build_control(
                     .map(|c| build_control(c, builder))
                     .collect::<CalyxResult<Vec<_>>>()?,
             );
-            *(s.get_mut_attributes().unwrap()) = attributes;
+            *s.get_mut_attributes() = attributes;
             s
         }
         ast::Control::Par { stmts, attributes } => {
@@ -562,7 +562,7 @@ fn build_control(
                     .map(|c| build_control(c, builder))
                     .collect::<CalyxResult<Vec<_>>>()?,
             );
-            *(p.get_mut_attributes().unwrap()) = attributes;
+            *p.get_mut_attributes() = attributes;
             p
         }
         ast::Control::If {
@@ -591,7 +591,7 @@ fn build_control(
                 Box::new(build_control(*tbranch, builder)?),
                 Box::new(build_control(*fbranch, builder)?),
             );
-            *(con.get_mut_attributes().unwrap()) = attributes;
+            *con.get_mut_attributes() = attributes;
             con
         }
         ast::Control::While {
@@ -618,9 +618,13 @@ fn build_control(
                 group,
                 Box::new(build_control(*body, builder)?),
             );
-            *(con.get_mut_attributes().unwrap()) = attributes;
+            *con.get_mut_attributes() = attributes;
             con
         }
-        ast::Control::Empty { .. } => Control::empty(),
+        ast::Control::Empty { attributes } => {
+            let mut emp = Control::empty();
+            *emp.get_mut_attributes() = attributes;
+            emp
+        }
     })
 }

--- a/calyx/src/ir/structure.rs
+++ b/calyx/src/ir/structure.rs
@@ -204,12 +204,12 @@ pub struct Cell {
 }
 
 impl GetAttributes for Cell {
-    fn get_attributes(&self) -> Option<&Attributes> {
-        Some(&self.attributes)
+    fn get_attributes(&self) -> &Attributes {
+        &self.attributes
     }
 
-    fn get_mut_attributes(&mut self) -> Option<&mut Attributes> {
-        Some(&mut self.attributes)
+    fn get_mut_attributes(&mut self) -> &mut Attributes {
+        &mut self.attributes
     }
 }
 

--- a/calyx/src/passes/compile_sync.rs
+++ b/calyx/src/passes/compile_sync.rs
@@ -50,7 +50,7 @@ fn count_barriers(s: &ir::Control, count: &mut HashSet<u64>) {
     match s {
         ir::Control::Seq(seq) => {
             for stmt in seq.stmts.iter() {
-                if let Some(&n) = stmt.get_attributes().unwrap().get("sync") {
+                if let Some(&n) = stmt.get_attributes().get("sync") {
                     count.insert(n);
                 }
                 count_barriers(stmt, count);
@@ -88,8 +88,7 @@ impl CompileSync {
                 let mut stmts_new: Vec<ir::Control> = Vec::new();
                 for mut stmt in std::mem::take(&mut seq.stmts) {
                     self.build_barriers(builder, &mut stmt, count);
-                    if let Some(n) = stmt.get_attributes().unwrap().get("sync")
-                    {
+                    if let Some(n) = stmt.get_attributes().get("sync") {
                         if self.barriers.get(n).is_none() {
                             self.add_shared_structure(builder, n);
                         }
@@ -290,7 +289,7 @@ fn build_member(
     let mut stmts: Vec<ir::Control> = Vec::new();
     let mut copy = ir::Control::clone(original);
 
-    copy.get_mut_attributes().unwrap().remove("sync");
+    copy.get_mut_attributes().remove("sync");
 
     let barrier = Rc::clone(&cells[0]);
     let eq = Rc::clone(&cells[1]);

--- a/calyx/src/passes/group_to_invoke.rs
+++ b/calyx/src/passes/group_to_invoke.rs
@@ -293,7 +293,7 @@ impl Visitor for GroupToInvoke {
             Some(invoke) => {
                 let mut inv = ir::Control::clone(invoke);
                 let attrs = std::mem::take(&mut s.attributes);
-                *inv.get_mut_attributes().unwrap() = attrs;
+                *inv.get_mut_attributes() = attrs;
                 Ok(Action::Change(Box::new(inv)))
             }
         }

--- a/calyx/src/passes/remove_comb_groups.rs
+++ b/calyx/src/passes/remove_comb_groups.rs
@@ -231,9 +231,8 @@ impl Visitor for RemoveCombGroups {
                 new_inputs,
                 s.outputs.drain(..).collect(),
             );
-            if let Some(attrs) = invoke.get_mut_attributes() {
-                *attrs = std::mem::take(&mut s.attributes);
-            }
+            let attrs = invoke.get_mut_attributes();
+            *attrs = std::mem::take(&mut s.attributes);
             // Seq to run the rewritten comb group first and then the invoke.
             let seq = ir::Control::seq(vec![
                 ir::Control::enable(Rc::clone(new_group.unwrap())),
@@ -267,9 +266,8 @@ impl Visitor for RemoveCombGroups {
         let new_body = ir::Control::seq(vec![body, cond_in_body]);
         let mut while_ =
             ir::Control::while_(Rc::clone(port_ref), None, Box::new(new_body));
-        if let Some(attrs) = while_.get_mut_attributes() {
-            *attrs = std::mem::take(&mut s.attributes);
-        }
+        let attrs = while_.get_mut_attributes();
+        *attrs = std::mem::take(&mut s.attributes);
         let cond_before_body = ir::Control::enable(Rc::clone(cond_ref));
         Ok(Action::change(ir::Control::seq(vec![
             cond_before_body,

--- a/calyx/src/passes/remove_ids.rs
+++ b/calyx/src/passes/remove_ids.rs
@@ -36,11 +36,10 @@ impl Visitor for RemoveIds {
 }
 
 fn remove_ids(c: &mut ir::Control) {
-    if let Some(atts) = c.get_mut_attributes() {
-        atts.remove(BEGIN_ID);
-        atts.remove(END_ID);
-        atts.remove(NODE_ID);
-    }
+    let atts = c.get_mut_attributes();
+    atts.remove(BEGIN_ID);
+    atts.remove(END_ID);
+    atts.remove(NODE_ID);
     match c {
         ir::Control::Empty(_)
         | ir::Control::Invoke(_)

--- a/calyx/src/passes/top_down_compile_control.rs
+++ b/calyx/src/passes/top_down_compile_control.rs
@@ -750,7 +750,7 @@ impl Visitor for TopDownCompileControl {
         // Add NODE_ID to compiled group.
         let mut en = ir::Control::enable(par_group);
         let node_id = s.attributes.get(NODE_ID).unwrap();
-        en.get_mut_attributes().unwrap().insert(NODE_ID, *node_id);
+        en.get_mut_attributes().insert(NODE_ID, *node_id);
 
         Ok(Action::change(en))
     }

--- a/src/backend/mlir.rs
+++ b/src/backend/mlir.rs
@@ -383,9 +383,8 @@ impl MlirBackend {
             }
             ir::Control::Empty(_) => writeln!(f),
         }?;
-        if let Some(attr) = control.get_attributes() {
-            write!(f, "{}", Self::format_attributes(attr))?;
-        }
+        let attr = control.get_attributes();
+        write!(f, "{}", Self::format_attributes(attr))?;
         writeln!(f)
     }
 

--- a/tests/parsing/empty.expect
+++ b/tests/parsing/empty.expect
@@ -1,0 +1,10 @@
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+  }
+  wires {
+  }
+
+  control {
+    @sync;
+  }
+}


### PR DESCRIPTION
Okay, this is an admittedly weird thing to do but: this PR adds the ability to parse *empty* control blocks when they have attributes.

## The Good
For example, this can be parsed now:

```
control {
  @sync; // <-- note the semicolon
}
```

The reason is that it gives us to experiment with "proto-keywords" like more easily. We currently have the philosophy of trying features out using attributes before we turn them into full blown keywords.

For example, the `@sync` keyword is an example. The current semantics is that for a program like this:
```
control {
  @sync A; B;
}
```
The synchronization happens before A executes. This means that sometimes we have to write programs like this:
```
control {
  if lt.out {
    @sync no_op;
  } else {
    @sync A; B;
  }
}
```
Where the `no_op` group doesn't do anything. With this change, we can write:
```
control {
  if lt.out {
    @sync;
  } else {
    @sync; A; B;
  }
}
```

This also has the pleasant outcome of making the meaning of `@sync` clearer---the synchronization occurs *before* the group executes. We also don't need to have special handling for `invoke`.

## The Bad

The bad thing is that this is an *empty* which means that it shouldn't really have any semantics and should be erasable? This would make it important for passes to keep empty control programs around when they have an attribute attached.

On the other hand, imagine the possibilities–a `@log` keyword for print out values? `@delay` to insert fake delays between `par` threads to test their delay insensitivity?
