### PR TITLE
Miscellaneous fixes in docs

### DIFF
--- a/docs/compiler-as-library.md
+++ b/docs/compiler-as-library.md
@@ -2,7 +2,7 @@
 
 The implementation of the compiler separates the frontend from the internal data structures.
 This allows developers to use the compiler as a library.
-The `calyx` library exports all the data structures used by the compiler can be used to design new
+The `calyx` library exports all the data structures used by the compiler and can be used to design new
 tools that make use of Calyx.
 
 See the [library documentation][source-doc] for an example of how to use the `calyx` library.

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -2,8 +2,8 @@
 
 The source code documentation for the compiler can be [found here][comp].
 
-The Calyx compiler has several command line to control the execution of various
-passes and backends.
+The Calyx compiler has several command line options to control the execution of
+various passes and backends.
 
 ## Specifying Primitives Library
 
@@ -55,8 +55,8 @@ Aliases:
 ...
 ```
 
-The first section list all the passes implemented in the compiler.
-The second section lists *aliases* for combination of passes that are commonly
+The first section lists all the passes implemented in the compiler.
+The second section lists *aliases* for combinations of passes that are commonly
 run together.
 For example, the alias `all` is an ordered sequence of default passes executed
 when the compiler is run from the command-line.

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -2,7 +2,7 @@
 
 The experimental Calyx interpreter resides in the `interp/` directory of the
 repository.
-The interpreter supports all Calyx programs---from high-level programs that
+The interpreter supports all Calyx programs—from high-level programs that
 make heavy use of control operators, to fully lowered Calyx programs.
 (RTL simulation, in contrast, only supports execution of fully lowered programs.)
 

--- a/docs/lang/attributes.md
+++ b/docs/lang/attributes.md
@@ -67,7 +67,7 @@ It has two meanings:
 1. If the `externalize` pass is enabled, the cell is turned into an "external"
    cell by exposing all its ports through the current component and rewriting
    assignments to the use the ports. See the documentation on
-   See [externalize](https://docs.calyxir.org/source/calyx/passes/struct.Externalize.html "Externalize Pass") for more information.
+   [externalize](https://docs.calyxir.org/source/calyx/passes/struct.Externalize.html "Externalize Pass") for more information.
 2. If the cell is a memory and has an `external` attribute on it, the verilog backend (`-b verilog`) generates code to read `<cell_name>.dat` to initialize the memory state and dumps out its final value after execution.
 
 ### `static(n)`

--- a/docs/lang/data-format.md
+++ b/docs/lang/data-format.md
@@ -80,7 +80,7 @@ Often times, it can be useful to automatically generate random values for a larg
 
 
 [toplevel-attr]: attributes.md#toplevel
-[ext-attr]: attributed.md#external
+[ext-attr]: attributes.md#external
 [fud]: ../fud/index.md
 [data-gen]: ../tools/data-gen.md
 [iv]: ../fud/index.md#icarus-verilog

--- a/docs/lang/memories-by-reference.md
+++ b/docs/lang/memories-by-reference.md
@@ -21,7 +21,7 @@ There are two steps to passing a memory by reference in Calyx:
 1. Define the component in a manner such that it can accept a memory by reference.
 2. Pass the desired memory by reference.
 
-The language provides two ways to doing this.
+The language provides two ways of doing this.
 
 ## The Easy Way
 

--- a/docs/lang/multi-component.md
+++ b/docs/lang/multi-component.md
@@ -4,7 +4,7 @@ Calyx designs can define and instantiate other Calyx components that themselves
 encode complex `control` programs.
 
 As an example, we'll build a Calyx design that uses a simple Calyx component
-to save a value in a register and use it in different component.
+to save a value in a register and use it in a different component.
 
 We define a new component called `identity` that has an input port `in`
 and an output port `out`.

--- a/docs/lang/ref.md
+++ b/docs/lang/ref.md
@@ -200,7 +200,7 @@ Guards can use the following constructs:
 
 ### Continuous Assignments
 
-When an assignment is appears directly inside a component's `wires` section, it
+When an assignment appears directly inside a component's `wires` section, it
 is called a *continuous assignment* and is permanently active, even when the
 [control program](#the-control-operators) of the component is inactive.
 
@@ -220,7 +220,7 @@ Assignments within a group can be reasoned about in isolation from assignments
 in other groups.
 Unlike [continuous assignments][continuous], a group's encapsulated assignments
 only execute as dictated by the [control program][control].
-These means that seemingly conflicting writes to the same ports are allowed:
+This means that seemingly conflicting writes to the same ports are allowed:
 
 ```
 group foo {
@@ -302,7 +302,7 @@ invoke instance[ref cells](inputs)(outputs) [with comb_group];
   required [*cell reference*][ref]. (It can be omitted if the invoked component
   contains no cell references.)
 
-Invoking a instance runs its control program to completion before returning.
+Invoking an instance runs its control program to completion before returning.
 Any Calyx component or primitive that implements the [go-done interface](#the-go-done-interface) can be invoked.
 Like the [group enable](#group-enable) statement, `invoke` is a leaf node in the control program.
 
@@ -375,7 +375,7 @@ value of `port`.
 
 ## The `go`-`done` Interface
 
-By default, calyx components implement a one-sided ready-valid interface called
+By default, Calyx components implement a one-sided ready-valid interface called
 *the `go`-`done` interface*.
 During compilation, the Calyx compiler will add an input port marked with the attribute [`@go`][godoneattr] and an output port marked with the attribute [`@done`][godoneattr] to the interface of the component:
 

--- a/docs/libraries/core.md
+++ b/docs/libraries/core.md
@@ -22,7 +22,7 @@ A `WIDTH`-wide register.
 
 - `in: WIDTH` - An input value to the register `WIDTH`-bits.
 - `write_en: 1` - The one bit write enabled signal. Indicates that the register
-  should store the value on the in wire.
+  should store the value on the `in` wire.
 
 **Outputs:**
 
@@ -46,7 +46,7 @@ A constant WIDTH-bit value with value VAL.
 
 ### `std_lsh<WIDTH>`
 
-A left bit shift. Performs `LEFT << RIGHT`. This component is combinational.
+A left bit shift. Performs `left << right`. This component is combinational.
 
 **Inputs:**
 
@@ -55,13 +55,13 @@ A left bit shift. Performs `LEFT << RIGHT`. This component is combinational.
 
 **Outputs:**
 
-- `out: WIDTH` - A WIDTH-bit value equivalent to `LEFT << RIGHT`
+- `out: WIDTH` - A WIDTH-bit value equivalent to `left << right`
 
 ---
 
 ### `std_rsh<WIDTH>`
 
-A right bit shift. Performs `LEFT >> RIGHT`. This component is combinational.
+A right bit shift. Performs `left >> right`. This component is combinational.
 
 **Inputs:**
 
@@ -70,13 +70,13 @@ A right bit shift. Performs `LEFT >> RIGHT`. This component is combinational.
 
 **Outputs:**
 
-- `out: WIDTH` - A WIDTH-bit value equivalent to `LEFT >> RIGHT`
+- `out: WIDTH` - A WIDTH-bit value equivalent to `left >> right`
 
 ---
 
 ### `std_add<WIDTH>`
 
-Bitwise addition without a carry flag. Performs `LEFT + RIGHT`. This component
+Bitwise addition without a carry flag. Performs `left + right`. This component
 is combinational.
 
 **Inputs:**
@@ -86,13 +86,13 @@ is combinational.
 
 **Outputs:**
 
-- `out: WIDTH` - A WIDTH-bit value equivalent to `LEFT + RIGHT`
+- `out: WIDTH` - A WIDTH-bit value equivalent to `left + right`
 
 ---
 
 ### `std_sub<WIDTH>`
 
-Bitwise subtraction. Performs `LEFT - RIGHT`. This component is combinational.
+Bitwise subtraction. Performs `left - right`. This component is combinational.
 
 **Inputs:**
 
@@ -101,14 +101,14 @@ Bitwise subtraction. Performs `LEFT - RIGHT`. This component is combinational.
 
 **Outputs:**
 
-- `out: WIDTH` - A WIDTH-bit value equivalent to `LEFT - RIGHT`
+- `out: WIDTH` - A WIDTH-bit value equivalent to `left - right`
 
 ---
 
 ### `std_slice<IN_WIDTH, OUT_WIDTH>`
 
 Slice out the lower OUT_WIDTH bits of an IN_WIDTH-bit value. Computes
-`in[out_width - 1 : 0]`. This component is combinational.
+`in[OUT_WIDTH - 1 : 0]`. This component is combinational.
 
 **Inputs:**
 
@@ -302,7 +302,7 @@ A one-dimensional memory.
 
 **Inputs:**
 
-- `addr0: IDX_SIZE - The index to be accessed or updated
+- `addr0: IDX_SIZE` - The index to be accessed or updated
 - `write_data: WIDTH` - Data to be written to the selected memory slot
 - `write_en: 1` - One bit write enabled signal, causes the memory to write `write_data` to the slot indexed by `addr0`
 

--- a/docs/tools/editor-highlighting.md
+++ b/docs/tools/editor-highlighting.md
@@ -2,7 +2,7 @@
 
 ## Vim
 
-The vim extension highlights files with the extension `.futil`. 
+The vim extension highlights files with the extension `.futil`.
 It can be installed using a plugin manager such as [vim-plug][] using a
 local installation.
 Add the following to your vim plug configuration:
@@ -37,7 +37,7 @@ I imagine it looks very similar for pure emacs, but haven't actually tried it my
 Add a link to the Calyx VSCode extension directory to your VSCode extensions directory.
 ```
 cd $HOME/.vscode/extensions
-ln -s <calyx root directory/tools/vscode calyx.calyx-0.0.1
+ln -s <calyx root directory>/tools/vscode calyx.calyx-0.0.1
 ```
 Restart VSCode.
 

--- a/docs/tools/runt.md
+++ b/docs/tools/runt.md
@@ -20,7 +20,7 @@ The following commands help focus on specific tests to run:
 
 **Differences**. `-d` or `--diff` shows differences between the expected test output and the generated output. Use this in conjunction with `-i` to focus on particular failing tests.
 
-**Saving Files**. `-s` is used to save test outputs when the have expected changes. In the case of `miss` tests, i.e. tests that currently don't any expected output file, this saves a completely new `.expect` file.
+**Saving Files**. `-s` is used to save test outputs when they have expected changes. In the case of `miss` tests, i.e. tests that currently don't have any expected output file, this saves a completely new `.expect` file.
 
 **Dry run**. `-n` flag shows the commands that `runt` will run for each test. Use this when you directly want to run the command for the test directly.
 

--- a/docs/tutorial/language-tut.md
+++ b/docs/tutorial/language-tut.md
@@ -18,7 +18,7 @@ statement to import the standard library:
 
     import "primitives/core.futil";
 
-    component main(go: 1) -> (done: 1) {
+    component main(@go go: 1) -> (@done done: 1) {
       cells {}
       wires {}
       control {}
@@ -262,7 +262,7 @@ The output should be the result of adding 4 to the initial value 8 times, so 10 
 
 Take a look at the [full language reference][lang-ref] for details on the complete language.
 
-[ext-attr]: ../lang/attributes.html#external1
+[ext-attr]: ../lang/attributes.html#external
 [json]: https://www.json.org/
 [verilator]: https://www.veripool.org/wiki/verilator
 [tutorial]: https://github.com/cucapra/calyx/tree/master/examples/tutorial

--- a/tools/vscode/README.md
+++ b/tools/vscode/README.md
@@ -7,7 +7,7 @@ fancier features if anybody is ever interested in it.
 Add a link to the Calyx VSCode extension directory to your VSCode extensions directory.
 ```
 cd $HOME/.vscode/extensions
-ln -s <calyx root directory/tools/vscode calyx.calyx-0.0.1
+ln -s <calyx root directory>/tools/vscode calyx.calyx-0.0.1
 ```
 Restart VSCode.
 


### PR DESCRIPTION
Fixes some minor issues in the documentation: a few broken links, typos, and one non-compiling code example.