### PR TITLE
[fud] Add `pre_install` to FutilToIcarus stage

### DIFF
--- a/fud/fud/stages/futil.py
+++ b/fud/fud/stages/futil.py
@@ -18,6 +18,10 @@ class FutilStage(Stage):
         )
 
     @staticmethod
+    def pre_install():
+        pass
+
+    @staticmethod
     def defaults():
         return {}
 

--- a/fud/fud/stages/futil.py
+++ b/fud/fud/stages/futil.py
@@ -18,10 +18,6 @@ class FutilStage(Stage):
         )
 
     @staticmethod
-    def pre_install():
-        pass
-
-    @staticmethod
     def defaults():
         return {}
 

--- a/fud/icarus/icarus.py
+++ b/fud/icarus/icarus.py
@@ -186,6 +186,10 @@ class FutilToIcarus(futil.FutilStage):
 
     # No name since FutilStage already defines names
 
+    @staticmethod
+    def pre_install():
+        pass
+
     def __init__(self):
         super().__init__(
             "icarus-verilog",


### PR DESCRIPTION
A recent change in #1323 added a new requirement for `pre_install` methods on newly-registered fud stages. The "futil" (core Calyx compilation) stage in fud didn't have one. At first glance, this wouldn't seem to be a problem, because that's a built-in stage that you never need to register. However, attempting to register the Icarus stage now makes fud crash:

```
$ fud register icarus-verilog -p fud/icarus/icarus.py
Registering external script: icarus-verilog
[fud] ERROR: Failed to register `icarus-verilog': Stage futil missing `pre_install()` method. If the stage has no pre-installation steps, add the  following stub to the class:
    @staticmethod
    def pre_install():
        pass
```

The error message incorrectly complains about the "futil" stage, but that of course is not the problem (the "futil" stage is built in and does not need to be registered). The problem is that the Icarus extension includes a `FutilToIcarus` class that _inherits_ from `FutilStage` but does not provide its own `pre_install` method. This rectifies that problem so it's possible to register the Icarus stage (using the command we recommend in our docs) once again.