### PR TITLE
Add `std_cat` concatenation primitive

### DIFF
--- a/primitives/core.futil
+++ b/primitives/core.futil
@@ -4,6 +4,7 @@ extern "core.sv" {
   comb primitive std_wire<"share"=1>[WIDTH](in: WIDTH) -> (out: WIDTH);
   comb primitive std_slice<"share"=1>[IN_WIDTH, OUT_WIDTH](in: IN_WIDTH) -> (out: OUT_WIDTH);
   comb primitive std_pad<"share"=1>[IN_WIDTH, OUT_WIDTH](in: IN_WIDTH) -> (out: OUT_WIDTH);
+  comb primitive std_cat<"share"=1>[LEFT_WIDTH, RIGHT_WIDTH, OUT_WIDTH](left: LEFT_WIDTH, right: RIGHT_WIDTH) -> (out: OUT_WIDTH);
 
   /// Logical operators
   comb primitive std_not<"share"=1>[WIDTH](in: WIDTH) -> (out: WIDTH);

--- a/primitives/core.sv
+++ b/primitives/core.sv
@@ -69,6 +69,30 @@ module std_pad #(
   `endif
 endmodule
 
+module std_cat #(
+  parameter LEFT_WIDTH  = 32,
+  parameter RIGHT_WIDTH = 32,
+  parameter OUT_WIDTH = 64
+) (
+  input wire logic [LEFT_WIDTH-1:0] left,
+  input wire logic [RIGHT_WIDTH-1:0] right,
+  output logic [OUT_WIDTH-1:0] out
+);
+  assign out = {left, right};
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (LEFT_WIDTH + RIGHT_WIDTH != OUT_WIDTH)
+        $error(
+          "std_cat: Output width must equal sum of input widths\n",
+          "LEFT_WIDTH: %0d", LEFT_WIDTH,
+          "RIGHT_WIDTH: %0d", RIGHT_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
 module std_not #(
     parameter WIDTH = 32
 ) (

--- a/tests/backend/verilog/big-const.expect
+++ b/tests/backend/verilog/big-const.expect
@@ -69,6 +69,30 @@ module std_pad #(
   `endif
 endmodule
 
+module std_cat #(
+  parameter LEFT_WIDTH  = 32,
+  parameter RIGHT_WIDTH = 32,
+  parameter OUT_WIDTH = 64
+) (
+  input wire logic [LEFT_WIDTH-1:0] left,
+  input wire logic [RIGHT_WIDTH-1:0] right,
+  output logic [OUT_WIDTH-1:0] out
+);
+  assign out = {left, right};
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (LEFT_WIDTH + RIGHT_WIDTH != OUT_WIDTH)
+        $error(
+          "std_cat: Output width must equal sum of input widths\n",
+          "LEFT_WIDTH: %0d", LEFT_WIDTH,
+          "RIGHT_WIDTH: %0d", RIGHT_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
 module std_not #(
     parameter WIDTH = 32
 ) (

--- a/tests/backend/verilog/data-instance.expect
+++ b/tests/backend/verilog/data-instance.expect
@@ -69,6 +69,30 @@ module std_pad #(
   `endif
 endmodule
 
+module std_cat #(
+  parameter LEFT_WIDTH  = 32,
+  parameter RIGHT_WIDTH = 32,
+  parameter OUT_WIDTH = 64
+) (
+  input wire logic [LEFT_WIDTH-1:0] left,
+  input wire logic [RIGHT_WIDTH-1:0] right,
+  output logic [OUT_WIDTH-1:0] out
+);
+  assign out = {left, right};
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (LEFT_WIDTH + RIGHT_WIDTH != OUT_WIDTH)
+        $error(
+          "std_cat: Output width must equal sum of input widths\n",
+          "LEFT_WIDTH: %0d", LEFT_WIDTH,
+          "RIGHT_WIDTH: %0d", RIGHT_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
 module std_not #(
     parameter WIDTH = 32
 ) (

--- a/tests/backend/verilog/memory-with-external-attribute.expect
+++ b/tests/backend/verilog/memory-with-external-attribute.expect
@@ -69,6 +69,30 @@ module std_pad #(
   `endif
 endmodule
 
+module std_cat #(
+  parameter LEFT_WIDTH  = 32,
+  parameter RIGHT_WIDTH = 32,
+  parameter OUT_WIDTH = 64
+) (
+  input wire logic [LEFT_WIDTH-1:0] left,
+  input wire logic [RIGHT_WIDTH-1:0] right,
+  output logic [OUT_WIDTH-1:0] out
+);
+  assign out = {left, right};
+
+  `ifdef VERILATOR
+    always_comb begin
+      if (LEFT_WIDTH + RIGHT_WIDTH != OUT_WIDTH)
+        $error(
+          "std_cat: Output width must equal sum of input widths\n",
+          "LEFT_WIDTH: %0d", LEFT_WIDTH,
+          "RIGHT_WIDTH: %0d", RIGHT_WIDTH,
+          "OUT_WIDTH: %0d", OUT_WIDTH
+        );
+    end
+  `endif
+endmodule
+
 module std_not #(
     parameter WIDTH = 32
 ) (

--- a/tests/import/a.expect
+++ b/tests/import/a.expect
@@ -9,6 +9,7 @@ extern "<ROOT>/calyx/primitives/core.sv" {
   comb primitive std_wire<"share"=1>[WIDTH](in: WIDTH) -> (out: WIDTH);
   comb primitive std_slice<"share"=1>[IN_WIDTH, OUT_WIDTH](in: IN_WIDTH) -> (out: OUT_WIDTH);
   comb primitive std_pad<"share"=1>[IN_WIDTH, OUT_WIDTH](in: IN_WIDTH) -> (out: OUT_WIDTH);
+  comb primitive std_cat<"share"=1>[LEFT_WIDTH, RIGHT_WIDTH, OUT_WIDTH](left: LEFT_WIDTH, right: RIGHT_WIDTH) -> (out: OUT_WIDTH);
   comb primitive std_not<"share"=1>[WIDTH](in: WIDTH) -> (out: WIDTH);
   comb primitive std_and<"share"=1>[WIDTH](left: WIDTH, right: WIDTH) -> (out: WIDTH);
   comb primitive std_or<"share"=1>[WIDTH](left: WIDTH, right: WIDTH) -> (out: WIDTH);


### PR DESCRIPTION
I honestly don't know if this is useful enough to justify a stdlib addition, but I found during AOC Day 2 (cf https://github.com/cucapra/aoc2022-calyx/pull/2) that I wanted to concatenate together two signals into one (so I could use them in as a compound look-up table key). `std_cat` is a simple primitive that does this and only this. An alternative would be to use the existing `std_pad` followed by `std_or`, but this was a little more convenient.

Feedback welcome! And rejecting this as too fiddly and not useful enough is OK too!