### PR TITLE
Static Par Timing Analysis 

### DIFF
--- a/calyx/src/analysis/mod.rs
+++ b/calyx/src/analysis/mod.rs
@@ -17,6 +17,7 @@ pub mod reaching_defns;
 mod read_write_set;
 mod schedule_conflicts;
 mod share_set;
+mod static_par_timing;
 mod variable_detection;
 
 pub use compute_static::WithStatic;
@@ -32,4 +33,5 @@ pub use port_interface::PortInterface;
 pub use read_write_set::ReadWriteSet;
 pub use schedule_conflicts::ScheduleConflicts;
 pub use share_set::ShareSet;
+pub use static_par_timing::StaticParTiming;
 pub use variable_detection::VariableDetection;

--- a/calyx/src/analysis/static_par_timing.rs
+++ b/calyx/src/analysis/static_par_timing.rs
@@ -1,0 +1,295 @@
+use crate::{
+    analysis::{ControlId, ReadWriteSet, ShareSet, VariableDetection},
+    ir::{self, CloneName, Id, RRC},
+};
+use itertools::Itertools;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    rc::Rc,
+};
+
+/// The data structure used to represent sets of ids. This is used to represent
+/// the `live`, `gen`, and `kill` sets.
+#[derive(Default, Clone)]
+pub struct Prop {
+    map: CellsByType,
+}
+
+/// Implement nice printing for prop for debugging purposes.
+impl Debug for Prop {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{")?;
+        let names = self.map.iter().flat_map(|(_, ids)| ids).join(", ");
+        write!(f, "{}", names)?;
+        write!(f, "}}")
+    }
+}
+
+impl Prop {
+    /// Defines the dataflow transfer function.
+    /// We use the standard definition for liveness:
+    /// `(alive - kill) + gen`
+    fn transfer(&mut self, gen: Prop, kill: Prop) {
+        self.sub(kill);
+        self.or(gen);
+    }
+
+    /// Defines the data_flow transfer function. `(alive - kill) + gen`.
+    /// However, this is for when gen and kill are sets, and self is a map.
+    fn transfer_set(&mut self, gen: TypeNameSet, kill: TypeNameSet) {
+        self.sub_set(kill);
+        self.or_set(gen);
+    }
+
+    // The or operation, but when the self is a map and rhs is a set of tuples.
+    fn or_set(&mut self, rhs: TypeNameSet) {
+        for (cell_type, cell_name) in rhs {
+            self.map.entry(cell_type).or_default().insert(cell_name);
+        }
+    }
+
+    // The sub operation, but when the self is a map and rhs is a set of tuples.
+    fn sub_set(&mut self, rhs: TypeNameSet) {
+        for (cell_type, cell_name) in rhs {
+            self.map.entry(cell_type).or_default().remove(&cell_name);
+        }
+    }
+
+    // edits self to equal self | rhs. Faster than self | rhs  but must take rhs
+    // ownership and not &rhs.
+    fn or(&mut self, rhs: Prop) {
+        for (cell_type, cell_names) in rhs.map {
+            self.map.entry(cell_type).or_default().extend(cell_names);
+        }
+    }
+
+    // edits self to equal self intersect rhs. Must take ownership of rhs
+    // ownership and not &rhs.
+    fn intersect(&mut self, mut rhs: Prop) {
+        for (cell_type, cell_names) in self.map.iter_mut() {
+            let empty_hash = HashSet::new();
+            let entry: HashSet<Id> =
+                rhs.map.remove(cell_type).unwrap_or(empty_hash);
+            cell_names.retain(|cell| entry.contains(cell));
+        }
+    }
+
+    // edits self to equal self - rhs. Faster than self - rhs  but must take rhs
+    // ownership and not &rhs.
+    fn sub(&mut self, rhs: Prop) {
+        for (cell_type, cell_names) in rhs.map {
+            self.map
+                .entry(cell_type)
+                .or_default()
+                .retain(|cell| !cell_names.contains(cell));
+        }
+    }
+}
+
+/// This analysis implements a parallel version of a classic liveness analysis.
+/// For each group or invoke, it returns a list of the state shareable cells
+/// that are "alive" during an execution of a group or invoke statement (we
+/// identify an invoke statement by the cell that is being invoked, and groups
+/// by the name of the group).
+///
+/// ## Parallel Analog to a CFG
+/// The `par` statement introduces a new kind of control branching that can
+/// not be captured by a traditional CFG.
+///
+/// Consider whether `x` is alive at `foo` in the following program.
+/// ```
+/// seq {
+///   wr_x; // writes register x
+///   foo;
+///   par {
+///     wr_x2; // writes register x
+///     bar;
+///   }
+///   rd_x; // reads register x
+/// }
+/// ```
+/// `x` is not alive at `foo` because there are no reads to `x` before
+/// `wr_x2` is executed which writes to `x` again. Note that `wr_x2` is always
+/// executed.
+///
+/// We might try and represent the `par` branching with a normal CFG like this:
+/// ```
+///       +------+
+///       | wr_x |
+///       +--+---+
+///          |
+///          v
+///       +--+--+
+///    +--+ foo +--+
+///    |  +-----+  |
+///    |           |
+///    v           v
+/// +--+----+   +--+--+
+/// | wr_x2 |   | bar |
+/// +--+----+   +--+--+
+///    |           |
+///    +------+----+
+///           |
+///           v
+///       +------+
+///       | rd_x |
+///       +------+
+/// ```
+/// But then this program is identical to
+/// ```
+/// seq {
+///   wr_x; // writes register x
+///   foo;
+///   if blah.out with B {
+///     wr_x2; // writes register x
+///   } else {
+///     bar;
+///   }
+///   rd_x; // reads register x
+/// }
+/// ```
+/// which has different semantics. In particular `x` is still alive at `foo` because
+/// `wr_x2` may not be executed.
+///
+/// We need to augment the traditional CFG to account for `par`.
+///
+/// ## A Parallel CFG
+/// The representation should:
+///  1) Have the same properties as a normal CFG when no parallelism is present.
+///  2) Threads of a `par` block should not have to know that they are in a `par` (i.e. are just CFGs themselves)
+///  3) External to the `par` block, the information of running all threads in `par` should be visible.
+///
+/// To address these concerns, we use a parallel CFG (pCFG) based on
+/// [Analyzing programs with explicit parallelism](https://link.springer.com/chapter/10.1007%2FBFb0038679).
+/// We introduce a new kind of node in the CFG called a `par node`. A `par node` represents an entire
+/// `par` block. The above program with `par` would look like:
+/// ```
+/// +------+
+/// | wr_x |
+/// +--+---+
+///    |
+///    v
+/// +--+--+
+/// | foo |
+/// +--+--+
+///    |
+///    v
+/// +--+---+
+/// | par1 |
+/// +--+---+
+///    |
+///    v
+/// +--+---+
+/// | rd_x |
+/// +------+
+/// ```
+/// For each `par node`, we associate a list of pCFGs where each pCFG represents a thread.
+/// Each thread starts with a `begin par` node and ends with a `end par` node.
+///
+/// These are the graphs associated with `par1`.
+/// ```
+/// First thread:    Second thread:
+/// +----------+      +----------+
+/// |begin par1|      |begin par1|
+/// +--+-------+      +-+--------+
+///    |                |
+///    v                v
+/// +--+--+           +-+-+
+/// |wr_x2|           |bar|
+/// +--+--+           +-+-+
+///    |                |
+///    v                v
+/// +--+-----+        +-+------+
+/// |end par1|        |end par1|
+/// +--------+        +--------+
+/// ```
+///
+/// The idea with the `begin/end parx` nodes is that these will handle the flow
+/// of information in and out of the threads. For example, you could write these equations:
+/// ```
+/// out(begin par1) = in(par1)
+/// out(par1) = join over all in(end par1)
+/// ```
+///
+/// ## Definition of Liveness
+/// Now we finally come to the definition of "liveness" and how we use the pCFG to compute this.
+///
+/// We say a cell `x` is "live" at a node `p` in the CFG if there is a write to `x` ordered before
+/// `p` (such that there are no more writes to `x` at a point between that and `p`) and if there is a read
+/// of `x` ordered after `p` (such that there are no writes between that and `p`).
+///
+/// We define the following equations (assuming a reversed direction dataflow analysis):
+/// ```
+/// for some node n:
+///   gen(n) = registers that may be read in n
+///   kill(n) = register that must be written to in n
+///   live_in(n) = union over live_out(pred(n))
+///   live_out(n) = (live_in(n) - kill(n)) + gen(n)
+/// for some par node p:
+///   gen(p) = union over gen(n) for sub-nodes n in p
+///   kill(p) = union over kill(n) for sub-nodes n in p
+///   live_in(p) = union over live_out(pred(p))
+///   live_out(p) = (live_in(p) - kill(p)) + gen(p)
+/// ```
+/// The main place this analysis differs from traditional liveness analysis
+/// is the definition of `gen(p)` and `kill(p)` for `par` nodes. These are the
+/// union of the `gen`s and `kill`s of all of their sub-nodes. Intuitively we
+/// are treating `par` blocks as if they were just a single group. Note that this
+/// is overly conservative because we are potentially ignoring ordering
+/// information of the threads.
+#[derive(Default)]
+pub struct LiveRangeAnalysis {
+    /// Map from node ids (i.e., group enables or invokes) names
+    /// to the components live inside them.
+    live: HashMap<u64, Prop>,
+    /// Groups that have been identified as variable-like.
+    /// Mapping from group name to Some(type, name) where type is the cell type and
+    /// name is the cell name. If group is not variable like, maps to None.
+    variable_like: HashMap<ir::Id, Option<(ir::CellType, ir::Id)>>,
+    /// Set of state shareable components (as type names)
+    state_share: ShareSet,
+    /// Set of shareable components (as type names)
+    share: ShareSet,
+    /// maps invokes/enable ids to the shareable cell types/names live in them
+    invokes_enables_map: HashMap<u64, TypeNameSet>,
+    /// maps comb groups of if/while statements to the cell types/
+    /// names used in them
+    cgroup_uses_map: HashMap<u64, TypeNameSet>,
+}
+
+impl LiveRangeAnalysis {
+    /// Construct a live range analysis.
+    pub fn new(
+        control: &mut ir::Control,
+        state_share: ShareSet,
+        share: ShareSet,
+    ) -> Self {
+        let mut ranges = LiveRangeAnalysis {
+            state_share,
+            share,
+            ..Default::default()
+        };
+
+        // Give each control statement a unique "NODE_ID" attribute.
+        ControlId::compute_unique_ids(control, 0, false);
+
+        ranges.build_live_ranges(
+            control,
+            Prop::default(),
+            Prop::default(),
+            Prop::default(),
+        );
+
+        for (node, cells_by_type) in &ranges.invokes_enables_map {
+            if let Some(prop) = ranges.live.get_mut(node) {
+                prop.or_set(cells_by_type.clone());
+            }
+        }
+
+        // LivRangeAnalysis does not handle comb groups currently. Eventually, we want to and make
+        // remove-comb-groups optional.
+
+        ranges
+    }
+}

--- a/calyx/src/analysis/static_par_timing.rs
+++ b/calyx/src/analysis/static_par_timing.rs
@@ -2,19 +2,22 @@ use crate::{
     analysis::ControlId,
     ir::{self},
 };
-use std::{
-    collections::{HashMap, HashSet},
-    fmt::Debug,
-};
+use std::{collections::HashMap, fmt::Debug};
 
-/// maps the node ids of enables to a set of tuples (i,j), which is clock cycles (relative
-/// to the start of the par) that enable is live
-type ParTimingMap = HashMap<u64, HashSet<(u64, u64)>>;
+use super::LiveRangeAnalysis;
+
+/// maps cell names to a vector of tuples (i,j), which is the clock
+/// cycles (relative to the start of the par) that enable is live
+/// the tuples/intervals should always be sorted within the vec
+type CellTimingMap = HashMap<ir::Id, Vec<(u64, u64)>>;
+/// maps threads (i.e., direct children of pars) to cell
+/// timing maps
+type ThreadTimingMap = HashMap<u64, CellTimingMap>;
 
 #[derive(Default)]
 pub struct StaticParTiming {
-    /// Map from from par block ids to par_timing_maps
-    map: HashMap<u64, ParTimingMap>,
+    /// Map from par block ids to cell_timing_maps
+    cell_map: HashMap<u64, ThreadTimingMap>,
     /// name of component
     component_name: ir::Id,
 }
@@ -24,36 +27,50 @@ impl Debug for StaticParTiming {
         //must sort the hashmap and hashsets in order to get consistent ordering
         writeln!(
             f,
-            "This maps ids of par blocks to \" par timing maps \", which map enable ids to intervals (i,j), that signify the clock cycles the group is active for, \n relative to the start of the given par block"
+            "This maps ids of par blocks to \" cell timing maps \", which map cells to intervals (i,j), that signify the clock cycles the group is active for, \n relative to the start of the given par block"
         )?;
-        write!(f, "======== Map for Component \"{}\"", self.component_name)?;
-        writeln!(f, " ========")?;
-        let map = self.map.clone();
+        write!(
+            f,
+            "============ Map for Component \"{}\"",
+            self.component_name
+        )?;
+        writeln!(f, " ============")?;
+        let map = self.cell_map.clone();
         // Sorting map to get deterministic ordering
-        let mut vec: Vec<(u64, ParTimingMap)> = map.into_iter().collect();
+        let mut vec: Vec<(u64, ThreadTimingMap)> = map.into_iter().collect();
         vec.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
-        for (par_id, par_timing_map) in vec.into_iter() {
-            write!(f, "====")?;
+        for (par_id, thread_timing_map) in vec.into_iter() {
+            write!(f, "========")?;
             write!(f, "Par Node ID: {:?}", par_id)?;
-            writeln!(f, "====")?;
-            let mut vec1: Vec<(u64, HashSet<(u64, u64)>)> =
-                par_timing_map.into_iter().collect::<Vec<_>>();
+            writeln!(f, " ========")?;
+            let mut vec1: Vec<(u64, CellTimingMap)> =
+                thread_timing_map.into_iter().collect::<Vec<_>>();
             vec1.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
-            for (group_id, clock_intervals) in vec1 {
-                write!(f, "Group Node ID: {:?} --", group_id)?;
-                let mut vec2: Vec<(u64, u64)> =
-                    clock_intervals.into_iter().collect();
-                vec2.sort_unstable();
-                writeln!(f, " {:?}", vec2)?;
+            for (thread_id, cell_timing_map) in vec1 {
+                write!(f, "====")?;
+                write!(f, "Child/Thread ID: {:?}", thread_id)?;
+                writeln!(f, " ====")?;
+                let mut vec2: Vec<(ir::Id, Vec<(u64, u64)>)> =
+                    cell_timing_map.into_iter().collect::<Vec<_>>();
+                vec2.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+                for (cell_name, clock_intervals) in vec2 {
+                    write!(f, "{:?} -- ", cell_name)?;
+                    writeln!(f, "{:?}", clock_intervals)?;
+                }
             }
+            writeln!(f, "")?
         }
-        write!(f, "}}")
+        write!(f, "")
     }
 }
 
 impl StaticParTiming {
     /// Construct a live range analysis.
-    pub fn new(control: &mut ir::Control, comp_name: ir::Id) -> Self {
+    pub fn new(
+        control: &mut ir::Control,
+        comp_name: ir::Id,
+        live: &LiveRangeAnalysis,
+    ) -> Self {
         let mut time_map = StaticParTiming {
             component_name: comp_name,
             ..Default::default()
@@ -64,20 +81,99 @@ impl StaticParTiming {
         // control program hasn't changed, then this is unnecessary)
         ControlId::compute_unique_ids(control, 0, false);
 
-        time_map.build_time_map(control, None);
+        time_map.build_time_map(control, None, live);
 
         time_map
     }
 
+    /// `par_id` is the id of a par thread.
+    /// `thread_a` and `thread_b` are ids of direct children of par_id (if `thread_a` and
+    /// `thread_b` are *not* direct children of par_id, then the function will error)
+    /// `a` and `b` are cell names
+    /// liveness_overlaps checks if the liveness of `a` in `thread_a` ever overlaps
+    /// with the liveness of `b` in `thread_b`
+    /// if `par_id` is not static, then will automtically return true
+    pub fn liveness_overlaps(
+        &self,
+        par_id: &u64,
+        thread_a: &u64,
+        thread_b: &u64,
+        a: &ir::Id,
+        b: &ir::Id,
+    ) -> bool {
+        // unwrapping cell_map data structure, eventually getting to the two vecs
+        // a_liveness, b_liveness, that we actually care about
+        let thread_timing_map = match self.cell_map.get(&par_id) {
+            Some(m) => m,
+            None => return true,
+        };
+        let a_liveness = thread_timing_map
+            .get(&thread_a)
+            .unwrap_or_else(|| {
+                unreachable!("{} not a thread in {}", thread_a, par_id)
+            })
+            .get(&a);
+        let b_liveness = thread_timing_map
+            .get(&thread_b)
+            .unwrap_or_else(|| {
+                unreachable!("{} not a thread in {}", thread_a, par_id)
+            })
+            .get(&b);
+        match (a_liveness, b_liveness) {
+            (Some(a_intervals), Some(b_intervals)) => {
+                let mut a_iter = a_intervals.iter();
+                let mut b_iter = b_intervals.iter();
+                let mut cur_a = a_iter.next();
+                let mut cur_b = b_iter.next();
+                // this relies on the fact that a_iter and b_iter are sorted
+                // in ascending order
+                while cur_a.is_some() && cur_b.is_some() {
+                    match (cur_a.unwrap(), cur_b.unwrap()) {
+                        ((a1, a2), (b1, b2)) => {
+                            // if a1 is smaller, checks if it overlaps with
+                            // b1. If it does, return true, otherwise, advance
+                            // a in the iteration
+                            if a1 < b1 {
+                                if a2 >= b1 {
+                                    return true;
+                                } else {
+                                    cur_a = a_iter.next();
+                                }
+                            }
+                            // same thing we did but in reverse
+                            else if b1 < a1 {
+                                if b2 >= a1 {
+                                    return true;
+                                } else {
+                                    cur_b = b_iter.next();
+                                }
+                            }
+                            // we know a and b are live in the same clock cycle:
+                            // namely, a1 == b1
+                            else {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                false
+            }
+            _ => false,
+        }
+    }
     // Recursively updates self.time_map
     fn build_time_map(
         &mut self,
         c: &ir::Control,
-        // cur_state = Some(parent_par_id, cur_clock) if we're inside a static par, None otherwise.
+        // cur_state = Some(parent_par_id, thread_id, cur_clock) if we're inside a static par, None otherwise.
         // parent_par_id = Node ID of the static par that we're analyzing
+        // thread_id = Node ID of the thread that we're analyzing within the par
+        // note that this thread_id only corresponds to "direct" children
         // cur_clock = current clock cycles we're at relative to the start of parent_par
-        cur_state: Option<(u64, u64)>,
-    ) -> Option<(u64, u64)> {
+        cur_state: Option<(u64, u64, u64)>,
+        // LiveRangeAnalysis instance
+        live: &LiveRangeAnalysis,
+    ) -> Option<(u64, u64, u64)> {
         match c {
             ir::Control::Invoke(_) => {
                 if cur_state.is_some() {
@@ -87,18 +183,48 @@ impl StaticParTiming {
             }
             ir::Control::Empty(_) => cur_state,
             ir::Control::Enable(_) => match cur_state {
-                Some((par_id, cur_clock)) => {
+                Some((par_id, thread_id, cur_clock)) => {
+                    let enable_id = ControlId::get_guaranteed_id(c);
                     // add enable to self.map
                     let latency =
                         ControlId::get_guaranteed_attribute(c, "static");
-                    let enable_id = ControlId::get_guaranteed_id(c);
-                    self.map
-                        .entry(par_id)
-                        .or_default()
-                        .entry(enable_id)
-                        .or_default()
-                        .insert((cur_clock, cur_clock + latency - 1));
-                    Some((par_id, cur_clock + latency))
+                    // live set is all cells live at this enable, organized by cell type
+                    let live_set = live.get(&enable_id).clone();
+                    // go thru all live cells in this enable add them to appropriate entry in
+                    // self.cell_map
+                    for (_, live_cells) in live_set {
+                        for cell in live_cells {
+                            let interval_vec = self
+                                .cell_map
+                                .entry(par_id)
+                                .or_default()
+                                .entry(thread_id)
+                                .or_default()
+                                .entry(cell)
+                                .or_default();
+                            // we need to check whether we've already added this
+                            // to vec before or not. If we haven't,
+                            // then we can push
+                            // This can sometimes occur if there is a par block,
+                            // that contains a while loop, and that while loop
+                            // contains another par block.
+                            match interval_vec.last() {
+                                None => interval_vec
+                                    .push((cur_clock, cur_clock + latency - 1)),
+                                Some(interval) => {
+                                    if *interval
+                                        != (cur_clock, cur_clock + latency - 1)
+                                    {
+                                        interval_vec.push((
+                                            cur_clock,
+                                            cur_clock + latency - 1,
+                                        ))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Some((par_id, thread_id, cur_clock + latency))
                 }
                 None => cur_state,
             },
@@ -106,14 +232,14 @@ impl StaticParTiming {
                 // this works whether or not cur_state is None or Some
                 let mut new_state = cur_state;
                 for stmt in stmts {
-                    new_state = self.build_time_map(stmt, new_state);
+                    new_state = self.build_time_map(stmt, new_state, live);
                 }
                 new_state
             }
             ir::Control::If(ir::If {
                 tbranch, fbranch, ..
             }) => match cur_state {
-                Some((parent_par, cur_clock)) => {
+                Some((parent_par, thread_id, cur_clock)) => {
                     let tbranch_latency =
                         ControlId::get_guaranteed_attribute(tbranch, "static");
                     let fbranch_latency =
@@ -122,15 +248,15 @@ impl StaticParTiming {
                         std::cmp::max(tbranch_latency, fbranch_latency);
                     // we already know parent par + latency of the if stmt, so don't
                     // care about return type: we just want to add enables to the timing map
-                    self.build_time_map(tbranch, cur_state);
-                    self.build_time_map(fbranch, cur_state);
-                    Some((parent_par, cur_clock + max_latency))
+                    self.build_time_map(tbranch, cur_state, live);
+                    self.build_time_map(fbranch, cur_state, live);
+                    Some((parent_par, thread_id, cur_clock + max_latency))
                 }
                 None => {
                     // should still look thru the branches in case there are static pars
                     // inside the branches
-                    self.build_time_map(tbranch, cur_state);
-                    self.build_time_map(fbranch, cur_state);
+                    self.build_time_map(tbranch, cur_state, live);
+                    self.build_time_map(fbranch, cur_state, live);
                     None
                 }
             },
@@ -140,12 +266,12 @@ impl StaticParTiming {
                     // essentially just unrolling the loop
                     let mut new_state = cur_state;
                     for _ in 0..bound {
-                        new_state = self.build_time_map(body, new_state)
+                        new_state = self.build_time_map(body, new_state, live)
                     }
                     new_state
                 } else {
                     // look thru while body for static pars
-                    self.build_time_map(body, cur_state);
+                    self.build_time_map(body, cur_state, live);
                     None
                 }
             }
@@ -155,7 +281,12 @@ impl StaticParTiming {
                     for stmt in stmts {
                         self.build_time_map(
                             stmt,
-                            Some((ControlId::get_guaranteed_id(c), 1)),
+                            Some((
+                                ControlId::get_guaranteed_id(c),
+                                ControlId::get_guaranteed_id(stmt),
+                                1,
+                            )),
+                            live,
                         );
                     }
                     // If we have nested pars, want to get the clock cycles relative
@@ -164,10 +295,10 @@ impl StaticParTiming {
                     // relative to the parent par.
                     // Might be overkill, but trying to keep it general.
                     match cur_state {
-                        Some((cur_parent_par, cur_clock)) => {
+                        Some((cur_parent_par, cur_thread, cur_clock)) => {
                             let mut max_latency = 0;
                             for stmt in stmts {
-                                self.build_time_map(stmt, cur_state);
+                                self.build_time_map(stmt, cur_state, live);
                                 let cur_latency =
                                     ControlId::get_guaranteed_attribute(
                                         stmt, "static",
@@ -175,14 +306,18 @@ impl StaticParTiming {
                                 max_latency =
                                     std::cmp::max(max_latency, cur_latency)
                             }
-                            Some((cur_parent_par, cur_clock + max_latency))
+                            Some((
+                                cur_parent_par,
+                                cur_thread,
+                                cur_clock + max_latency,
+                            ))
                         }
                         None => None,
                     }
                 } else {
                     // look thru par block for static pars
                     for stmt in stmts {
-                        self.build_time_map(stmt, None);
+                        self.build_time_map(stmt, None, live);
                     }
                     None
                 }

--- a/calyx/src/analysis/static_par_timing.rs
+++ b/calyx/src/analysis/static_par_timing.rs
@@ -1,10 +1,9 @@
+use super::LiveRangeAnalysis;
 use crate::{
     analysis::ControlId,
     ir::{self},
 };
 use std::{collections::HashMap, fmt::Debug};
-
-use super::LiveRangeAnalysis;
 
 /// maps cell names to a vector of tuples (i,j), which is the clock
 /// cycles (relative to the start of the par) that enable is live

--- a/calyx/src/analysis/static_par_timing.rs
+++ b/calyx/src/analysis/static_par_timing.rs
@@ -1,295 +1,161 @@
 use crate::{
-    analysis::{ControlId, ReadWriteSet, ShareSet, VariableDetection},
-    ir::{self, CloneName, Id, RRC},
+    analysis::ControlId,
+    ir::{self},
 };
-use itertools::Itertools;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
-    rc::Rc,
 };
 
-/// The data structure used to represent sets of ids. This is used to represent
-/// the `live`, `gen`, and `kill` sets.
-#[derive(Default, Clone)]
-pub struct Prop {
-    map: CellsByType,
+/// maps the ids of groups to a set of tuples (i,j), the clock cycles (relative
+/// to the start of the par) that group is live
+type ParTimingMap = HashMap<u64, HashSet<(u64, u64)>>;
+
+///
+#[derive(Default)]
+pub struct StaticParTiming {
+    /// Map from from ids of par blocks to par_timing_maps
+    map: HashMap<u64, ParTimingMap>,
+    component_name: ir::Id,
 }
 
-/// Implement nice printing for prop for debugging purposes.
-impl Debug for Prop {
+impl Debug for StaticParTiming {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{")?;
-        let names = self.map.iter().flat_map(|(_, ids)| ids).join(", ");
-        write!(f, "{}", names)?;
+        //must sort the hashmap and hashsets in order to get consistent ordering
+        writeln!(
+            f,
+            "This maps ids of par blocks to \" par timing maps \", which map group ids to intervals (i,j), that signify the clock cycles the group is active for, \n relative to the start of the given par block"
+        )?;
+        write!(f, "======== Map for Component \"{}\"", self.component_name)?;
+        writeln!(f, " ========")?;
+        let map = self.map.clone();
+        let mut vec: Vec<(u64, ParTimingMap)> = map.into_iter().collect();
+        vec.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+        for (par_id, par_timing_map) in vec.into_iter() {
+            write!(f, "====")?;
+            write!(f, "Par Node ID: {:?}", par_id)?;
+            writeln!(f, "====")?;
+            let mut vec1: Vec<(u64, HashSet<(u64, u64)>)> =
+                par_timing_map.into_iter().collect::<Vec<_>>();
+            vec1.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+            for (group_id, clock_intervals) in vec1 {
+                write!(f, "Group Node ID: {:?} --", group_id)?;
+                let mut vec2: Vec<(u64, u64)> =
+                    clock_intervals.into_iter().collect();
+                vec2.sort_unstable();
+                writeln!(f, " {:?}", vec2)?;
+            }
+        }
         write!(f, "}}")
     }
 }
 
-impl Prop {
-    /// Defines the dataflow transfer function.
-    /// We use the standard definition for liveness:
-    /// `(alive - kill) + gen`
-    fn transfer(&mut self, gen: Prop, kill: Prop) {
-        self.sub(kill);
-        self.or(gen);
-    }
-
-    /// Defines the data_flow transfer function. `(alive - kill) + gen`.
-    /// However, this is for when gen and kill are sets, and self is a map.
-    fn transfer_set(&mut self, gen: TypeNameSet, kill: TypeNameSet) {
-        self.sub_set(kill);
-        self.or_set(gen);
-    }
-
-    // The or operation, but when the self is a map and rhs is a set of tuples.
-    fn or_set(&mut self, rhs: TypeNameSet) {
-        for (cell_type, cell_name) in rhs {
-            self.map.entry(cell_type).or_default().insert(cell_name);
-        }
-    }
-
-    // The sub operation, but when the self is a map and rhs is a set of tuples.
-    fn sub_set(&mut self, rhs: TypeNameSet) {
-        for (cell_type, cell_name) in rhs {
-            self.map.entry(cell_type).or_default().remove(&cell_name);
-        }
-    }
-
-    // edits self to equal self | rhs. Faster than self | rhs  but must take rhs
-    // ownership and not &rhs.
-    fn or(&mut self, rhs: Prop) {
-        for (cell_type, cell_names) in rhs.map {
-            self.map.entry(cell_type).or_default().extend(cell_names);
-        }
-    }
-
-    // edits self to equal self intersect rhs. Must take ownership of rhs
-    // ownership and not &rhs.
-    fn intersect(&mut self, mut rhs: Prop) {
-        for (cell_type, cell_names) in self.map.iter_mut() {
-            let empty_hash = HashSet::new();
-            let entry: HashSet<Id> =
-                rhs.map.remove(cell_type).unwrap_or(empty_hash);
-            cell_names.retain(|cell| entry.contains(cell));
-        }
-    }
-
-    // edits self to equal self - rhs. Faster than self - rhs  but must take rhs
-    // ownership and not &rhs.
-    fn sub(&mut self, rhs: Prop) {
-        for (cell_type, cell_names) in rhs.map {
-            self.map
-                .entry(cell_type)
-                .or_default()
-                .retain(|cell| !cell_names.contains(cell));
-        }
-    }
-}
-
-/// This analysis implements a parallel version of a classic liveness analysis.
-/// For each group or invoke, it returns a list of the state shareable cells
-/// that are "alive" during an execution of a group or invoke statement (we
-/// identify an invoke statement by the cell that is being invoked, and groups
-/// by the name of the group).
-///
-/// ## Parallel Analog to a CFG
-/// The `par` statement introduces a new kind of control branching that can
-/// not be captured by a traditional CFG.
-///
-/// Consider whether `x` is alive at `foo` in the following program.
-/// ```
-/// seq {
-///   wr_x; // writes register x
-///   foo;
-///   par {
-///     wr_x2; // writes register x
-///     bar;
-///   }
-///   rd_x; // reads register x
-/// }
-/// ```
-/// `x` is not alive at `foo` because there are no reads to `x` before
-/// `wr_x2` is executed which writes to `x` again. Note that `wr_x2` is always
-/// executed.
-///
-/// We might try and represent the `par` branching with a normal CFG like this:
-/// ```
-///       +------+
-///       | wr_x |
-///       +--+---+
-///          |
-///          v
-///       +--+--+
-///    +--+ foo +--+
-///    |  +-----+  |
-///    |           |
-///    v           v
-/// +--+----+   +--+--+
-/// | wr_x2 |   | bar |
-/// +--+----+   +--+--+
-///    |           |
-///    +------+----+
-///           |
-///           v
-///       +------+
-///       | rd_x |
-///       +------+
-/// ```
-/// But then this program is identical to
-/// ```
-/// seq {
-///   wr_x; // writes register x
-///   foo;
-///   if blah.out with B {
-///     wr_x2; // writes register x
-///   } else {
-///     bar;
-///   }
-///   rd_x; // reads register x
-/// }
-/// ```
-/// which has different semantics. In particular `x` is still alive at `foo` because
-/// `wr_x2` may not be executed.
-///
-/// We need to augment the traditional CFG to account for `par`.
-///
-/// ## A Parallel CFG
-/// The representation should:
-///  1) Have the same properties as a normal CFG when no parallelism is present.
-///  2) Threads of a `par` block should not have to know that they are in a `par` (i.e. are just CFGs themselves)
-///  3) External to the `par` block, the information of running all threads in `par` should be visible.
-///
-/// To address these concerns, we use a parallel CFG (pCFG) based on
-/// [Analyzing programs with explicit parallelism](https://link.springer.com/chapter/10.1007%2FBFb0038679).
-/// We introduce a new kind of node in the CFG called a `par node`. A `par node` represents an entire
-/// `par` block. The above program with `par` would look like:
-/// ```
-/// +------+
-/// | wr_x |
-/// +--+---+
-///    |
-///    v
-/// +--+--+
-/// | foo |
-/// +--+--+
-///    |
-///    v
-/// +--+---+
-/// | par1 |
-/// +--+---+
-///    |
-///    v
-/// +--+---+
-/// | rd_x |
-/// +------+
-/// ```
-/// For each `par node`, we associate a list of pCFGs where each pCFG represents a thread.
-/// Each thread starts with a `begin par` node and ends with a `end par` node.
-///
-/// These are the graphs associated with `par1`.
-/// ```
-/// First thread:    Second thread:
-/// +----------+      +----------+
-/// |begin par1|      |begin par1|
-/// +--+-------+      +-+--------+
-///    |                |
-///    v                v
-/// +--+--+           +-+-+
-/// |wr_x2|           |bar|
-/// +--+--+           +-+-+
-///    |                |
-///    v                v
-/// +--+-----+        +-+------+
-/// |end par1|        |end par1|
-/// +--------+        +--------+
-/// ```
-///
-/// The idea with the `begin/end parx` nodes is that these will handle the flow
-/// of information in and out of the threads. For example, you could write these equations:
-/// ```
-/// out(begin par1) = in(par1)
-/// out(par1) = join over all in(end par1)
-/// ```
-///
-/// ## Definition of Liveness
-/// Now we finally come to the definition of "liveness" and how we use the pCFG to compute this.
-///
-/// We say a cell `x` is "live" at a node `p` in the CFG if there is a write to `x` ordered before
-/// `p` (such that there are no more writes to `x` at a point between that and `p`) and if there is a read
-/// of `x` ordered after `p` (such that there are no writes between that and `p`).
-///
-/// We define the following equations (assuming a reversed direction dataflow analysis):
-/// ```
-/// for some node n:
-///   gen(n) = registers that may be read in n
-///   kill(n) = register that must be written to in n
-///   live_in(n) = union over live_out(pred(n))
-///   live_out(n) = (live_in(n) - kill(n)) + gen(n)
-/// for some par node p:
-///   gen(p) = union over gen(n) for sub-nodes n in p
-///   kill(p) = union over kill(n) for sub-nodes n in p
-///   live_in(p) = union over live_out(pred(p))
-///   live_out(p) = (live_in(p) - kill(p)) + gen(p)
-/// ```
-/// The main place this analysis differs from traditional liveness analysis
-/// is the definition of `gen(p)` and `kill(p)` for `par` nodes. These are the
-/// union of the `gen`s and `kill`s of all of their sub-nodes. Intuitively we
-/// are treating `par` blocks as if they were just a single group. Note that this
-/// is overly conservative because we are potentially ignoring ordering
-/// information of the threads.
-#[derive(Default)]
-pub struct LiveRangeAnalysis {
-    /// Map from node ids (i.e., group enables or invokes) names
-    /// to the components live inside them.
-    live: HashMap<u64, Prop>,
-    /// Groups that have been identified as variable-like.
-    /// Mapping from group name to Some(type, name) where type is the cell type and
-    /// name is the cell name. If group is not variable like, maps to None.
-    variable_like: HashMap<ir::Id, Option<(ir::CellType, ir::Id)>>,
-    /// Set of state shareable components (as type names)
-    state_share: ShareSet,
-    /// Set of shareable components (as type names)
-    share: ShareSet,
-    /// maps invokes/enable ids to the shareable cell types/names live in them
-    invokes_enables_map: HashMap<u64, TypeNameSet>,
-    /// maps comb groups of if/while statements to the cell types/
-    /// names used in them
-    cgroup_uses_map: HashMap<u64, TypeNameSet>,
-}
-
-impl LiveRangeAnalysis {
+impl StaticParTiming {
     /// Construct a live range analysis.
-    pub fn new(
-        control: &mut ir::Control,
-        state_share: ShareSet,
-        share: ShareSet,
-    ) -> Self {
-        let mut ranges = LiveRangeAnalysis {
-            state_share,
-            share,
+    pub fn new(control: &mut ir::Control, comp_name: ir::Id) -> Self {
+        let mut time_map = StaticParTiming {
+            component_name: comp_name,
             ..Default::default()
         };
 
-        // Give each control statement a unique "NODE_ID" attribute.
+        // compute_unique_ids should give same id labeling if the control is the same
         ControlId::compute_unique_ids(control, 0, false);
 
-        ranges.build_live_ranges(
-            control,
-            Prop::default(),
-            Prop::default(),
-            Prop::default(),
-        );
+        time_map.build_time_map(control, None, 1);
 
-        for (node, cells_by_type) in &ranges.invokes_enables_map {
-            if let Some(prop) = ranges.live.get_mut(node) {
-                prop.or_set(cells_by_type.clone());
+        time_map
+    }
+
+    fn build_time_map(
+        &mut self,
+        c: &ir::Control,
+        cur_parent_par: Option<u64>,
+        cur_clock: u64,
+    ) -> u64 {
+        match c {
+            ir::Control::Invoke(_) => {
+                if cur_parent_par.is_some() {
+                    unreachable!("no static guarantees for invoke")
+                }
+                0
+            }
+            ir::Control::Empty(_) => cur_clock,
+            ir::Control::Enable(_) => match cur_parent_par {
+                Some(par_id) => {
+                    let latency =
+                        ControlId::get_guaranteed_attribute(c, "static");
+                    let enable_id = ControlId::get_guaranteed_id(c);
+                    self.map
+                        .entry(par_id)
+                        .or_default()
+                        .entry(enable_id)
+                        .or_default()
+                        .insert((cur_clock, cur_clock + latency - 1));
+                    cur_clock + latency
+                }
+                None => 0,
+            },
+            ir::Control::Seq(ir::Seq { stmts, .. }) => {
+                let mut new_clock = cur_clock;
+                for stmt in stmts {
+                    new_clock =
+                        self.build_time_map(stmt, cur_parent_par, new_clock);
+                }
+                new_clock
+            }
+            ir::Control::If(ir::If {
+                tbranch, fbranch, ..
+            }) => {
+                let tbranch_new_clock =
+                    self.build_time_map(tbranch, cur_parent_par, cur_clock);
+                let fbranch_new_clock =
+                    self.build_time_map(fbranch, cur_parent_par, cur_clock);
+                std::cmp::max(tbranch_new_clock, fbranch_new_clock)
+            }
+            ir::Control::While(ir::While { body, .. }) => {
+                let bound = ControlId::get_guaranteed_attribute(c, "bound");
+                // might be inefficient bc we're basically just unrolling the
+                // loop
+                let mut new_clock = cur_clock;
+                for _ in 0..bound {
+                    new_clock =
+                        self.build_time_map(body, cur_parent_par, new_clock)
+                }
+                new_clock
+            }
+            ir::Control::Par(ir::Par { stmts, attributes }) => {
+                if attributes.get("static").is_some() {
+                    for stmt in stmts {
+                        self.build_time_map(
+                            stmt,
+                            Some(ControlId::get_guaranteed_id(c)),
+                            1,
+                        );
+                    }
+                    // If we have nested pars, want to get the clock cycles relative
+                    // to the start of both par blocks. This is possibly overkill,
+                    // but trying to keep it general.
+                    if cur_parent_par.is_some() {
+                        let mut max_clock = cur_clock;
+                        for stmt in stmts {
+                            let new_clock = self.build_time_map(
+                                stmt,
+                                cur_parent_par,
+                                cur_clock,
+                            );
+                            max_clock = std::cmp::max(max_clock, new_clock);
+                        }
+                        max_clock
+                    } else {
+                        0
+                    }
+                } else {
+                    for stmt in stmts {
+                        self.build_time_map(stmt, None, 0);
+                    }
+                    0
+                }
             }
         }
-
-        // LivRangeAnalysis does not handle comb groups currently. Eventually, we want to and make
-        // remove-comb-groups optional.
-
-        ranges
     }
 }

--- a/calyx/src/passes/cell_share.rs
+++ b/calyx/src/passes/cell_share.rs
@@ -237,8 +237,6 @@ impl CellShare {
             })
             .collect();
 
-        let print_par_timing = Self::get_opts(&["print_par_timing"], ctx)[0];
-
         // searching for "-x cell-share:bounds=x,y,z" and getting back "x,y,z"
         let bounds_arg = given_opts.iter().find_map(|arg| {
             let split: Vec<&str> = arg.split('=').collect();
@@ -249,6 +247,9 @@ impl CellShare {
             }
             None
         });
+
+        let print_par_timing =
+            given_opts.iter().any(|arg| *arg == "print_par_timing");
 
         // searching for "-x cell-share:print-share-freqs=file_name" and getting Some(file_name) back
         let print_pdf_arg = given_opts.iter().find_map(|arg| {

--- a/calyx/src/passes/cell_share.rs
+++ b/calyx/src/passes/cell_share.rs
@@ -426,13 +426,14 @@ impl Visitor for CellShare {
                                     par_thread_map.get(live_a).unwrap();
                                 let parent_b =
                                     par_thread_map.get(live_b).unwrap();
-                                if live_a != live_b && parent_a == parent_b {
-                                    if self.par_timing_map.liveness_overlaps(
+                                if live_a != live_b
+                                    && parent_a == parent_b
+                                    && self.par_timing_map.liveness_overlaps(
                                         parent_a, live_a, live_b, a, b,
-                                    ) {
-                                        g.insert_conflict(a, b);
-                                        break 'outer;
-                                    }
+                                    )
+                                {
+                                    g.insert_conflict(a, b);
+                                    break 'outer;
                                 }
                             }
                         }

--- a/calyx/src/passes/cell_share.rs
+++ b/calyx/src/passes/cell_share.rs
@@ -231,10 +231,8 @@ impl CellShare {
             })
             .collect();
 
-        let print_par_timing = given_opts
-            .iter()
-            .find(|arg| **arg == "print_par_timing")
-            .is_some();
+        let print_par_timing =
+            given_opts.iter().any(|arg| *arg == "print_par_timing");
 
         // searching for "-x cell-share:bounds=x,y,z" and getting back "x,y,z"
         let bounds_arg = given_opts.iter().find_map(|arg| {

--- a/tests/passes/cell-share/static-par.expect
+++ b/tests/passes/cell-share/static-par.expect
@@ -1,0 +1,73 @@
+import "primitives/core.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    lt = std_lt(32);
+    a = std_reg(32);
+    b = std_reg(32);
+    c = std_reg(16);
+    d = std_reg(16);
+    x = std_reg(4);
+    sl = std_slice(16, 4);
+  }
+  wires {
+    group wr_a {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      wr_a[done] = a.done;
+    }
+    group wr_b {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      wr_b[done] = a.done;
+    }
+    group wr_x {
+      x.write_en = 1'd1;
+      x.in = 4'd2;
+      wr_x[done] = x.done;
+    }
+    group wr_c {
+      c.write_en = 1'd1;
+      c.in = 16'd4;
+      wr_c[done] = c.done;
+    }
+    group wr_d {
+      d.write_en = 1'd1;
+      d.in = 16'd4;
+      wr_d[done] = d.done;
+    }
+    group read_c {
+      sl.in = c.out;
+      x.write_en = 1'd1;
+      x.in = sl.out;
+      read_c[done] = x.done;
+    }
+  }
+
+  control {
+    seq {
+      @static(3) par {
+        @static if lt.out {
+          @static wr_a;
+        } else {
+          @static wr_b;
+        }
+        @static(2) seq {
+          @static wr_x;
+          @static wr_b;
+        }
+      }
+      @static(3) par {
+        @static(3) seq {
+          @static wr_c;
+          @static wr_x;
+          @static read_c;
+        }
+        @static(3) seq {
+          @static wr_x;
+          @static wr_d;
+          @static wr_x;
+        }
+      }
+    }
+  }
+}

--- a/tests/passes/cell-share/static-par.futil
+++ b/tests/passes/cell-share/static-par.futil
@@ -1,0 +1,76 @@
+// -p cell-share -p remove-ids
+import "primitives/core.futil";
+component main() -> () {
+  cells {
+    lt = std_lt(32);
+    a = std_reg(32);
+    b = std_reg(32);
+    c = std_reg(16);
+    d = std_reg(16); 
+    x = std_reg(4);
+    sl = std_slice(16, 4);
+  }
+  wires {
+    group wr_a{
+      a.write_en = 1'd1; 
+      a.in = 32'd2; 
+      wr_a[done] = a.done; 
+    }
+    group wr_b{
+      b.write_en = 1'd1; 
+      b.in = 32'd2; 
+      wr_b[done] = b.done; 
+    }
+    group wr_x{
+      x.write_en = 1'd1; 
+      x.in = 4'd2; 
+      wr_x[done] = x.done;
+    }
+    group wr_c{
+      c.write_en = 1'd1; 
+      c.in = 16'd4; 
+      wr_c[done] = c.done; 
+    }
+    group wr_d{
+      d.write_en = 1'd1;
+      d.in = 16'd4; 
+      wr_d[done] = d.done; 
+    }
+    group read_c{
+      sl.in = c.out; 
+      x.write_en = 1'd1; 
+      x.in = sl.out; 
+      read_c[done] = x.done; 
+    }
+  }
+  control {
+    seq{
+      // a and b should be shared, never will be live at same time 
+      @static(3) par{
+        @static if lt.out{
+          @static wr_a;
+        }
+        else{
+          @static wr_b; 
+        }
+        @static(2) seq{
+          @static wr_x; 
+          @static wr_b;
+        }
+      }
+      // c and d shouldn't shared 
+      @static(3) par{
+        @static(3) seq{
+          @static wr_c; 
+          @static wr_x;
+          @static read_c;
+        }
+        @static(3) seq{
+          @static wr_x; 
+          @static wr_d;
+          @static wr_x; 
+        }
+      }
+    }
+  }
+}

--- a/tests/passes/par-timing-map/nested-par.expect
+++ b/tests/passes/par-timing-map/nested-par.expect
@@ -1,4 +1,4 @@
-This maps ids of par blocks to " par timing maps ", which map group ids to intervals (i,j), that signify the clock cycles the group is active for, 
+This maps ids of par blocks to " par timing maps ", which map enable ids to intervals (i,j), that signify the clock cycles the group is active for, 
  relative to the start of the given par block
 ======== Map for Component "main" ========
 ====Par Node ID: 0====

--- a/tests/passes/par-timing-map/nested-par.expect
+++ b/tests/passes/par-timing-map/nested-par.expect
@@ -1,0 +1,79 @@
+This maps ids of par blocks to " par timing maps ", which map group ids to intervals (i,j), that signify the clock cycles the group is active for, 
+ relative to the start of the given par block
+======== Map for Component "main" ========
+====Par Node ID: 0====
+Group Node ID: 2 -- [(1, 4)]
+Group Node ID: 3 -- [(5, 8)]
+Group Node ID: 4 -- [(9, 12)]
+Group Node ID: 6 -- [(1, 1)]
+Group Node ID: 9 -- [(2, 5)]
+Group Node ID: 10 -- [(6, 9)]
+Group Node ID: 12 -- [(2, 3)]
+Group Node ID: 13 -- [(4, 5)]
+Group Node ID: 14 -- [(10, 10)]
+Group Node ID: 17 -- [(1, 1), (3, 3), (5, 5), (7, 7)]
+Group Node ID: 18 -- [(2, 2), (4, 4), (6, 6), (8, 8)]
+====Par Node ID: 7====
+Group Node ID: 9 -- [(1, 4)]
+Group Node ID: 10 -- [(5, 8)]
+Group Node ID: 12 -- [(1, 2)]
+Group Node ID: 13 -- [(3, 4)]
+}
+import "primitives/core.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    lt = std_lt(32);
+  }
+  wires {
+    group A {
+    }
+    group B {
+    }
+    group C {
+    }
+    group D {
+    }
+    group E {
+    }
+    group F {
+    }
+    group G {
+    }
+    group H {
+    }
+    group I {
+    }
+    group J {
+    }
+  }
+
+  control {
+    @static(12) @NODE_ID(0) par {
+      @static(12) @NODE_ID seq {
+        @static(4) @NODE_ID(2) A;
+        @static(4) @NODE_ID(3) B;
+        @static(4) @NODE_ID(4) C;
+      }
+      @static(10) @NODE_ID(5) seq {
+        @static @NODE_ID(6) D;
+        @static(8) @NODE_ID(7) par {
+          @static(8) @NODE_ID(8) seq {
+            @static(4) @NODE_ID(9) E;
+            @static(4) @NODE_ID(10) F;
+          }
+          @static(4) @NODE_ID(11) seq {
+            @static(2) @NODE_ID(12) G;
+            @static(2) @NODE_ID(13) H;
+          }
+        }
+        @static @NODE_ID(14) D;
+      }
+      @bound(4) @NODE_ID(15) while lt.out {
+        @static(2) @NODE_ID(16) seq {
+          @static @NODE_ID(17) I;
+          @static @NODE_ID(18) J;
+        }
+      }
+    }
+  }
+}

--- a/tests/passes/par-timing-map/nested-par.expect
+++ b/tests/passes/par-timing-map/nested-par.expect
@@ -1,49 +1,95 @@
-This maps ids of par blocks to " par timing maps ", which map enable ids to intervals (i,j), that signify the clock cycles the group is active for, 
+This maps ids of par blocks to " cell timing maps ", which map cells to intervals (i,j), that signify the clock cycles the group is active for, 
  relative to the start of the given par block
-======== Map for Component "main" ========
-====Par Node ID: 0====
-Group Node ID: 2 -- [(1, 4)]
-Group Node ID: 3 -- [(5, 8)]
-Group Node ID: 4 -- [(9, 12)]
-Group Node ID: 6 -- [(1, 1)]
-Group Node ID: 9 -- [(2, 5)]
-Group Node ID: 10 -- [(6, 9)]
-Group Node ID: 12 -- [(2, 3)]
-Group Node ID: 13 -- [(4, 5)]
-Group Node ID: 14 -- [(10, 10)]
-Group Node ID: 17 -- [(1, 1), (3, 3), (5, 5), (7, 7)]
-Group Node ID: 18 -- [(2, 2), (4, 4), (6, 6), (8, 8)]
-====Par Node ID: 7====
-Group Node ID: 9 -- [(1, 4)]
-Group Node ID: 10 -- [(5, 8)]
-Group Node ID: 12 -- [(1, 2)]
-Group Node ID: 13 -- [(3, 4)]
-}
+============ Map for Component "main" ============
+========Par Node ID: 0 ========
+====Child/Thread ID: 1 ====
+Id { id: "a" } -- [(1, 4)]
+Id { id: "b" } -- [(5, 8)]
+Id { id: "c" } -- [(9, 12)]
+====Child/Thread ID: 5 ====
+Id { id: "d" } -- [(1, 1), (10, 10)]
+Id { id: "e" } -- [(2, 5)]
+Id { id: "f" } -- [(6, 9)]
+Id { id: "g" } -- [(2, 3)]
+Id { id: "h" } -- [(4, 5)]
+====Child/Thread ID: 15 ====
+Id { id: "i" } -- [(1, 1), (3, 3), (5, 5), (7, 7)]
+Id { id: "j" } -- [(2, 2), (4, 4), (6, 6), (8, 8)]
+
+========Par Node ID: 7 ========
+====Child/Thread ID: 8 ====
+Id { id: "e" } -- [(1, 4)]
+Id { id: "f" } -- [(5, 8)]
+====Child/Thread ID: 11 ====
+Id { id: "g" } -- [(1, 2)]
+Id { id: "h" } -- [(3, 4)]
+
+
 import "primitives/core.futil";
 component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     lt = std_lt(32);
+    a = std_reg(32);
+    b = std_reg(32);
+    c = std_reg(32);
+    d = std_reg(32);
+    e = std_reg(32);
+    f = std_reg(32);
+    g = std_reg(32);
+    h = std_reg(32);
+    i = std_reg(32);
+    j = std_reg(32);
   }
   wires {
     group A {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      A[done] = a.done;
     }
     group B {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      B[done] = a.done;
     }
     group C {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      C[done] = a.done;
     }
     group D {
+      d.write_en = 1'd1;
+      d.in = 32'd2;
+      D[done] = d.done;
     }
     group E {
+      d.write_en = 1'd1;
+      d.in = 32'd2;
+      E[done] = d.done;
     }
     group F {
+      d.write_en = 1'd1;
+      d.in = 32'd2;
+      F[done] = d.done;
     }
     group G {
+      g.write_en = 1'd1;
+      g.in = 32'd2;
+      G[done] = g.done;
     }
     group H {
+      g.write_en = 1'd1;
+      g.in = 32'd2;
+      H[done] = g.done;
     }
     group I {
+      i.write_en = 1'd1;
+      i.in = 32'd2;
+      I[done] = i.done;
     }
     group J {
+      i.write_en = 1'd1;
+      i.in = 32'd2;
+      J[done] = i.done;
     }
   }
 

--- a/tests/passes/par-timing-map/nested-par.futil
+++ b/tests/passes/par-timing-map/nested-par.futil
@@ -1,0 +1,44 @@
+// -p cell-share -x cell-share:print_par_timing
+import "primitives/core.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    lt = std_lt(32);
+  }
+  wires {
+    group A{
+    }
+    group B{
+    }
+    group C{
+    }
+    group D{
+    }
+    group E{
+    }
+    group F{
+    }
+    group G{
+    }
+    group H{
+    }
+    group I{
+    }
+    group J{
+    }
+  }
+
+  control {
+    @static(12) par {
+      @static(12) seq { @static(4) A; @static(4) B; @static(4) C;}
+      @static(10) seq { 
+        @static D; 
+        @static(8) par{ 
+            @static(8) seq {@static(4) E; @static(4) F;} 
+            @static(4) seq {@static(2) G; @static(2) H;} 
+        } 
+        @static D;
+      }
+      @bound(4) while lt.out {@static(2) seq{ @static I; @static J;}}
+    }
+  }
+}

--- a/tests/passes/par-timing-map/nested-par.futil
+++ b/tests/passes/par-timing-map/nested-par.futil
@@ -3,30 +3,69 @@ import "primitives/core.futil";
 component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     lt = std_lt(32);
+    a = std_reg(32);
+    b = std_reg(32);
+    c = std_reg(32);
+    d = std_reg(32);
+    e = std_reg(32);
+    f = std_reg(32);
+    g = std_reg(32);
+    h = std_reg(32);
+    i = std_reg(32);
+    j = std_reg(32);
   }
   wires {
     group A{
+      a.write_en = 1'd1; 
+      a.in = 32'd2; 
+      A[done] = a.done;
     }
     group B{
+      b.write_en = 1'd1; 
+      b.in = 32'd2; 
+      B[done] = b.done;
     }
     group C{
+      c.write_en = 1'd1; 
+      c.in = 32'd2; 
+      C[done] = c.done;  
     }
     group D{
+      d.write_en = 1'd1; 
+      d.in = 32'd2; 
+      D[done] = d.done;
     }
     group E{
+      e.write_en = 1'd1; 
+      e.in = 32'd2; 
+      E[done] = e.done;
     }
     group F{
+      f.write_en = 1'd1; 
+      f.in = 32'd2; 
+      F[done] = f.done;
     }
     group G{
+      g.write_en = 1'd1; 
+      g.in = 32'd2; 
+      G[done] = g.done;
     }
-    group H{
+    group H {
+      h.write_en = 1'd1; 
+      h.in = 32'd2; 
+      H[done] = h.done;
     }
-    group I{
+    group I {
+      i.write_en = 1'd1; 
+      i.in = 32'd2; 
+      I[done] = i.done;
     }
-    group J{
+    group J {
+      j.write_en = 1'd1; 
+      j.in = 32'd2; 
+      J[done] = j.done;
     }
   }
-
   control {
     @static(12) par {
       @static(12) seq { @static(4) A; @static(4) B; @static(4) C;}

--- a/tests/passes/par-timing-map/nested-while.expect
+++ b/tests/passes/par-timing-map/nested-while.expect
@@ -1,4 +1,4 @@
-This maps ids of par blocks to " par timing maps ", which map group ids to intervals (i,j), that signify the clock cycles the group is active for, 
+This maps ids of par blocks to " par timing maps ", which map enable ids to intervals (i,j), that signify the clock cycles the group is active for, 
  relative to the start of the given par block
 ======== Map for Component "main" ========
 ====Par Node ID: 1====

--- a/tests/passes/par-timing-map/nested-while.expect
+++ b/tests/passes/par-timing-map/nested-while.expect
@@ -1,0 +1,62 @@
+This maps ids of par blocks to " par timing maps ", which map group ids to intervals (i,j), that signify the clock cycles the group is active for, 
+ relative to the start of the given par block
+======== Map for Component "main" ========
+====Par Node ID: 1====
+Group Node ID: 7 -- [(1, 3), (12, 14), (23, 25), (38, 40), (49, 51), (60, 62)]
+Group Node ID: 8 -- [(1, 3), (12, 14), (23, 25), (38, 40), (49, 51), (60, 62)]
+Group Node ID: 10 -- [(4, 7), (8, 11), (15, 18), (19, 22), (26, 29), (30, 33), (41, 44), (45, 48), (52, 55), (56, 59), (63, 66), (67, 70)]
+Group Node ID: 11 -- [(34, 37), (71, 74)]
+====Par Node ID: 6====
+Group Node ID: 7 -- [(1, 3)]
+Group Node ID: 8 -- [(1, 3)]
+}
+import "primitives/core.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    lt = std_lt(32);
+  }
+  wires {
+    group A {
+    }
+    group B {
+    }
+    group C {
+    }
+    group D {
+    }
+    group E {
+    }
+    group F {
+    }
+    group G {
+    }
+  }
+
+  control {
+    @NODE_ID(0) seq {
+      @static(74) @NODE_ID par {
+        @bound(2) @NODE_ID(2) while lt.out {
+          @NODE_ID(3) seq {
+            @bound(3) @NODE_ID(4) while lt.out {
+              @static(11) @NODE_ID(5) seq {
+                @static(3) @NODE_ID(6) par {
+                  @static(3) @NODE_ID(7) A;
+                  @static(3) @NODE_ID(8) B;
+                }
+                @bound(2) @NODE_ID(9) while lt.out {
+                  @static(4) @NODE_ID(10) C;
+                }
+              }
+            }
+            @static(4) @NODE_ID(11) D;
+          }
+        }
+      }
+      @static(12) @NODE_ID(12) seq {
+        @static(4) @NODE_ID(13) E;
+        @static(4) @NODE_ID(14) F;
+        @static(4) @NODE_ID(15) G;
+      }
+    }
+  }
+}

--- a/tests/passes/par-timing-map/nested-while.expect
+++ b/tests/passes/par-timing-map/nested-while.expect
@@ -1,34 +1,67 @@
-This maps ids of par blocks to " par timing maps ", which map enable ids to intervals (i,j), that signify the clock cycles the group is active for, 
+This maps ids of par blocks to " cell timing maps ", which map cells to intervals (i,j), that signify the clock cycles the group is active for, 
  relative to the start of the given par block
-======== Map for Component "main" ========
-====Par Node ID: 1====
-Group Node ID: 7 -- [(1, 3), (12, 14), (23, 25), (38, 40), (49, 51), (60, 62)]
-Group Node ID: 8 -- [(1, 3), (12, 14), (23, 25), (38, 40), (49, 51), (60, 62)]
-Group Node ID: 10 -- [(4, 7), (8, 11), (15, 18), (19, 22), (26, 29), (30, 33), (41, 44), (45, 48), (52, 55), (56, 59), (63, 66), (67, 70)]
-Group Node ID: 11 -- [(34, 37), (71, 74)]
-====Par Node ID: 6====
-Group Node ID: 7 -- [(1, 3)]
-Group Node ID: 8 -- [(1, 3)]
-}
+============ Map for Component "main" ============
+========Par Node ID: 1 ========
+====Child/Thread ID: 2 ====
+Id { id: "a" } -- [(1, 3), (12, 14), (23, 25), (38, 40), (49, 51), (60, 62)]
+Id { id: "b" } -- [(1, 3), (12, 14), (23, 25), (38, 40), (49, 51), (60, 62)]
+Id { id: "c" } -- [(4, 7), (8, 11), (15, 18), (19, 22), (26, 29), (30, 33), (41, 44), (45, 48), (52, 55), (56, 59), (63, 66), (67, 70)]
+Id { id: "d" } -- [(34, 37), (71, 74)]
+
+========Par Node ID: 6 ========
+====Child/Thread ID: 7 ====
+Id { id: "a" } -- [(1, 3)]
+====Child/Thread ID: 8 ====
+Id { id: "b" } -- [(1, 3)]
+
+
 import "primitives/core.futil";
 component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     lt = std_lt(32);
+    a = std_reg(32);
+    b = std_reg(32);
+    c = std_reg(32);
+    d = std_reg(32);
+    e = std_reg(32);
+    f = std_reg(32);
+    g = std_reg(32);
   }
   wires {
     group A {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      A[done] = a.done;
     }
     group B {
+      b.write_en = 1'd1;
+      b.in = 32'd2;
+      B[done] = b.done;
     }
     group C {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      C[done] = a.done;
     }
     group D {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      D[done] = a.done;
     }
     group E {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      E[done] = a.done;
     }
     group F {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      F[done] = a.done;
     }
     group G {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      G[done] = a.done;
     }
   }
 

--- a/tests/passes/par-timing-map/nested-while.futil
+++ b/tests/passes/par-timing-map/nested-while.futil
@@ -3,21 +3,49 @@ import "primitives/core.futil";
 component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     lt = std_lt(32);
+    a = std_reg(32);
+    b = std_reg(32);
+    c = std_reg(32);
+    d = std_reg(32);
+    e = std_reg(32);
+    f = std_reg(32);
+    g = std_reg(32);
   }
   wires {
     group A{
+      a.write_en = 1'd1; 
+      a.in = 32'd2; 
+      A[done] = a.done;
     }
     group B{
+      b.write_en = 1'd1; 
+      b.in = 32'd2; 
+      B[done] = b.done;
     }
     group C{
+      c.write_en = 1'd1; 
+      c.in = 32'd2; 
+      C[done] = c.done;  
     }
     group D{
+      d.write_en = 1'd1; 
+      d.in = 32'd2; 
+      D[done] = d.done;
     }
     group E{
+      e.write_en = 1'd1; 
+      e.in = 32'd2; 
+      E[done] = e.done;
     }
     group F{
+      f.write_en = 1'd1; 
+      f.in = 32'd2; 
+      F[done] = f.done;
     }
     group G{
+      g.write_en = 1'd1; 
+      g.in = 32'd2; 
+      G[done] = g.done;
     }
   }
 

--- a/tests/passes/par-timing-map/nested-while.futil
+++ b/tests/passes/par-timing-map/nested-while.futil
@@ -1,0 +1,47 @@
+// -p cell-share -x cell-share:print_par_timing
+import "primitives/core.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    lt = std_lt(32);
+  }
+  wires {
+    group A{
+    }
+    group B{
+    }
+    group C{
+    }
+    group D{
+    }
+    group E{
+    }
+    group F{
+    }
+    group G{
+    }
+  }
+
+  control {
+    @static(74) par {
+      @bound(2) while lt.out {
+        @bound(3) while lt.out {
+          @static(11) seq {
+            @static(3) par {
+              @static(3) A;
+              @static(3) B;
+            }
+            @bound(2) while lt.out {
+              @static(4) C;
+            }
+          }
+        }
+        @static(4) D; 
+      }
+    }
+    @static(12) seq {
+      @static(4) E; 
+      @static(4) F;
+      @static(4) G;
+    }
+  }
+}

--- a/tests/passes/par-timing-map/simple.expect
+++ b/tests/passes/par-timing-map/simple.expect
@@ -1,4 +1,4 @@
-This maps ids of par blocks to " par timing maps ", which map group ids to intervals (i,j), that signify the clock cycles the group is active for, 
+This maps ids of par blocks to " par timing maps ", which map enable ids to intervals (i,j), that signify the clock cycles the group is active for, 
  relative to the start of the given par block
 ======== Map for Component "comp" ========
 ====Par Node ID: 6====
@@ -7,7 +7,7 @@ Group Node ID: 9 -- [(3, 3)]
 Group Node ID: 11 -- [(1, 1)]
 Group Node ID: 12 -- [(2, 3)]
 }
-This maps ids of par blocks to " par timing maps ", which map group ids to intervals (i,j), that signify the clock cycles the group is active for, 
+This maps ids of par blocks to " par timing maps ", which map enable ids to intervals (i,j), that signify the clock cycles the group is active for, 
  relative to the start of the given par block
 ======== Map for Component "main" ========
 ====Par Node ID: 0====

--- a/tests/passes/par-timing-map/simple.expect
+++ b/tests/passes/par-timing-map/simple.expect
@@ -1,0 +1,92 @@
+This maps ids of par blocks to " par timing maps ", which map group ids to intervals (i,j), that signify the clock cycles the group is active for, 
+ relative to the start of the given par block
+======== Map for Component "comp" ========
+====Par Node ID: 6====
+Group Node ID: 8 -- [(1, 2)]
+Group Node ID: 9 -- [(3, 3)]
+Group Node ID: 11 -- [(1, 1)]
+Group Node ID: 12 -- [(2, 3)]
+}
+This maps ids of par blocks to " par timing maps ", which map group ids to intervals (i,j), that signify the clock cycles the group is active for, 
+ relative to the start of the given par block
+======== Map for Component "main" ========
+====Par Node ID: 0====
+Group Node ID: 3 -- [(1, 2)]
+Group Node ID: 4 -- [(1, 3)]
+Group Node ID: 6 -- [(4, 6)]
+Group Node ID: 7 -- [(1, 4)]
+}
+import "primitives/core.futil";
+component comp(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    lt = std_lt(32);
+  }
+  wires {
+    group A {
+    }
+    group B {
+    }
+    group C {
+    }
+    group D {
+    }
+    group E {
+    }
+    group F {
+    }
+    group G {
+    }
+  }
+
+  control {
+    @NODE_ID(0) if lt.out {
+      @NODE_ID seq {
+        @NODE_ID(2) A;
+        @NODE_ID(3) B;
+      }
+    } else {
+      @NODE_ID(4) seq {
+        @NODE_ID(5) C;
+        @static(3) @NODE_ID(6) par {
+          @static(3) @NODE_ID(7) seq {
+            @static(2) @NODE_ID(8) D;
+            @static @NODE_ID(9) E;
+          }
+          @static(3) @NODE_ID(10) seq {
+            @static @NODE_ID(11) F;
+            @static(2) @NODE_ID(12) G;
+          }
+        }
+      }
+    }
+  }
+}
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    lt = std_lt(32);
+  }
+  wires {
+    group A {
+    }
+    group B {
+    }
+    group C {
+    }
+    group D {
+    }
+  }
+
+  control {
+    @static(8) @NODE_ID(0) par {
+      @static(8) @NODE_ID seq {
+        @static(3) @NODE_ID(2) if lt.out {
+          @static(2) @NODE_ID(3) A;
+        } else {
+          @static(3) @NODE_ID(4) B;
+        }
+        @static(3) @NODE_ID(6) C;
+      }
+      @static(4) @NODE_ID(7) D;
+    }
+  }
+}

--- a/tests/passes/par-timing-map/simple.expect
+++ b/tests/passes/par-timing-map/simple.expect
@@ -1,40 +1,74 @@
-This maps ids of par blocks to " par timing maps ", which map enable ids to intervals (i,j), that signify the clock cycles the group is active for, 
+This maps ids of par blocks to " cell timing maps ", which map cells to intervals (i,j), that signify the clock cycles the group is active for, 
  relative to the start of the given par block
-======== Map for Component "comp" ========
-====Par Node ID: 6====
-Group Node ID: 8 -- [(1, 2)]
-Group Node ID: 9 -- [(3, 3)]
-Group Node ID: 11 -- [(1, 1)]
-Group Node ID: 12 -- [(2, 3)]
-}
-This maps ids of par blocks to " par timing maps ", which map enable ids to intervals (i,j), that signify the clock cycles the group is active for, 
+============ Map for Component "comp" ============
+========Par Node ID: 6 ========
+====Child/Thread ID: 7 ====
+Id { id: "d" } -- [(1, 2)]
+Id { id: "e" } -- [(3, 3)]
+====Child/Thread ID: 10 ====
+Id { id: "f" } -- [(1, 1)]
+Id { id: "g" } -- [(2, 3)]
+
+
+This maps ids of par blocks to " cell timing maps ", which map cells to intervals (i,j), that signify the clock cycles the group is active for, 
  relative to the start of the given par block
-======== Map for Component "main" ========
-====Par Node ID: 0====
-Group Node ID: 3 -- [(1, 2)]
-Group Node ID: 4 -- [(1, 3)]
-Group Node ID: 6 -- [(4, 6)]
-Group Node ID: 7 -- [(1, 4)]
-}
+============ Map for Component "main" ============
+========Par Node ID: 0 ========
+====Child/Thread ID: 1 ====
+Id { id: "a" } -- [(1, 2)]
+Id { id: "b" } -- [(1, 3)]
+Id { id: "c" } -- [(4, 6)]
+====Child/Thread ID: 7 ====
+Id { id: "d" } -- [(1, 4)]
+
+
 import "primitives/core.futil";
 component comp(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     lt = std_lt(32);
+    a = std_reg(32);
+    b = std_reg(32);
+    c = std_reg(32);
+    d = std_reg(32);
+    e = std_reg(32);
+    f = std_reg(32);
+    g = std_reg(32);
   }
   wires {
     group A {
+      d.write_en = 1'd1;
+      d.in = 32'd2;
+      A[done] = d.done;
     }
     group B {
+      d.write_en = 1'd1;
+      d.in = 32'd2;
+      B[done] = d.done;
     }
     group C {
+      d.write_en = 1'd1;
+      d.in = 32'd2;
+      C[done] = d.done;
     }
     group D {
+      d.write_en = 1'd1;
+      d.in = 32'd2;
+      D[done] = d.done;
     }
     group E {
+      d.write_en = 1'd1;
+      d.in = 32'd2;
+      E[done] = d.done;
     }
     group F {
+      f.write_en = 1'd1;
+      f.in = 32'd2;
+      F[done] = f.done;
     }
     group G {
+      f.write_en = 1'd1;
+      f.in = 32'd2;
+      G[done] = f.done;
     }
   }
 
@@ -64,15 +98,31 @@ component comp(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
 component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     lt = std_lt(32);
+    a = std_reg(32);
+    b = std_reg(32);
+    c = std_reg(32);
+    d = std_reg(32);
   }
   wires {
     group A {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      A[done] = a.done;
     }
     group B {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      B[done] = a.done;
     }
     group C {
+      a.write_en = 1'd1;
+      a.in = 32'd2;
+      C[done] = a.done;
     }
     group D {
+      d.write_en = 1'd1;
+      d.in = 32'd2;
+      D[done] = d.done;
     }
   }
 

--- a/tests/passes/par-timing-map/simple.futil
+++ b/tests/passes/par-timing-map/simple.futil
@@ -3,21 +3,49 @@ import "primitives/core.futil";
 component comp(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     lt = std_lt(32);
+    a = std_reg(32);
+    b = std_reg(32);
+    c = std_reg(32);
+    d = std_reg(32);
+    e = std_reg(32);
+    f = std_reg(32);
+    g = std_reg(32);
   }
   wires {
     group A{
+      a.write_en = 1'd1; 
+      a.in = 32'd2; 
+      A[done] = a.done;
     }
     group B{
+      b.write_en = 1'd1; 
+      b.in = 32'd2; 
+      B[done] = b.done;
     }
     group C{
+      c.write_en = 1'd1; 
+      c.in = 32'd2; 
+      C[done] = c.done;  
     }
     group D{
+      d.write_en = 1'd1; 
+      d.in = 32'd2; 
+      D[done] = d.done;
     }
     group E{
+      e.write_en = 1'd1; 
+      e.in = 32'd2; 
+      E[done] = e.done;
     }
     group F{
+      f.write_en = 1'd1; 
+      f.in = 32'd2; 
+      F[done] = f.done;
     }
     group G{
+      g.write_en = 1'd1; 
+      g.in = 32'd2; 
+      G[done] = g.done;
     }
   }
 
@@ -39,16 +67,31 @@ component comp(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
 component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     lt = std_lt(32);
+    a = std_reg(32);
+    b = std_reg(32);
+    c = std_reg(32);
+    d = std_reg(32);
   }
   wires {
     group A{
+      a.write_en = 1'd1; 
+      a.in = 32'd2; 
+      A[done] = a.done;
     }
     group B{
+      b.write_en = 1'd1; 
+      b.in = 32'd2; 
+      B[done] = b.done;
     }
     group C{
+      c.write_en = 1'd1; 
+      c.in = 32'd2; 
+      C[done] = c.done;  
     }
     group D{
-      
+      d.write_en = 1'd1; 
+      d.in = 32'd2; 
+      D[done] = d.done;
     }
   }
 

--- a/tests/passes/par-timing-map/simple.futil
+++ b/tests/passes/par-timing-map/simple.futil
@@ -1,6 +1,8 @@
 // -p cell-share -x cell-share:print_par_timing
-component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+import "primitives/core.futil";
+component comp(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
+    lt = std_lt(32);
   }
   wires {
     group A{
@@ -9,12 +11,59 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     }
     group C{
     }
+    group D{
+    }
+    group E{
+    }
+    group F{
+    }
+    group G{
+    }
   }
 
   control {
-    @static(2) par {
-      @static(2) seq { @static(1) A; @static B;}
-      @static(2) B; 
+    if lt.out {
+      seq {A; B;}
+    }
+    else{
+      seq{
+        C; 
+        @static(3) par {
+          @static(3) seq{ @static(2) D; @static(1) E;}
+          @static(3) seq{ @static(1) F; @static(2) G; }
+        } 
+      }
+    }
+  }
+}
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    lt = std_lt(32);
+  }
+  wires {
+    group A{
+    }
+    group B{
+    }
+    group C{
+    }
+    group D{
+      
+    }
+  }
+
+  control {
+    @static(8) par {
+      @static(8) seq {
+        @static(3) if lt.out {
+          @static(2) A;
+        }
+        else{
+          @static(3) B; 
+        }
+        @static(3) C; 
+      }
+      @static(4) D; 
     }
   }
 }

--- a/tests/passes/par-timing-map/simple.futil
+++ b/tests/passes/par-timing-map/simple.futil
@@ -1,0 +1,20 @@
+// -p cell-share -x cell-share:print_par_timing
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+  }
+  wires {
+    group A{
+    }
+    group B{
+    }
+    group C{
+    }
+  }
+
+  control {
+    @static(2) par {
+      @static(2) seq { @static(1) A; @static B;}
+      @static(2) B; 
+    }
+  }
+}


### PR DESCRIPTION
Implements the idea in #1353. 

The key HashMap has the following structure: 
```
Maps Par ID -> (Map that maps Enable ID -> clock interval (i,j))
```
The intervals are relative to the start of the par block. 

Couple of points: 

1) I chose not to include invokes in this because they're not included in #1331. Although, if we wanted to, it shouldn't be too hard to add support for them in this analysis. 
2) If we have nested static pars (that merge-static-par pass doesn't deal with), like: 
```
@static par{
    @static seq{
            ...
            @static par{
                @static A; 
                 ...
             }
            ...     
    }
}
```
Then the enable A will appear in the hashmap relative to _both_  par blocks. 

