### PR TITLE
Amending links/commands

### DIFF
--- a/docs/frontends/dahlia.md
+++ b/docs/frontends/dahlia.md
@@ -11,7 +11,7 @@ Then, clone the repository and build the Dahlia compiler:
 ```
 git clone https://github.com/cucapra/dahlia.git
 cd dahlia
-sbt install
+sbt compile
 sbt assembly
 chmod +x ./fuse
 ```

--- a/docs/fud/index.md
+++ b/docs/fud/index.md
@@ -20,13 +20,13 @@ You need [Flit](https://flit.readthedocs.io/en/latest/) to install `fud`. Instal
 You can then install `fud` with
 
 ```bash
-flit install
+cd fud && flit install
 ```
 (If using this method to install `fud`, `pip3` should be version >= 20)
 
 If you are working on `fud` itself, you can install it with a symlink with:
 ```bash
-flit install --symlink
+cd fud && flit install --symlink
 ```
 
 You can also install `fud` with
@@ -166,7 +166,7 @@ Frontend specific instructions:
 
 `fud` supports wraps the Vivado (`synth-verilog`) and Vivado HLS (`vivado-hls`)
 tools to generate area and resource estimates for Calyx designs.
-See [the instructions](./synthesis.md) to configure them.
+See [the instructions](./xilinx.md) to configure them.
 
 ## Working with Stages
 

--- a/docs/tutorial/language-tut.md
+++ b/docs/tutorial/language-tut.md
@@ -127,7 +127,7 @@ name *group*:
 ```
 
 We also need one extra line in the group: that assignment to `the_answer[done]`.
-Here, we say that `the_answer`'s work is one once the update to `mem` has finished.
+Here, we say that `the_answer`'s work is done once the update to `mem` has finished.
 Calyx groups have *compilation holes* called `go` and `done` that the control program will use to orchestrate their execution.
 
 The last thing we need is a control program.
@@ -267,6 +267,6 @@ Take a look at the [full language reference][lang-ref] for details on the comple
 [verilator]: https://www.veripool.org/wiki/verilator
 [tutorial]: https://github.com/cucapra/calyx/tree/master/examples/tutorial
 [icarus verilog]: http://iverilog.icarus.com
-[fud]: ./fud/index.md
+[fud]: ../fud/index.md
 [data-format]: ../lang/data-format.md
 [lang-ref]: ../lang/ref.md


### PR DESCRIPTION
This PR fixes a few broken links in the Calyx documentation. It also amends 2 commands: 

In the Dahlia setup instructions, the build instructions call for `sbt install` to be run. But this isn't an sbt command! I think this is supposed to be `sbt compile`, which is the definition of `make install` in the MAKEFILE. 

In the fud installation instructions, it's not clear that the flit commands should be run inside the `fud` directory. I added a `cd fud` to the commands to ensure users are in the correct directory. 

Let me know if there are any questions/fixes to be made! 