### PR TITLE
Cell Share pass flags

### DIFF
--- a/calyx/src/analysis/static_par_timing.rs
+++ b/calyx/src/analysis/static_par_timing.rs
@@ -104,6 +104,7 @@ impl StaticParTiming {
         // a_liveness, b_liveness, that we actually care about
         let thread_timing_map = match self.cell_map.get(par_id) {
             Some(m) => m,
+            // not a static par block, so must assume overlap
             None => return true,
         };
         let a_liveness = thread_timing_map

--- a/calyx/src/passes/cell_share.rs
+++ b/calyx/src/passes/cell_share.rs
@@ -480,21 +480,18 @@ impl Visitor for CellShare {
                                     par_thread_map.get(live_b).unwrap();
                                 if live_a != live_b && parent_a == parent_b {
                                     // if share_static_par, then we need to check
-                                    // another condition before building conflict
+                                    // par timing map before building conflict
                                     // between two cells.
-                                    // if not share_static_par, then we immediately
+                                    // if not share_static_par, then we can immediately insert conflict
                                     // insert conflict
-                                    if self.share_static_par {
-                                        if self
+                                    if (self.share_static_par
+                                        && self
                                             .par_timing_map
                                             .liveness_overlaps(
                                                 parent_a, live_a, live_b, a, b,
-                                            )
-                                        {
-                                            g.insert_conflict(a, b);
-                                            break 'outer;
-                                        }
-                                    } else {
+                                            ))
+                                        || !self.share_static_par
+                                    {
                                         g.insert_conflict(a, b);
                                         break 'outer;
                                     }

--- a/tests/passes/cell-share/calyx_2020.expect
+++ b/tests/passes/cell-share/calyx_2020.expect
@@ -1,0 +1,112 @@
+{"main":{"std_add_WIDTH_32":{"6":1},"std_mult_pipe_WIDTH_32":{"1":6},"std_reg_WIDTH_32":{"6":1}}}
+import "primitives/core.futil";
+import "primitives/binary_operators.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    a = std_reg(32);
+    add1 = std_add(32);
+    mult0 = std_mult_pipe(32);
+    mult1 = std_mult_pipe(32);
+    mult2 = std_mult_pipe(32);
+    mult3 = std_mult_pipe(32);
+    mult4 = std_mult_pipe(32);
+    mult5 = std_mult_pipe(32);
+  }
+  wires {
+    group let0 {
+      add1.left = 32'd2;
+      add1.right = 32'd4;
+      a.in = add1.out;
+      a.write_en = 1'd1;
+      let0[done] = a.done;
+    }
+    group let1 {
+      add1.left = 32'd2;
+      add1.right = 32'd4;
+      a.in = add1.out;
+      a.write_en = 1'd1;
+      let1[done] = a.done;
+    }
+    group let2 {
+      add1.left = 32'd2;
+      add1.right = 32'd4;
+      a.in = add1.out;
+      a.write_en = 1'd1;
+      let2[done] = a.done;
+    }
+    group let3 {
+      add1.left = 32'd2;
+      add1.right = 32'd4;
+      a.in = add1.out;
+      a.write_en = 1'd1;
+      let3[done] = a.done;
+    }
+    group let4 {
+      add1.left = 32'd2;
+      add1.right = 32'd4;
+      a.in = add1.out;
+      a.write_en = 1'd1;
+      let4[done] = a.done;
+    }
+    group let5 {
+      add1.left = 32'd2;
+      add1.right = 32'd4;
+      a.in = add1.out;
+      a.write_en = 1'd1;
+      let5[done] = a.done;
+    }
+    group m0 {
+      mult0.go = 1'd1;
+      mult0.left = 32'd1;
+      mult0.right = 32'd2;
+      m0[done] = mult0.done;
+    }
+    group m1 {
+      mult1.go = 1'd1;
+      mult1.left = 32'd1;
+      mult1.right = 32'd2;
+      m1[done] = mult1.done;
+    }
+    group m2 {
+      mult2.go = 1'd1;
+      mult2.left = 32'd1;
+      mult2.right = 32'd2;
+      m2[done] = mult2.done;
+    }
+    group m3 {
+      mult3.go = 1'd1;
+      mult3.left = 32'd1;
+      mult3.right = 32'd2;
+      m3[done] = mult3.done;
+    }
+    group m4 {
+      mult4.go = 1'd1;
+      mult4.left = 32'd1;
+      mult4.right = 32'd2;
+      m4[done] = mult4.done;
+    }
+    group m5 {
+      mult5.go = 1'd1;
+      mult5.left = 32'd1;
+      mult5.right = 32'd2;
+      m5[done] = mult5.done;
+    }
+  }
+
+  control {
+    seq {
+      let0;
+      let1;
+      let2;
+      let3;
+      let4;
+      let5;
+      m0;
+      m1;
+      m2;
+      m3;
+      m4;
+      m5;
+    }
+  }
+}

--- a/tests/passes/cell-share/calyx_2020.futil
+++ b/tests/passes/cell-share/calyx_2020.futil
@@ -1,0 +1,122 @@
+// -p cell-share -x cell-share:calyx_2020 -x cell-share:print-share-freqs=stdout -p dead-cell-removal -p remove-ids
+// share adders twice, registers 3 times, and mults 4 times 
+import "primitives/core.futil";
+import "primitives/binary_operators.futil";
+component main() -> () {
+  cells {
+    a = std_reg(32);
+    b = std_reg(32);
+    c = std_reg(32);
+    d = std_reg(32);
+    e = std_reg(32);
+    f = std_reg(32);
+    add1 = std_add(32);
+    add2 = std_add(32);
+    add3 = std_add(32);
+    add4 = std_add(32);
+    add5 = std_add(32);
+    add6 = std_add(32);
+    mult0 = std_mult_pipe(32);
+    mult1 = std_mult_pipe(32);
+    mult2 = std_mult_pipe(32);
+    mult3 = std_mult_pipe(32);
+    mult4 = std_mult_pipe(32);
+    mult5 = std_mult_pipe(32);
+  }
+  wires {
+    group let0 {
+      add1.left = 32'd2;
+      add1.right = 32'd4;
+      a.in = add1.out;
+      a.write_en = 1'd1;
+      let0[done] = a.done;
+    }
+    group let1 {
+      add2.left = 32'd2;
+      add2.right = 32'd4;
+      b.in = add2.out;
+      b.write_en = 1'd1;
+      let1[done] = b.done;
+    }
+    group let2 {
+      add3.left = 32'd2;
+      add3.right = 32'd4;
+      c.in = add3.out;
+      c.write_en = 1'd1;
+      let2[done] = c.done;
+    }
+    group let3 {
+      add4.left = 32'd2;
+      add4.right = 32'd4;
+      d.in = add4.out;
+      d.write_en = 1'd1;
+      let3[done] = d.done;
+    }
+    group let4 {
+      add5.left = 32'd2;
+      add5.right = 32'd4;
+      e.in = add5.out;
+      e.write_en = 1'd1;
+      let4[done] = e.done;
+    }
+    group let5 {
+      add6.left = 32'd2;
+      add6.right = 32'd4;
+      f.in = add6.out;
+      f.write_en = 1'd1;
+      let5[done] = f.done;
+    }
+    group m0{
+      mult0.go = 1'd1; 
+      mult0.left = 32'd1; 
+      mult0.right = 32'd2; 
+      m0[done] = mult0.done; 
+    }
+    group m1{
+      mult1.go = 1'd1; 
+      mult1.left = 32'd1; 
+      mult1.right = 32'd2; 
+      m1[done] = mult1.done; 
+    }
+    group m2{
+      mult2.go = 1'd1; 
+      mult2.left = 32'd1; 
+      mult2.right = 32'd2; 
+      m2[done] = mult2.done; 
+    }
+    group m3{
+      mult3.go = 1'd1; 
+      mult3.left = 32'd1; 
+      mult3.right = 32'd2; 
+      m3[done] = mult3.done; 
+    }
+    group m4{
+      mult4.go = 1'd1; 
+      mult4.left = 32'd1; 
+      mult4.right = 32'd2; 
+      m4[done] = mult4.done; 
+    }
+    group m5{
+      mult5.go = 1'd1; 
+      mult5.left = 32'd1; 
+      mult5.right = 32'd2; 
+      m5[done] = mult5.done; 
+    }
+  }
+  control {
+    seq {
+      let0;
+      let1;
+      let2;
+      let3;
+      let4;
+      let5;
+      m0;
+      m1;
+      m2;
+      m3;
+      m4;
+      m5;
+    }
+  }
+}

--- a/tests/passes/cell-share/static-par.futil
+++ b/tests/passes/cell-share/static-par.futil
@@ -1,4 +1,4 @@
-// -p cell-share -p remove-ids
+// -p cell-share -x cell-share:share_static_par  -p remove-ids
 import "primitives/core.futil";
 component main() -> () {
   cells {


### PR DESCRIPTION
Added two new flags for cell-share pass. 

1) "calyx_2020" flag: runs cell sharing w/ Calyx 2020 settings, aka unlimited sharing of registers/combinational components, no sharing of anything else. This is mainly so that we can look at the improvement of sharing over time 

2) "share_static_par" flag: whether or not to share across static par blocks. Right now, we probably shouldn't, because tdst isn't applied in all cases, so we actually don't have the timing guarantees across par block that the static attribute tells us. But we would eventually want this to be defaulted to true. 