### PR TITLE
`build_assignments!` returns an array instead of vec

### DIFF
--- a/calyx/src/ir/macros.rs
+++ b/calyx/src/ir/macros.rs
@@ -81,7 +81,7 @@ macro_rules! build_assignments {
      $($dst_node:ident[$dst_port:expr] =
          $($guard:ident)? ?
          $src_node:ident[$src_port:expr];)*)  => {
-        vec![$(
+        [$(
             build_assignments!(@base $builder;
                 $dst_node[$dst_port] = $($guard)? ? $src_node[$src_port])
         ),*]

--- a/calyx/src/passes/compile_empty.rs
+++ b/calyx/src/passes/compile_empty.rs
@@ -56,12 +56,12 @@ impl Visitor for CompileEmpty {
                     let signal_on = constant(1, 1);
                     let empty_reg = prim std_reg(1);
                 );
-                let mut assigns: Vec<_> = build_assignments!(builder;
+                let assigns = build_assignments!(builder;
                     empty_reg["write_en"] = ? signal_on["out"];
                     empty_reg["in"] = ? signal_on["out"];
                     empty_group["done"] = ? empty_reg["done"];
                 );
-                empty_group.borrow_mut().assignments.append(&mut assigns);
+                empty_group.borrow_mut().assignments.extend(assigns);
 
                 // Register the name of the group to the pass
                 self.group_name = Some(empty_group.borrow().name());

--- a/calyx/src/passes/wire_inliner.rs
+++ b/calyx/src/passes/wire_inliner.rs
@@ -73,11 +73,11 @@ impl Visitor for WireInliner {
                 let one = constant(1, 1);
             );
             let group_done = guard!(group["done"]);
-            let mut assigns = build_assignments!(builder;
+            let assigns = build_assignments!(builder;
                 group["go"] = ? this["go"];
                 this["done"] = group_done ? one["out"];
             );
-            comp.continuous_assignments.append(&mut assigns);
+            comp.continuous_assignments.extend(assigns);
         } else {
             return Err(crate::errors::Error::malformed_control(format!(
                 "{}: Structure has more than one group",


### PR DESCRIPTION
Because `build_assignments!` knows exactly how many assignments it is going to create a compile-time, we can return an array instead of a vec