### PR TITLE
Exit edges for while are guarded with loop exit condition

### DIFF
--- a/calyx/src/passes/top_down_compile_control.rs
+++ b/calyx/src/passes/top_down_compile_control.rs
@@ -49,6 +49,7 @@ const NODE_ID: &str = "NODE_ID";
 /// The exit set is `[(8, tru[done] & !comb_reg.out), (9, fal & !comb_reg.out)]`.
 fn control_exits(con: &ir::Control, exits: &mut Vec<PredEdge>) {
     match con {
+        ir::Control::Empty(_) => {}
         ir::Control::Enable(ir::Enable { group, attributes }) => {
             let cur_state = attributes.get(NODE_ID).unwrap();
             exits.push((*cur_state, guard!(group["done"])))
@@ -75,7 +76,6 @@ fn control_exits(con: &ir::Control, exits: &mut Vec<PredEdge>) {
             }));
         },
         ir::Control::Invoke(_) => unreachable!("`invoke` statements should have been compiled away. Run `{}` before this pass.", passes::CompileInvoke::name()),
-        ir::Control::Empty(_) => unreachable!("`empty` statements should have been compiled away. Run `{}` before this pass.", passes::CompileEmpty::name()),
         ir::Control::Par(_) => unreachable!(),
     }
 }

--- a/tests/passes/tdcc/empty-exit.expect
+++ b/tests/passes/tdcc/empty-exit.expect
@@ -1,0 +1,12 @@
+======== main:tdcc =========
+1:
+  grp1[go] = !grp1[done] ? 1'd1;
+2:
+  <end>
+transitions:
+  (0, 1): r_wh.out & r_if.out
+  (0, 2): !r_wh.out
+  (0, 2): r_wh.out & !r_if.out & !r_wh.out
+  (1, 1): grp1[done] & r_wh.out & r_if.out
+  (1, 2): grp1[done] & !r_wh.out
+  (1, 2): grp1[done] & r_wh.out & !r_if.out & !r_wh.out

--- a/tests/passes/tdcc/empty-exit.futil
+++ b/tests/passes/tdcc/empty-exit.futil
@@ -1,0 +1,23 @@
+// -x tdcc:dump-fsm -d top-down-st -d post-opt -d group2invoke -d lower -d merge-static-par -b none
+import "primitives/core.futil";
+
+component main() -> () {
+    cells {
+        r_wh = std_reg(1);
+        r_if = std_reg(1);
+    }
+    wires {
+        group grp1 {
+            r_wh.in = 1'd1;
+            r_wh.write_en = 1'd1;
+            grp1[done] = r_wh.done;
+        }
+    }
+    control {
+        while r_wh.out {
+            if r_if.out {
+                grp1;
+            }
+        }
+    }
+}

--- a/tests/passes/tdcc/nested-while.expect
+++ b/tests/passes/tdcc/nested-while.expect
@@ -1,0 +1,18 @@
+======== main:tdcc =========
+0:
+  init[go] = !init[done] ? 1'd1;
+1:
+  body[go] = !body[done] ? 1'd1;
+2:
+  exit[go] = !exit[done] ? 1'd1;
+3:
+  <end>
+transitions:
+  (0, 1): init[done] & r0.out & r1.out
+  (0, 2): init[done] & !r0.out
+  (0, 2): init[done] & r0.out & !r1.out & !r0.out
+  (1, 1): body[done] & !r1.out & r0.out & r1.out
+  (1, 1): body[done] & r1.out
+  (1, 2): body[done] & !r1.out & r0.out & !r1.out & !r0.out
+  (1, 2): body[done] & !r1.out & !r0.out
+  (2, 3): exit[done]

--- a/tests/passes/tdcc/nested-while.futil
+++ b/tests/passes/tdcc/nested-while.futil
@@ -1,0 +1,29 @@
+// -x tdcc:dump-fsm -d top-down-st -d post-opt -d group2invoke -d lower -d merge-static-par -b none
+import "primitives/core.futil";
+
+component main() -> () {
+    cells {
+      r0 = std_reg(1);
+      r1 = std_reg(1);
+    }
+    wires {
+        group init<"static"=1> {
+            init[done] = r0.out;
+        }
+        group exit {
+            exit[done] = r0.out;
+        }
+        group body {
+            body[done] = r0.out;
+        }
+    }
+    control {
+        init;
+        while r0.out {
+            while r1.out {
+                body;
+            }
+        }
+        exit;
+    }
+}


### PR DESCRIPTION
`control_exits` in TDCC computes the predecessors of a control program and should correctly guard the exit edges from the `while` with the loop's exit condition.