### PR TITLE
use `std::mem::take` in the component order

### DIFF
--- a/calyx/src/ir/traversal/visitor.rs
+++ b/calyx/src/ir/traversal/visitor.rs
@@ -171,7 +171,7 @@ pub trait Visitor {
         }
 
         let signatures = &context.lib;
-        let comps = context.components.drain(..).collect_vec();
+        let comps = std::mem::take(&mut context.components);
 
         // Temporarily take ownership of components from context.
         let mut po = CompTraversal::new(comps, Self::iteration_order());


### PR DESCRIPTION
A one-line change I noticed in passing. No need to use `drain` in this context as that will result in unnecessary allocations and iteration. The drained vec retains its capacity and the new collected vec will need the same capacity. Using `std::mem::take` should just be a pointer swap and avoids extra allocation since the default val is an empty vec.