### PR TITLE
Check combinational group assignments do not conflict with control program

### DIFF
--- a/calyx/src/errors.rs
+++ b/calyx/src/errors.rs
@@ -18,7 +18,7 @@ impl std::fmt::Debug for Error {
         if self.pos == GPosIdx::UNKNOWN {
             write!(f, "{}", self.kind)?
         } else {
-            write!(f, "{}", self.pos.format(&self.kind.to_string()))?
+            write!(f, "{}", self.pos.format(self.kind.to_string()))?
         }
         if let Some(post) = &self.post_msg {
             write!(f, "\n{}", post)?;

--- a/calyx/src/passes/well_formed.rs
+++ b/calyx/src/passes/well_formed.rs
@@ -21,7 +21,6 @@ struct ActiveAssignments {
 impl ActiveAssignments {
     /// Push a set of assignments to the stack.
     pub fn push(&mut self, assign: &[ir::Assignment]) {
-        assert!(!assign.is_empty(), "Cannot add empty assignment");
         let prev_size = self.assigns.len();
         self.assigns.extend(assign.iter().cloned());
         // Number of assignments added at this level
@@ -429,19 +428,18 @@ impl Visitor for WellFormed {
     ) -> VisResult {
         if let Some(cgr) = &s.cond {
             let cg = cgr.borrow();
+            let assigns = &cg.assignments;
             // Check if the combinational group conflicts with the active combinational groups
-            obvious_conflicts(
-                cg.assignments.iter().chain(self.active_comb.iter()),
-            )
-            .map_err(|err| {
-                let msg = s.attributes.copy_span().format(format!(
-                    "Assignments from `{}' are actived here",
-                    cg.name()
-                ));
-                err.with_post_msg(Some(msg))
-            })?;
+            obvious_conflicts(assigns.iter().chain(self.active_comb.iter()))
+                .map_err(|err| {
+                    let msg = s.attributes.copy_span().format(format!(
+                        "Assignments from `{}' are actived here",
+                        cg.name()
+                    ));
+                    err.with_post_msg(Some(msg))
+                })?;
             // Push the combinational group to the stack of active groups
-            self.active_comb.push(&cg.assignments);
+            self.active_comb.push(assigns);
         }
         Ok(Action::Continue)
     }
@@ -471,19 +469,18 @@ impl Visitor for WellFormed {
     ) -> VisResult {
         if let Some(cgr) = &s.cond {
             let cg = cgr.borrow();
+            let assigns = &cg.assignments;
             // Check if the combinational group conflicts with the active combinational groups
-            obvious_conflicts(
-                cg.assignments.iter().chain(self.active_comb.iter()),
-            )
-            .map_err(|err| {
-                let msg = s.attributes.copy_span().format(format!(
-                    "Assignments from `{}' are actived here",
-                    cg.name()
-                ));
-                err.with_post_msg(Some(msg))
-            })?;
+            obvious_conflicts(assigns.iter().chain(self.active_comb.iter()))
+                .map_err(|err| {
+                    let msg = s.attributes.copy_span().format(format!(
+                        "Assignments from `{}' are actived here",
+                        cg.name()
+                    ));
+                    err.with_post_msg(Some(msg))
+                })?;
             // Push the combinational group to the stack of active groups
-            self.active_comb.push(&cg.assignments);
+            self.active_comb.push(assigns);
         }
         Ok(Action::Continue)
     }

--- a/calyx/src/passes/well_formed.rs
+++ b/calyx/src/passes/well_formed.rs
@@ -346,7 +346,15 @@ impl Visitor for WellFormed {
                 .iter()
                 .chain(comp.continuous_assignments.iter())
                 .chain(self.active_comb.iter()),
-        )?;
+        )
+        .map_err(|err| {
+            let msg = s
+                .attributes
+                .copy_span()
+                .into_option()
+                .map(|s| s.format("Assigments activated by group enable"));
+            err.with_post_msg(msg)
+        })?;
 
         Ok(Action::Continue)
     }

--- a/calyx/src/utils/position.rs
+++ b/calyx/src/utils/position.rs
@@ -179,7 +179,7 @@ impl GPosIdx {
     }
 
     /// Format this position with a the error message `err_msg`
-    pub fn format(&self, err_msg: &str) -> String {
+    pub fn format<S: AsRef<str>>(&self, err_msg: S) -> String {
         let table = GlobalPositionTable::as_ref();
         let pos_d = table.get_pos(self.0);
         let name = &table.get_file_data(pos_d.file).name;
@@ -197,7 +197,15 @@ impl GPosIdx {
         let space: String = " ".repeat(pos_d.start - pos);
         writeln!(buf).unwrap();
         writeln!(buf, "{}|{}", linum_text, l).unwrap();
-        write!(buf, "{}|{}{} {}", linum_space, space, mark, err_msg).unwrap();
+        write!(
+            buf,
+            "{}|{}{} {}",
+            linum_space,
+            space,
+            mark,
+            err_msg.as_ref()
+        )
+        .unwrap();
         buf
     }
 

--- a/interp/tests/control/iteration/iter_mult.futil
+++ b/interp/tests/control/iteration/iter_mult.futil
@@ -30,6 +30,7 @@ component main() -> () {
 
     //will also use this slicer to check the last bit
     slicer = std_slice(4, 1);
+    slicer0 = std_slice(4, 1);
 
     //for the while loop
     lt = std_lt(3); //counting to 4, b/c multiplying 4 bit numbers (4 = [100])
@@ -148,7 +149,7 @@ component main() -> () {
 
     comb group cond_if {
       //get LSB of Q
-      slicer.in = q.out;
+      slicer0.in = q.out;
     }
 
   }
@@ -158,7 +159,7 @@ component main() -> () {
       init;
       while lt.out with cond_while { //just 4 iterations (i starts as 0)
         seq {
-          if slicer.out with cond_if { //there is a 1 in LSB of Q
+          if slicer0.out with cond_if { //there is a 1 in LSB of Q
             seq {
               decide_c;
               add;

--- a/interp/tests/control/iteration/while.futil
+++ b/interp/tests/control/iteration/while.futil
@@ -4,14 +4,18 @@ component main() -> () {
   cells {
     @external i = std_mem_d1(32, 1, 1);
     lt = std_lt(32);
+    lt_reg = std_reg(1);
     add = std_add(32);
   }
 
   wires {
-    comb group cond<"static"=0> { //how can something take 0 cycles?
+    group cond {
       i.addr0 = 1'd0;
       lt.left = i.read_data;
       lt.right = 32'd8;
+      lt_reg.in = lt.out;
+      lt_reg.write_en = 1'd1;
+      cond[done] = lt_reg.done;
     }
 
     group incr<"static"=1> {
@@ -27,8 +31,14 @@ component main() -> () {
   }
 
   control {
-    while lt.out with cond {
-      incr;
+    seq {
+      cond;
+      while lt_reg.out {
+        seq {
+          incr;
+          cond;
+        }
+      }
     }
-}
+  }
 }

--- a/interp/tests/control/static/while_static.futil
+++ b/interp/tests/control/static/while_static.futil
@@ -2,17 +2,17 @@ import "primitives/core.futil";
 
 component main() -> () {
   cells {
+    w = std_wire(1);
     zero = std_const(1, 0);
   }
 
   wires {
     comb group cond_while {
+      w.in = zero.out;
     }
   }
 
   control {
-    while zero.out with cond_while {
-      seq {}
-    }
+    while w.out with cond_while { seq{} }
   }
 }

--- a/tests/backend/mlir/no-guards.expect
+++ b/tests/backend/mlir/no-guards.expect
@@ -19,6 +19,7 @@ calyx.component @main(%go: i1, %clk: i1, %reset: i1, %go0: i1 {go=1}, %clk0: i1 
   %m0.addr0, %m0.write_data, %m0.write_en, %m0.clk, %m0.read_data, %m0.done = calyx.memory @m0 <[1] x 32> [1] : i1, i32, i1, i1, i32, i1
   %m1.addr0, %m1.addr1, %m1.write_data, %m1.write_en, %m1.clk, %m1.read_data, %m1.done = calyx.memory @m1 <[64, 64] x 8> [6, 6] : i6, i6, i8, i1, i1, i8, i1
   %add.left, %add.right, %add.out = calyx.std_add @add : i8, i8, i8
+  %lt.left, %lt.right, %lt.out = calyx.std_lt @lt : i8, i8, i1
   %_1_8.out = hw.constant 1 : i8
   %_1_1.out = hw.constant 1 : i1
   %_0_1.out = hw.constant 0 : i1
@@ -37,8 +38,8 @@ calyx.component @main(%go: i1, %clk: i1, %reset: i1, %go0: i1 {go=1}, %clk0: i1 
       calyx.group_done %r.done : i1
     }
     calyx.comb_group @CombGroup {
-      calyx.assign %add.left = %r.out : i8
-      calyx.assign %add.right = %_1_8.out : i8
+      calyx.assign %lt.left = %r.out : i8
+      calyx.assign %lt.right = %_1_8.out : i8
     }
     calyx.assign %c0.go = %_0_1.out : i1
   }
@@ -46,11 +47,11 @@ calyx.component @main(%go: i1, %clk: i1, %reset: i1, %go0: i1 {go=1}, %clk0: i1 
   calyx.control {
     calyx.seq {
       calyx.enable @Group2
-      calyx.while %c1.out with @CombGroup {
+      calyx.while %lt.out with @CombGroup {
         calyx.seq {
           calyx.enable @Group1
           calyx.enable @Group1
-          calyx.if %c1.out with @CombGroup {
+          calyx.if %r.out {
             calyx.enable @Group2
           }
         }

--- a/tests/backend/mlir/no-guards.futil
+++ b/tests/backend/mlir/no-guards.futil
@@ -24,6 +24,7 @@ component main(go: 1, clk: 1, reset: 1) -> (done: 1) {
     m0 = std_mem_d1(32, 1, 1);
     m1 = std_mem_d2(8, 64, 64, 6, 6);
     add = std_add(8);
+    lt = std_lt(8);
   }
   wires {
     group Group1 {
@@ -40,19 +41,19 @@ component main(go: 1, clk: 1, reset: 1) -> (done: 1) {
       Group2[done] = r.done;
     }
     comb group CombGroup {
-      add.left = r.out;
-      add.right = 8'd1;
+      lt.left = r.out;
+      lt.right = 8'd1;
     }
     c0.go = 1'd0;
   }
   control {
     seq {
       Group2;
-      while c1.out with CombGroup {
+      while lt.out with CombGroup {
         seq {
           Group1;
           Group1;
-          if c1.out with CombGroup {
+          if r.out {
             Group2;
           }
         }

--- a/tests/backend/mlir/with-guards.expect
+++ b/tests/backend/mlir/with-guards.expect
@@ -76,7 +76,7 @@ calyx.component @main(%go: i1 {go=1}, %clk: i1 {clk=1}, %reset: i1 {reset=1}) ->
         calyx.seq {
           calyx.enable @Group1
           calyx.enable @Group1
-          calyx.if %c1.out with @CombGroup {
+          calyx.if %c1.out {
             calyx.enable @Group2
           }
           calyx.if %c1.out {

--- a/tests/backend/mlir/with-guards.futil
+++ b/tests/backend/mlir/with-guards.futil
@@ -59,7 +59,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 1, @done done: 
         seq {
           Group1;
           Group1;
-          if c1.out with CombGroup {
+          if c1.out {
             Group2;
           }
           if c1.out {

--- a/tests/correctness/new_fsm.futil
+++ b/tests/correctness/new_fsm.futil
@@ -5,67 +5,68 @@ component main() -> () {
     a = std_reg(32);
     b = std_reg(32);
     r = std_reg(32);
-    lt = std_lt(32);
+    lt0 = std_lt(32);
+    lt1 = std_lt(32);
     add = std_add(32);
     @external(1) out = std_mem_d1(32, 1, 1);
   }
   wires {
     group A{
-      a.in = 32'd2; 
-      a.write_en = 1'd1; 
-      A[done] = a.done; 
+      a.in = 32'd2;
+      a.write_en = 1'd1;
+      A[done] = a.done;
     }
     group B{
-      b.in = 32'd4; 
-      b.write_en = 1'd1; 
-      B[done] = b.done; 
+      b.in = 32'd4;
+      b.write_en = 1'd1;
+      B[done] = b.done;
     }
     group R{
-      r.in = 32'd10; 
-      r.write_en = 1'd1; 
-      R[done] = r.done; 
+      r.in = 32'd10;
+      r.write_en = 1'd1;
+      R[done] = r.done;
     }
     comb group a_lt_seven {
-      lt.left = a.out; 
-      lt.right = 32'd7;
+      lt0.left = a.out;
+      lt0.right = 32'd7;
     }
     comb group b_lt_a {
-      lt.left = b.out; 
-      lt.right = a.out;
+      lt1.left = b.out;
+      lt1.right = a.out;
     }
     group r_plus_a {
       add.left = r.out;
-      add.right = a.out; 
-      r.in = add.out; 
+      add.right = a.out;
+      r.in = add.out;
       r.write_en = 1'd1;
-      r_plus_a[done] = r.done; 
+      r_plus_a[done] = r.done;
     }
     group r_plus_b {
       add.left = r.out;
-      add.right = b.out; 
-      r.in = add.out; 
+      add.right = b.out;
+      r.in = add.out;
       r.write_en = 1'd1;
-      r_plus_b[done] = r.done; 
+      r_plus_b[done] = r.done;
     }
     group r_plus_3 {
       add.left = r.out;
-      add.right = 32'd3; 
-      r.in = add.out; 
+      add.right = 32'd3;
+      r.in = add.out;
       r.write_en = 1'd1;
-      r_plus_3[done] = r.done; 
+      r_plus_3[done] = r.done;
     }
     group a_plus_1 {
       add.left = a.out;
-      add.right = 32'd1; 
-      a.in = add.out; 
+      add.right = 32'd1;
+      a.in = add.out;
       a.write_en = 1'd1;
-      a_plus_1[done] = a.done; 
+      a_plus_1[done] = a.done;
     }
     group write_mem {
-      out.addr0 = 1'd0; 
-      out.write_data = r.out; 
-      out.write_en = 1'd1; 
-      write_mem[done] = out.done; 
+      out.addr0 = 1'd0;
+      out.write_data = r.out;
+      out.write_en = 1'd1;
+      write_mem[done] = out.done;
     }
   }
   control {
@@ -73,12 +74,12 @@ component main() -> () {
       @new_fsm seq {
         A;B;R;
       }
-      @new_fsm while lt.out with a_lt_seven {
-        seq{
-          @new_fsm if lt.out with b_lt_a{
+      @new_fsm while lt0.out with a_lt_seven {
+        seq {
+          @new_fsm if lt1.out with b_lt_a {
             r_plus_b;
           }
-          else{
+          else {
             r_plus_a;
           }
           r_plus_3;

--- a/tests/correctness/sync/sync-dot-product-opt.futil
+++ b/tests/correctness/sync/sync-dot-product-opt.futil
@@ -1,5 +1,5 @@
 // A sparse dot product implementation that takes advantage of parallelism.
-// thread A is in charge of updating the physical and logical pointers of 
+// thread A is in charge of updating the physical and logical pointers of
 // the "ahead" vector: the vector whose current logical pointer is ahead of
 // the other vector
 // thread B is in charge of doing the multiplication and addition
@@ -20,7 +20,9 @@ component main () -> () {
     val_1 = std_reg(32);
     val_out = std_reg(32);
     lt_0 = std_lt(32);
+    lt_0_reg = std_reg(1);
     lt_1 = std_lt(32);
+    lt_1_reg = std_reg(1);
     incr_0 = std_add(32);
     incr_1 = std_add(32);
     add = std_add(32);
@@ -102,14 +104,14 @@ component main () -> () {
       idx_0.in = in_0.read_data;
       in_0.addr0 = point_0.out;
       idx_0.write_en = 1'd1;
-      fwd_idx_0[done] = idx_0.done; 
+      fwd_idx_0[done] = idx_0.done;
     }
 
     group fwd_idx_1 {
       idx_1.in = in_1.read_data;
       in_1.addr0 = point_1.out;
       idx_1.write_en = 1'd1;
-      fwd_idx_1[done] = idx_1.done; 
+      fwd_idx_1[done] = idx_1.done;
     }
 
     group forward_pointer_0 {
@@ -164,9 +166,25 @@ component main () -> () {
       add_to_out[done] = out.done;
     }
 
+    group chase_0_reg {
+      lt_0.left = idx_0.out;
+      lt_0.right = idx_1.out;
+      lt_0_reg.in = lt_0.out;
+      lt_0_reg.write_en = 1'd1;
+      chase_0_reg[done] = lt_0_reg.done;
+    }
+
     comb group chase_0 {
       lt_0.left = idx_0.out;
       lt_0.right = idx_1.out;
+    }
+
+    group chase_1_reg {
+      lt_1.left = idx_1.out;
+      lt_1.right = idx_0.out;
+      lt_1_reg.in = lt_1.out;
+      lt_1_reg.write_en = 1'd1;
+      chase_1_reg[done] = lt_1_reg.done;
     }
 
     comb group chase_1 {
@@ -190,12 +208,13 @@ component main () -> () {
       // initialize the physical and logical pointer
       initialize_idx;
       // initialize the val registers that record the values of the sparse
-      // vectors at logical pointers where thread A stops incrementing 
+      // vectors at logical pointers where thread A stops incrementing
       initialize_val;
       par {
         // thread A
-        while signal.out with comp {
-          if lt_0.out with chase_0 {
+        while signal.out with comp { seq {
+          chase_0_reg;
+          if lt_0_reg.out {
             // while logical pointer of vector 1 < logical pointer of vector 2,
             // increments the physical pointer and logical pointer of vector 1
             // if thread B is doing the computation while thread A is incrementing
@@ -217,14 +236,14 @@ component main () -> () {
                 }
               }
             }
-          }
-          else {
+          } else { seq {
             // while logical pointer of vector 1 > logical pointer of vector 2,
             // increments the physical pointer and logical pointer of vector 2
-            // Similarly, if it sees that thread B is doing some computation 
+            // Similarly, if it sees that thread B is doing some computation
             // simultaneously, then when it finishes incrementing for vector
             // 2, it waits for thread B to finish computing
-            if lt_1.out with chase_1 {
+            chase_1_reg;
+            if lt_1_reg.out {
               seq {
                 while lt_1.out with chase_1 {
                   seq {
@@ -252,8 +271,8 @@ component main () -> () {
                   val_to_reg_0;
               }
             }
-          }
-        }
+          }}
+        }}
 
         // thread B
         while signal.out with comp {
@@ -273,7 +292,7 @@ component main () -> () {
           }
         }
       }
-      // compute multiplication for last entry to address an edge case. 
+      // compute multiplication for last entry to address an edge case.
       compute_product;
       add_to_out;
     }

--- a/tests/correctness/sync/sync-dot-product.futil
+++ b/tests/correctness/sync/sync-dot-product.futil
@@ -1,10 +1,10 @@
 // A program that computes dot product of sparse vectors
 // using two threads that alternately increment the physical
-// and logical pointer. 
+// and logical pointer.
 // Note that this program does not take advantage of parallelism
-// for performance boost. 
-// Representation of sparse vector is index-value: 
-// 1. We only store non-zero values except for zeroes at the end 
+// for performance boost.
+// Representation of sparse vector is index-value:
+// 1. We only store non-zero values except for zeroes at the end
 // 2. [4, 4, 6, 5, 10, 9, 16, 0, 0, 0, 0]
 //     means that we have a sparse vector of length 17, and has non-zero values
 //     4 at index 4, 5 at index 6, 9 at index 10
@@ -25,7 +25,9 @@ component main () -> () {
     val_1 = std_reg(32);
     val_out = std_reg(32);
     lt_0 = std_lt(32);
+    lt_0_reg = std_reg(1);
     lt_1 = std_lt(32);
+    lt_1_reg = std_reg(1);
     incr_0 = std_add(32);
     incr_1 = std_add(32);
     add = std_add(32);
@@ -50,7 +52,7 @@ component main () -> () {
       no_use.write_en = 1'd1;
       no_op[done] = no_use.done;
     }
-    
+
     group initialize_idx {
       idx_0.in = in_0.read_data;
       in_0.addr0 = 32'd0;
@@ -75,14 +77,14 @@ component main () -> () {
       idx_0.in = in_0.read_data;
       in_0.addr0 = point_0.out;
       idx_0.write_en = 1'd1;
-      fwd_idx_0[done] = idx_0.done; 
+      fwd_idx_0[done] = idx_0.done;
     }
 
     group fwd_idx_1 {
       idx_1.in = in_1.read_data;
       in_1.addr0 = point_1.out;
       idx_1.write_en = 1'd1;
-      fwd_idx_1[done] = idx_1.done; 
+      fwd_idx_1[done] = idx_1.done;
     }
 
     group forward_pointer_0 {
@@ -137,9 +139,25 @@ component main () -> () {
       add_to_out[done] = out.done;
     }
 
+    group chase_0_reg {
+      lt_0.left = idx_0.out;
+      lt_0.right = idx_1.out;
+      lt_0_reg.in = lt_0.out;
+      lt_0_reg.write_en = 1'd1;
+      chase_0_reg[done] = lt_0_reg.done;
+    }
+
     comb group chase_0 {
       lt_0.left = idx_0.out;
       lt_0.right = idx_1.out;
+    }
+
+    group chase_1_reg {
+      lt_1.left = idx_1.out;
+      lt_1.right = idx_0.out;
+      lt_1_reg.in = lt_1.out;
+      lt_1_reg.write_en = 1'd1;
+      chase_1_reg[done] = lt_1_reg.done;
     }
 
     comb group chase_1 {
@@ -168,7 +186,7 @@ component main () -> () {
       // initialize the physical and logical pointer
       initialize_idx;
       // initialize the val registers that record the values of the sparse
-      // vectors at logical pointers where thread A or thread B stops incrementing 
+      // vectors at logical pointers where thread A or thread B stops incrementing
       initialize_val;
       par {
         // thread A
@@ -176,10 +194,11 @@ component main () -> () {
         //    pointer 2 is ahead of logical pointer 1
         // 2. when the logical pointer of vector 1 equals that of vector 2,
         // does the computation(multiplication and adding to accumulator)
-        // 3. when logical pointer of vector 1 is ahead of logical pointer of 
+        // 3. when logical pointer of vector 1 is ahead of logical pointer of
         //    vector 2, waits there and does nothing
-        while signal.out with comp {
-          if lt_0.out with chase_0 {
+        while signal.out with comp { seq {
+          chase_0_reg;
+          if lt_0_reg.out {
             seq {
               while lt_0.out with chase_0 {
                 seq {
@@ -190,7 +209,7 @@ component main () -> () {
               val_to_reg_0;
               @sync(1);
             }
-            
+
           }
           else {
             if eq1.out with equal {
@@ -210,14 +229,15 @@ component main () -> () {
               }
             }
           }
-        }
+        }}
 
         // thread B
         // 1. Forwards the logical and physical pointers of vector 2 when logical
         //    pointer of vector 1 is ahead of that of vector 2
-        // 2. Otherwise waits there and does nothing  
-        while signal.out with comp {
-          if lt_1.out with chase_1 {
+        // 2. Otherwise waits there and does nothing
+        while signal.out with comp { seq {
+          chase_1_reg;
+          if lt_1_reg.out {
             seq {
               while lt_1.out with chase_1 {
                 seq {
@@ -233,8 +253,8 @@ component main () -> () {
               @sync(1);
           }
         }
-      }
-      // compute multiplication for last entry to address an edge case. 
+      }}
+      // compute multiplication for last entry to address an edge case.
       compute_product;
       add_to_out;
     }

--- a/tests/correctness/while.futil
+++ b/tests/correctness/while.futil
@@ -4,14 +4,18 @@ component main() -> () {
   cells {
     @external(1) i = std_mem_d1(32, 1, 1);
     lt = std_lt(32);
+    lt_reg = std_reg(1);
     add = std_add(32);
   }
 
   wires {
-    comb group cond<"static"=0> {
+    group cond {
       i.addr0 = 1'd0;
       lt.left = i.read_data;
       lt.right = 32'd8;
+      lt_reg.in = lt.out;
+      lt_reg.write_en = 1'b1;
+      cond[done] = lt_reg.done;
     }
 
     group incr<"static"=1> {
@@ -27,10 +31,14 @@ component main() -> () {
   }
 
   control {
-    while lt.out with cond {
-      seq {
-        incr;
-        incr;
+    seq {
+      cond;
+      while lt_reg.out {
+        seq {
+          incr;
+          incr;
+          cond;
+        }
       }
     }
   }

--- a/tests/errors/group-comb-conflict.expect
+++ b/tests/errors/group-comb-conflict.expect
@@ -5,3 +5,6 @@ Error: Malformed Structure: Obviously conflicting assignments found:
 13 |      w1.in = r.out;
 10 |      w1.in = 32'd10;
 
+tests/errors/group-comb-conflict.futil
+21 |      do_r;
+   |      ^^^^^ Assigments activated by group enable

--- a/tests/errors/group-comb-conflict.expect
+++ b/tests/errors/group-comb-conflict.expect
@@ -1,0 +1,7 @@
+---CODE---
+1
+---STDERR---
+Error: Malformed Structure: Obviously conflicting assignments found:
+13 |      w1.in = r.out;
+10 |      w1.in = 32'd10;
+

--- a/tests/errors/group-comb-conflict.futil
+++ b/tests/errors/group-comb-conflict.futil
@@ -4,17 +4,21 @@ component main() -> () {
   cells {
     r = std_reg(32);
     w1 = std_wire(32);
-    w2 = std_wire(32);
   }
   wires {
+    comb group do_w1 {
+      w1.in = 32'd10;
+    }
     group do_r {
+      w1.in = r.out;
       r.write_en = 1'd1;
       r.in = 32'd10;
       do_r[done] = r.done;
     }
-    r.in = w1.out;
   }
   control {
-    do_r;
+    if w1.out with do_w1 {
+      do_r;
+    }
   }
 }

--- a/tests/errors/group-cont-assign-conflict.expect
+++ b/tests/errors/group-cont-assign-conflict.expect
@@ -5,3 +5,6 @@ Error: Malformed Structure: Obviously conflicting assignments found:
 12 |      r.in = 32'd10;
 15 |    r.in = w1.out;
 
+tests/errors/group-cont-assign-conflict.futil
+18 |    do_r;
+   |    ^^^^^ Assigments activated by group enable

--- a/tests/errors/if-cond-conflict.expect
+++ b/tests/errors/if-cond-conflict.expect
@@ -1,0 +1,10 @@
+---CODE---
+1
+---STDERR---
+Error: Malformed Structure: Obviously conflicting assignments found:
+13 |      w1.in = 32'd2;
+10 |      w1.in = 32'd1;
+
+tests/errors/if-cond-conflict.futil
+23 |      if w1.out with w1_2 {
+   |      ^^^^^^^^^^^^^^^^^^^^^ Assignments from `w1_2' are actived here

--- a/tests/errors/if-cond-conflict.futil
+++ b/tests/errors/if-cond-conflict.futil
@@ -4,17 +4,25 @@ component main() -> () {
   cells {
     r = std_reg(32);
     w1 = std_wire(32);
-    w2 = std_wire(32);
   }
   wires {
+    comb group w1_1 {
+      w1.in = 32'd1;
+    }
+    comb group w1_2 {
+      w1.in = 32'd2;
+    }
     group do_r {
       r.write_en = 1'd1;
       r.in = 32'd10;
       do_r[done] = r.done;
     }
-    r.in = w1.out;
   }
   control {
-    do_r;
+    if w1.out with w1_1 {
+      if w1.out with w1_2 {
+        do_r;
+      }
+    }
   }
 }


### PR DESCRIPTION
This check enforces the well-formedness constraint for `with <comb-group>` syntax which allows the assignments in the combinational group to be active during the entirely of the body of the `if` or `while` using the `with` syntax.