### PR TITLE
Remove span information from `ir::Id`

### DIFF
--- a/calyx/src/analysis/port_interface.rs
+++ b/calyx/src/analysis/port_interface.rs
@@ -66,7 +66,7 @@ impl PortInterface {
                         });
                     // There should only be one port in the read_together specification.
                     if outputs.len() != 1 {
-                        return Err(Error::papercut(format!("Invalid @read_together specification for primitive `{}`. Each specification group is only allowed to have one output port specified.", prim.name)).with_pos(&prim.name))
+                        return Err(Error::papercut(format!("Invalid @read_together specification for primitive `{}`. Each specification group is only allowed to have one output port specified.", prim.name)))
                     }
                     assert!(outputs.len() == 1);
                     Ok((

--- a/calyx/src/errors.rs
+++ b/calyx/src/errors.rs
@@ -170,18 +170,16 @@ impl Error {
         }
     }
     pub fn undefined(name: ir::Id, typ: String) -> Self {
-        let pos = name.copy_span();
         Self {
             kind: Box::new(ErrorKind::Undefined(name, typ)),
-            pos,
+            pos: None,
             post_msg: None,
         }
     }
     pub fn already_bound(name: ir::Id, typ: String) -> Self {
-        let pos = name.copy_span();
         Self {
             kind: Box::new(ErrorKind::AlreadyBound(name, typ)),
-            pos,
+            pos: None,
             post_msg: None,
         }
     }

--- a/calyx/src/frontend/parser.rs
+++ b/calyx/src/frontend/parser.rs
@@ -152,8 +152,7 @@ impl CalyxParser {
 
     // ================ Literals =====================
     fn identifier(input: Node) -> ParseResult<ir::Id> {
-        let span = Self::get_span(&input);
-        Ok(ir::Id::new(input.as_str(), Some(span)))
+        Ok(ir::Id::new(input.as_str()))
     }
 
     fn bitwidth(input: Node) -> ParseResult<u64> {

--- a/calyx/src/ir/component.rs
+++ b/calyx/src/ir/component.rs
@@ -53,10 +53,8 @@ impl Component {
     where
         S: AsRef<str>,
     {
-        let prev_names: HashSet<_> = ports
-            .iter()
-            .map(|pd| pd.name.as_ref().to_string())
-            .collect();
+        let prev_names: HashSet<_> =
+            ports.iter().map(|pd| pd.name.clone()).collect();
 
         let this_sig = Builder::cell_from_signature(
             THIS_ID.into(),
@@ -85,7 +83,7 @@ impl Component {
         }
     }
 
-    pub(super) fn add_names(&mut self, names: HashSet<String>) {
+    pub(super) fn add_names(&mut self, names: HashSet<Id>) {
         self.namegen.add_names(names)
     }
 

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -4,7 +4,7 @@ use super::{
     LibrarySignatures, Port, PortDef, RESERVED_NAMES, RRC,
 };
 use crate::{
-    errors::{CalyxResult, Error, WithPos},
+    errors::{self, CalyxResult, Error, WithPos},
     frontend::{self, ast},
     ir::PortComp,
     utils::NameGenerator,
@@ -25,32 +25,31 @@ struct SigCtx {
 }
 
 /// Validates a component signature to make sure there are not duplicate ports.
-fn check_signature(ports: &[PortDef<u64>]) -> CalyxResult<()> {
-    let mut inputs: HashSet<&Id> = HashSet::new();
-    let mut outputs: HashSet<&Id> = HashSet::new();
+fn check_signature(pds: &[PortDef<u64>]) -> CalyxResult<()> {
+    let mut ports: HashSet<&Id> = HashSet::new();
     for PortDef {
         name, direction, ..
-    } in ports
+    } in pds
     {
         // check for uniqueness
         match &direction {
             Direction::Input => {
-                if !inputs.contains(&name) {
-                    inputs.insert(name);
+                if !ports.contains(&name) {
+                    ports.insert(name);
                 } else {
                     return Err(Error::already_bound(
                         name.clone(),
-                        "component".to_string(),
+                        "port".to_string(),
                     ));
                 }
             }
             Direction::Output => {
-                if !outputs.contains(&name) {
-                    outputs.insert(name);
+                if !ports.contains(&name) {
+                    ports.insert(name);
                 } else {
                     return Err(Error::already_bound(
                         name.clone(),
-                        "component".to_string(),
+                        "port".to_string(),
                     ));
                 }
             }
@@ -162,23 +161,21 @@ fn validate_component(
     comp: &ast::ComponentDef,
     sig_ctx: &SigCtx,
 ) -> CalyxResult<()> {
-    let mut cells: HashSet<Id> = HashSet::new();
-    let mut groups: HashSet<Id> = HashSet::new();
+    let mut cells: HashMap<Id, Option<Rc<errors::Span>>> = HashMap::new();
+    let mut groups: HashMap<Id, Option<Rc<errors::Span>>> = HashMap::new();
 
     for cell in &comp.cells {
-        if cells.contains(&cell.name) {
-            let prev = cells
-                .get(&cell.name)
-                .unwrap()
-                .copy_span()
-                .map(|s| s.format("Previous definition"));
+        let attrs = &cell.attributes;
+        if let Some(pos) = cells.get(&cell.name) {
+            let prev = pos.as_ref().map(|s| s.format("Previous definition"));
             return Err(Error::already_bound(
                 cell.name.clone(),
                 "cell".to_string(),
             )
+            .with_pos(attrs)
             .with_post_msg(prev));
         }
-        cells.insert(cell.name.clone());
+        cells.insert(cell.name.clone(), cell.attributes.copy_span());
 
         let proto_name = &cell.prototype.name;
 
@@ -194,28 +191,23 @@ fn validate_component(
 
     for group in &comp.groups {
         let name = &group.name;
-        if groups.contains(name) {
-            let prev = groups
-                .get(name)
-                .unwrap()
-                .copy_span()
-                .map(|s| s.format("Previous definition"));
+        let attrs = &group.attributes;
+        if let Some(pos) = groups.get(name) {
+            let prev = pos.as_ref().map(|s| s.format("Previous definition"));
             return Err(Error::already_bound(
                 name.clone(),
                 "group".to_string(),
             )
+            .with_pos(attrs)
             .with_post_msg(prev));
         }
-        if cells.contains(name) {
-            let prev = cells
-                .get(name)
-                .unwrap()
-                .copy_span()
-                .map(|s| s.format("Previous definition"));
+        if let Some(pos) = cells.get(name) {
+            let prev = pos.as_ref().map(|s| s.format("Previous definition"));
             return Err(Error::already_bound(name.clone(), "cell".to_string())
+                .with_pos(attrs)
                 .with_post_msg(prev));
         }
-        groups.insert(name.clone());
+        groups.insert(name.clone(), group.attributes.copy_span());
     }
 
     Ok(())

--- a/calyx/src/ir/from_ast.rs
+++ b/calyx/src/ir/from_ast.rs
@@ -71,8 +71,7 @@ const INTERFACE_PORTS: [(&str, u64, Direction); 4] = [
 
 /// Extend the signature with magical ports.
 fn extend_signature(sig: &mut Vec<PortDef<u64>>) {
-    let port_names: HashSet<_> =
-        sig.iter().map(|pd| pd.name.to_string()).collect();
+    let port_names: HashSet<_> = sig.iter().map(|pd| pd.name.clone()).collect();
     let mut namegen = NameGenerator::with_prev_defined_names(port_names);
     for (name, width, direction) in INTERFACE_PORTS.iter() {
         // Check if there is already another interface port defined for the
@@ -250,7 +249,7 @@ fn build_component(
     // Add reserved names to the component's namegenerator so future conflicts
     // don't occur
     ir_component
-        .add_names(RESERVED_NAMES.iter().map(|s| s.to_string()).collect());
+        .add_names(RESERVED_NAMES.iter().map(|s| Id::from(*s)).collect());
 
     Ok(ir_component)
 }

--- a/calyx/src/ir/id.rs
+++ b/calyx/src/ir/id.rs
@@ -1,35 +1,18 @@
-use crate::errors::{Span, WithPos};
 use crate::utils::GSym;
-use derivative::Derivative;
 use serde::{Deserialize, Serialize};
-use std::rc::Rc;
 
 /// Represents an identifier in a Calyx program
-#[derive(Derivative, Clone, Deserialize)]
-#[derivative(Hash, Eq, Debug, PartialOrd, Ord)]
+#[derive(Clone, Deserialize, Hash, PartialEq, Eq, Debug, PartialOrd, Ord)]
 #[serde(transparent)]
 pub struct Id {
     pub id: GSym,
-    #[derivative(Hash = "ignore")]
-    #[derivative(Debug = "ignore")]
-    #[derivative(PartialOrd = "ignore")]
-    #[derivative(Ord = "ignore")]
-    #[serde(skip)]
-    span: Option<Rc<Span>>,
 }
 
 impl Id {
-    pub fn new<S: ToString>(id: S, span: Option<Rc<Span>>) -> Self {
+    pub fn new<S: ToString>(id: S) -> Self {
         Self {
             id: GSym::from(id.to_string()),
-            span,
         }
-    }
-}
-
-impl WithPos for Id {
-    fn copy_span(&self) -> Option<Rc<Span>> {
-        self.span.clone()
     }
 }
 
@@ -37,7 +20,7 @@ impl WithPos for Id {
 
 impl Default for Id {
     fn default() -> Self {
-        Id::new("", None)
+        Id::new("")
     }
 }
 
@@ -58,13 +41,13 @@ impl AsRef<str> for Id {
 
 impl From<&str> for Id {
     fn from(s: &str) -> Self {
-        Id::new(s, None)
+        Id::new(s)
     }
 }
 
 impl From<String> for Id {
     fn from(s: String) -> Self {
-        Id::new(s, None)
+        Id::new(s)
     }
 }
 
@@ -85,11 +68,6 @@ impl PartialEq<&str> for Id {
 }
 impl PartialEq<&Id> for Id {
     fn eq(&self, other: &&Id) -> bool {
-        self.id == other.id
-    }
-}
-impl PartialEq<Id> for Id {
-    fn eq(&self, other: &Id) -> bool {
         self.id == other.id
     }
 }

--- a/calyx/src/ir/primitives.rs
+++ b/calyx/src/ir/primitives.rs
@@ -171,7 +171,7 @@ impl PortDef<Width> {
                 None => {
                     let param_name = &self.name;
                     let msg = format!("Failed to resolve: {param_name}");
-                    Err(Error::malformed_structure(msg).with_pos(value))
+                    Err(Error::malformed_structure(msg))
                 }
             },
         }

--- a/calyx/src/passes/papercut.rs
+++ b/calyx/src/passes/papercut.rs
@@ -98,7 +98,7 @@ impl Visitor for Papercut {
                             assign.name == p.borrow().name && !assign.is_hole()
                         });
                     if done_use.is_none() {
-                        return Err(Error::papercut(format!("Component `{}` has an empty control program and does not assign to the done port `{}`. Without an assignment to the done port, the component cannot return control flow.", comp.name, p.borrow().name)).with_pos(&comp.name));
+                        return Err(Error::papercut(format!("Component `{}` has an empty control program and does not assign to the done port `{}`. Without an assignment to the done port, the component cannot return control flow.", comp.name, p.borrow().name)));
                     }
                 }
             }

--- a/calyx/src/passes/synthesis_papercut.rs
+++ b/calyx/src/passes/synthesis_papercut.rs
@@ -80,7 +80,7 @@ impl Visitor for SynthesisPapercut {
                     format!(
                         "Only writes performed on memory `{mem}'. Synthesis tools will remove this memory. Add @external(1) to cell to turn this into an interface memory.",
                     ),
-                ).with_pos(&mem));
+                ));
             }
             let write_port = cell.borrow().get(WRITE_PORT);
             if analysis.writes_to(&write_port.borrow()).next().is_none() {
@@ -88,7 +88,7 @@ impl Visitor for SynthesisPapercut {
                     format!(
                         "Only reads performed on memory `{mem}'. Synthesis tools will remove this memory. Add @external(1) to cell to turn this into an interface memory.",
                     ),
-                ).with_pos(&mem));
+                ));
             }
         }
         Ok(Action::Stop)

--- a/calyx/src/passes/well_formed.rs
+++ b/calyx/src/passes/well_formed.rs
@@ -2,7 +2,8 @@ use crate::errors::{CalyxResult, Error, WithPos};
 use crate::ir::traversal::ConstructVisitor;
 use crate::ir::traversal::{Action, Named, VisResult, Visitor};
 use crate::ir::{
-    self, CellType, CloneName, Component, LibrarySignatures, RESERVED_NAMES,
+    self, CellType, CloneName, Component, GetAttributes, LibrarySignatures,
+    RESERVED_NAMES,
 };
 use itertools::Itertools;
 use linked_hash_map::LinkedHashMap;
@@ -58,7 +59,7 @@ impl ConstructVisitor for WellFormed {
                         return Err(Error::malformed_structure(
                             "ref cells are not allowed for main component",
                         )
-                        .with_pos(cell.borrow().name()));
+                        .with_pos(cell.borrow().get_attributes()));
                     }
                 }
             }
@@ -167,7 +168,7 @@ impl Visitor for WellFormed {
             // Check if any of the cells use a reserved name.
             if self.reserved_names.contains(cell.name().id.as_str()) {
                 return Err(Error::reserved_name(cell.clone_name())
-                    .with_pos(cell.name()));
+                    .with_pos(cell.get_attributes()));
             }
             // Check if a `ref` cell is invalid
             if cell.is_reference() {
@@ -175,7 +176,7 @@ impl Visitor for WellFormed {
                     return Err(Error::malformed_structure(
                         "constant not allowed for ref cells".to_string(),
                     )
-                    .with_pos(cell.name()));
+                    .with_pos(cell.get_attributes()));
                 }
                 if matches!(cell.prototype, CellType::ThisComponent) {
                     unreachable!(
@@ -359,8 +360,7 @@ impl Visitor for WellFormed {
                     return Err(Error::malformed_control(format!(
                         "{} does not have ref cell named {}",
                         id, outcell
-                    ))
-                    .with_pos(outcell));
+                    )));
                 }
             }
             for id in cellmap.keys() {

--- a/calyx/src/passes/well_formed.rs
+++ b/calyx/src/passes/well_formed.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 /// 7. Invoking components with impatible fed-in cell type for ref cells.
 pub struct WellFormed {
     /// Reserved names
-    reserved_names: HashSet<String>,
+    reserved_names: HashSet<ir::Id>,
     /// Names of the groups that have been used in the control.
     used_groups: HashSet<ir::Id>,
     /// Names of combinational groups used in the control.
@@ -37,7 +37,7 @@ impl ConstructVisitor for WellFormed {
         Self: Sized,
     {
         let reserved_names =
-            RESERVED_NAMES.iter().map(|s| s.to_string()).collect();
+            RESERVED_NAMES.iter().map(|s| ir::Id::from(*s)).collect();
 
         for prim in ctx.lib.signatures() {
             if prim.attributes.has("static") {
@@ -166,7 +166,7 @@ impl Visitor for WellFormed {
         for cell_ref in comp.cells.iter() {
             let cell = cell_ref.borrow();
             // Check if any of the cells use a reserved name.
-            if self.reserved_names.contains(cell.name().id.as_str()) {
+            if self.reserved_names.contains(cell.name()) {
                 return Err(Error::reserved_name(cell.clone_name())
                     .with_pos(cell.get_attributes()));
             }

--- a/calyx/src/utils/namegenerator.rs
+++ b/calyx/src/utils/namegenerator.rs
@@ -5,14 +5,14 @@ use std::collections::{HashMap, HashSet};
 /// prefix.
 #[derive(Clone, Debug)]
 pub struct NameGenerator {
-    name_hash: HashMap<String, i64>,
-    generated_names: HashSet<String>,
+    name_hash: HashMap<ir::Id, i64>,
+    generated_names: HashSet<ir::Id>,
 }
 
 impl NameGenerator {
     /// Create a NameGenerator where `names` are already defined so that this generator
     /// will never generate those names.
-    pub fn with_prev_defined_names(names: HashSet<String>) -> Self {
+    pub fn with_prev_defined_names(names: HashSet<ir::Id>) -> Self {
         NameGenerator {
             generated_names: names,
             name_hash: HashMap::default(),
@@ -20,7 +20,7 @@ impl NameGenerator {
     }
 
     /// Add generated names
-    pub fn add_names(&mut self, names: HashSet<String>) {
+    pub fn add_names(&mut self, names: HashSet<ir::Id>) {
         self.generated_names.extend(names)
     }
 
@@ -32,14 +32,14 @@ impl NameGenerator {
     /// ```
     pub fn gen_name<S>(&mut self, prefix: S) -> ir::Id
     where
-        S: Into<ir::Id> + ToString + Clone,
+        S: Into<ir::Id> + Clone,
     {
         let mut cur_prefix: ir::Id = prefix.into();
         loop {
             // Insert default value for this prefix if there is no entry.
             let count = self
                 .name_hash
-                .entry(cur_prefix.to_string())
+                .entry(cur_prefix.clone())
                 .and_modify(|v| *v += 1)
                 .or_insert(-1);
 
@@ -50,8 +50,8 @@ impl NameGenerator {
             };
 
             // If we've not generated this name before, return it.
-            if !self.generated_names.contains(name.id.as_str()) {
-                self.generated_names.insert(name.to_string());
+            if !self.generated_names.contains(&name) {
+                self.generated_names.insert(name.clone());
                 return name;
             }
 

--- a/interp/src/debugger/parser/command_parser.rs
+++ b/interp/src/debugger/parser/command_parser.rs
@@ -109,7 +109,7 @@ impl CommandParser {
     // ----------------------
 
     fn identifier(input: Node) -> ParseResult<Id> {
-        Ok(Id::new(input.as_str(), None))
+        Ok(Id::new(input.as_str()))
     }
 
     fn group(input: Node) -> ParseResult<ParsedGroupName> {

--- a/tests/errors/duplicate-cells.expect
+++ b/tests/errors/duplicate-cells.expect
@@ -3,7 +3,7 @@
 ---STDERR---
 Error: tests/errors/duplicate-cells.futil
 6 |    r = std_reg(32);
-  |    ^ Name `r' already bound by cell
+  |    ^^^^^^^^^^^^^^^ Name `r' already bound by cell
 tests/errors/duplicate-cells.futil
 5 |    r = std_reg(32);
-  |    ^ Previous definition
+  |    ^^^^^^^^^^^^^^^ Previous definition

--- a/tests/errors/mem-only-reads.expect
+++ b/tests/errors/mem-only-reads.expect
@@ -1,6 +1,4 @@
 ---CODE---
 1
 ---STDERR---
-Error: tests/errors/mem-only-reads.futil
-4 |    mem = std_mem_d1(32, 4, 4);
-  |    ^^^ [Papercut] Only reads performed on memory `mem'. Synthesis tools will remove this memory. Add @external(1) to cell to turn this into an interface memory.
+Error: [Papercut] Only reads performed on memory `mem'. Synthesis tools will remove this memory. Add @external(1) to cell to turn this into an interface memory.

--- a/tests/errors/papercut/cell-and-group-conflict.expect
+++ b/tests/errors/papercut/cell-and-group-conflict.expect
@@ -3,7 +3,7 @@
 ---STDERR---
 Error: tests/errors/papercut/cell-and-group-conflict.futil
 9 |    group incr {
-  |          ^^^^ Name `incr' already bound by cell
+  |    ^^^^^^^^^^^^ Name `incr' already bound by cell
 tests/errors/papercut/cell-and-group-conflict.futil
 5 |    incr = std_add(32);
-  |    ^^^^ Previous definition
+  |    ^^^^^^^^^^^^^^^^^^ Previous definition

--- a/tests/errors/papercut/cell-as-group.expect
+++ b/tests/errors/papercut/cell-as-group.expect
@@ -1,6 +1,4 @@
 ---CODE---
 1
 ---STDERR---
-Error: tests/errors/papercut/cell-as-group.futil
-9 |    save;
-  |    ^^^^ Undefined group name: save
+Error: Undefined group name: save

--- a/tests/errors/redefine-external.expect
+++ b/tests/errors/redefine-external.expect
@@ -1,6 +1,4 @@
 ---CODE---
 1
 ---STDERR---
-Error: tests/errors/redefine-external.futil
-7 |component exp() -> () {
-  |          ^^^ Name `exp' already bound by component or primitive
+Error: Name `exp' already bound by component or primitive

--- a/tests/errors/reserved-name.expect
+++ b/tests/errors/reserved-name.expect
@@ -3,4 +3,4 @@
 ---STDERR---
 Error: tests/errors/reserved-name.futil
 4 |    reg = std_reg(32);
-  |    ^^^ Use of reserved keyword: reg
+  |    ^^^^^^^^^^^^^^^^^ Use of reserved keyword: reg

--- a/tests/passes/well-formed/constant-ref-cell.expect
+++ b/tests/passes/well-formed/constant-ref-cell.expect
@@ -3,4 +3,4 @@
 ---STDERR---
 Error: tests/passes/well-formed/constant-ref-cell.futil
 8 |    ref m2 = std_const(2, 1);
-  |        ^^ Malformed Structure: constant not allowed for ref cells
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^ Malformed Structure: constant not allowed for ref cells

--- a/tests/passes/well-formed/main-ref-cell.expect
+++ b/tests/passes/well-formed/main-ref-cell.expect
@@ -3,4 +3,4 @@
 ---STDERR---
 Error: tests/passes/well-formed/main-ref-cell.futil
 7 |    ref m = std_const(2,1);
-  |        ^ Malformed Structure: ref cells are not allowed for main component
+  |    ^^^^^^^^^^^^^^^^^^^^^^ Malformed Structure: ref cells are not allowed for main component

--- a/tests/passes/well-formed/ref-incorrect-name.expect
+++ b/tests/passes/well-formed/ref-incorrect-name.expect
@@ -1,6 +1,4 @@
 ---CODE---
 1
 ---STDERR---
-Error: tests/passes/well-formed/ref-incorrect-name.futil
-32 |      invoke f[m1 = k1]()();
-   |               ^^ Malformed Control: foo does not have ref cell named m1
+Error: Malformed Control: foo does not have ref cell named m1


### PR DESCRIPTION
- More perf hacking with string interner
- remove span information from `ir::Id`
