### PR TITLE
Create a workflow for VCalyx

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -1,0 +1,45 @@
+name: Verification
+
+# Right now, we should only run this check on the vcalyx branch
+on:  
+  push:
+    branches:
+      - vcalyx
+
+# Ensures that only the latest commit of a PR can execute the actions.
+# Useful for cancelling job when a sequence of commits are quickly added.
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build VCalyx
+    runs-on: ubuntu-latest
+    container: ghcr.io/cucapra/calyx:latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Get bwrap for opam
+      run: |
+        apt-get update -y
+        apt-get install -y bubblewrap
+    - name: Set up opam and OCaml 4.13.1
+      uses: ocaml/setup-ocaml@v2
+      with:
+          ocaml-compiler: 4.13.1
+    - name: Checkout commit that triggered run
+      run: |
+        git fetch --all
+        git checkout $GITHUB_SHA
+    - name: Install dependencies
+      run: |
+        cd vcalyx
+        opam install dune
+        opam repo add coq-released https://coq.inria.fr/opam/released
+        opam install . --deps-only 
+        opam install coq yojson core core_unix ppx_deriving coq-stdpp coq-ceres
+    - name: Build with dune
+      run: |
+        cd vcalyx
+        opam exec -- dune build


### PR DESCRIPTION
This workflow installs OCaml/opam/dune/required libraries and takes about 16 minutes to run, mostly due to Coq and Core taking forever to build. I have configured it to only run on the `vcalyx` branch, and all it does is check that our code builds! 

You can check out a workflow run [here](https://github.com/priyasrikumar/calyx/actions/runs/4338631661/jobs/7575460684) (excuse the string of sad commits).