### PR TITLE
Add pipelined muliplier PoC

### DIFF
--- a/mult-pipe/data.json
+++ b/mult-pipe/data.json
@@ -1,0 +1,59 @@
+{
+    "left": {
+        "data": [
+            77,
+            15,
+            3,
+            22,
+            81,
+            80,
+            43,
+            70,
+            47,
+            69
+        ],
+        "format": {
+            "numeric_type": "bitnum",
+            "is_signed": false,
+            "width": 32
+        }
+    },
+    "right": {
+        "data": [
+            75,
+            83,
+            33,
+            93,
+            30,
+            94,
+            43,
+            11,
+            60,
+            96
+        ],
+        "format": {
+            "numeric_type": "bitnum",
+            "is_signed": false,
+            "width": 32
+        }
+    },
+    "out": {
+        "data": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ],
+        "format": {
+            "numeric_type": "bitnum",
+            "is_signed": false,
+            "width": 32
+        }
+    }
+}

--- a/mult-pipe/ex.futil
+++ b/mult-pipe/ex.futil
@@ -1,0 +1,75 @@
+import "primitives/core.futil";
+
+extern "mult.sv" {
+    primitive mult_pipe(
+        @clk clk: 1,
+        @reset reset: 1,
+        // The input data is valid
+        @go valid: 1,
+        // inputs
+        left: 32,
+        right: 32
+    ) -> (
+        // The input has been committed
+        @done read_done: 1,
+        out: 32
+    );
+}
+
+component main() -> () {
+    cells {
+        mul = mult_pipe();
+        @external left = std_mem_d1(32, 10, 4);
+        @external right = std_mem_d1(32, 10, 4);
+        @external out = std_mem_d1(32, 10, 4);
+        idx = std_reg(4);
+        incr = std_add(4);
+        lt = std_lt(4);
+        cond = std_reg(1);
+    }
+    wires {
+        group init_cond<"static"=1> {
+            cond.in = 1'd1;
+            cond.write_en = 1'd1;
+            init_cond[done] = cond.done;
+        }
+        group incr_idx<"static"=1> {
+            incr.left = idx.out;
+            incr.right = 4'd1;
+            idx.in = incr.out;
+            idx.write_en = 1'd1;
+            // Computation for cond
+            lt.left = incr.out;
+            lt.right = 4'd10;
+            cond.in = lt.out;
+            cond.write_en = 1'd1;
+            incr_idx[done] = idx.done;
+        }
+        group start_mult<"static"=1> {
+            left.addr0 = idx.out;
+            right.addr0 = idx.out;
+            mul.left = left.read_data;
+            mul.right = right.read_data;
+            mul.valid = 1'd1;
+            start_mult[done] = mul.read_done;
+        }
+        group do_write<"static"=1> {
+            out.addr0 = idx.out;
+            out.write_data = mul.out;
+            out.write_en = 1'd1;
+            do_write[done] = out.done;
+        }
+    }
+    control {
+        seq {
+            init_cond;
+            @bound(10) while cond.out {
+                par {
+                    start_mult;
+                    incr_idx;
+                    do_write;
+                }
+            }
+        }
+    }
+}

--- a/mult-pipe/mult.sv
+++ b/mult-pipe/mult.sv
@@ -1,0 +1,37 @@
+module mult_pipe (
+    input wire clk,
+    input wire reset,
+    // The input data is valid
+    input wire valid,
+    // inputs
+    input wire [31:0] left,
+    input wire [31:0] right,
+    // The input has been committed
+    output reg read_done,
+    output wire [31:0] out
+);
+
+    reg [31:0] reg_out, tmp;
+
+    assign tmp = left * right;
+
+    always @(posedge clk) begin
+        if (reset) begin
+            reg_out <= 0;
+        end else begin
+            reg_out <= tmp;
+        end
+    end
+
+    always @(posedge clk) begin
+        if (reset)
+            read_done <= 0;
+        else if (valid)
+            read_done <= 1;
+        else
+            read_done <= 0;
+    end
+
+    assign out = reg_out;
+
+endmodule


### PR DESCRIPTION
Adding a multiplier with a truly pipelined interface. This interface currently only works for the latency-sensitive case but we can extend it to latency-insensitive too.

The key idea is that the multiplier immediately sets its `read_done` signal when an input is provided allowing the group to exit. The pipeline stages execute in parallel and starting the second iteration, get the correct values (the mult is 1-cycle latency).

To enable the group to execute every cycle, we need to hack around some stuff:
```
% fud e ex.futil --to dat -s verilog.data data.json -s verilog.cycle_limit 50 -s futil.flags '-p unroll-bound -p validate -p infer-static-timing -p top-down-st -p compile -p lower'
{
  "cycles": 10,
  "memories": {
    "left": [
      77,
      15,
      3,
      22,
      81,
      80,
      43,
      70,
      47,
      69
    ],
    "out": [
      0,
      5775,
      1245,
      99,
      2046,
      2430,
      7520,
      1849,
      770,
      2820
    ],
    "right": [
      75,
      83,
      33,
      93,
      30,
      94,
      43,
      11,
      60,
      96
    ]
  }
}
```

The `unroll-bound` eliminates the `while` loop completely allowing the broken `top-down-st` pass to do its thing. Lot to improve here but this is a good, minimal example that `top-down-st` should support without `unroll-bound` once fixed.
