### PR TITLE
Flattened guard emission in the Verilog backend

### DIFF
--- a/calyx/src/ir/context.rs
+++ b/calyx/src/ir/context.rs
@@ -112,6 +112,8 @@ pub struct BackendConf {
     pub enable_verification: bool,
     /// Generate initial assignments for input ports
     pub initialize_inputs: bool,
+    /// Use flat (ANF) assignments for guards instead of deep expression trees.
+    pub flat_assign: bool,
 }
 
 /// The IR Context that represents an entire Calyx program with all of its

--- a/calyx/src/ir/flat_guard.rs
+++ b/calyx/src/ir/flat_guard.rs
@@ -61,11 +61,11 @@ impl GuardPool {
     }
 
     #[cfg(debug_assertions)]
-    pub fn display(&self, guard: GuardRef) -> String {
-        match self.get(guard) {
-            FlatGuard::Or(l, r) => format!("({} | {})", self.display(*l), self.display(*r)),
-            FlatGuard::And(l, r) => format!("({} & {})", self.display(*l), self.display(*r)),
-            FlatGuard::Not(g) => format!("!{}", self.display(*g)),
+    pub fn display(&self, guard: &FlatGuard) -> String {
+        match guard {
+            FlatGuard::Or(l, r) => format!("({} | {})", self.display(self.get(*l)), self.display(self.get(*r))),
+            FlatGuard::And(l, r) => format!("({} & {})", self.display(self.get(*l)), self.display(self.get(*r))),
+            FlatGuard::Not(g) => format!("!{}", self.display(self.get(*g))),
             FlatGuard::True => "true".to_string(),
             FlatGuard::CompOp(op, l, r) => {
                 let op_str = match op {
@@ -76,9 +76,14 @@ impl GuardPool {
                     PortComp::Gt => ">",
                     PortComp::Geq => ">=",
                 };
-                format!("({} {} {})", l.borrow().name, op_str, r.borrow().name)
+                format!("({} {} {})", l.borrow().canonical(), op_str, r.borrow().canonical())
             },
-            FlatGuard::Port(p) => p.borrow().name.to_string(),
+            FlatGuard::Port(p) => format!("{}", p.borrow().canonical()),
         }
+    }
+
+    /// Iterate over *all* the guards in the pool.
+    pub fn iter(&self) -> impl Iterator<Item = &FlatGuard> {
+        self.0.iter()
     }
 }

--- a/calyx/src/ir/flat_guard.rs
+++ b/calyx/src/ir/flat_guard.rs
@@ -142,3 +142,9 @@ impl GuardPool {
             .map(|(i, g)| (GuardRef(i.try_into().unwrap()), g))
     }
 }
+
+impl Default for GuardPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/calyx/src/ir/flat_guard.rs
+++ b/calyx/src/ir/flat_guard.rs
@@ -1,0 +1,56 @@
+use super::{Port, RRC};
+use super::guard::{PortComp, Guard};
+
+pub struct GuardRef(u16);
+
+pub enum FlatGuard {
+    Or(GuardRef, GuardRef),
+    And(GuardRef, GuardRef),
+    Not(GuardRef),
+    True,
+    CompOp(PortComp, RRC<Port>, RRC<Port>),
+    Port(RRC<Port>),
+}
+
+/// A GuardPool stores FlatGuard. It can have multiple "roots," or it can have just one (as in when
+/// we are just replacing a single guard with this). It has an important invariant: GuardRefs are
+/// always within the same pool (obviously), and they can only go "backward," in the sense that
+/// they refer to smaller indices than the current FlatGuard.
+/// 
+/// This currently does not do *any* kind of hash-consing or deduplication. It also naively grows
+/// the underlying vector; a more efficient implementation would pre-allocate the space. But we are
+/// currently focused on building up guards of unknown size, so I'm leaving this off for now.
+pub struct GuardPool(Vec<FlatGuard>);
+
+impl GuardPool {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    fn add(&mut self, guard: FlatGuard) -> GuardRef {
+        self.0.push(guard);
+        GuardRef((self.0.len() - 1).try_into().expect("too many guards in the pool"))
+    }
+    
+    pub fn flatten(&mut self, old: &Guard) -> GuardRef {
+        match old {
+            Guard::Or(l, r) => {
+                let flat_l = self.flatten(l);
+                let flat_r = self.flatten(r);
+                self.add(FlatGuard::Or(flat_l, flat_r))
+            }
+            Guard::And(l, r) => {
+                let flat_l = self.flatten(l);
+                let flat_r = self.flatten(r);
+                self.add(FlatGuard::And(flat_l, flat_r))
+            }
+            Guard::Not(g) => {
+                let flat_g = self.flatten(g);
+                self.add(FlatGuard::Not(flat_g))
+            }
+            Guard::True => self.add(FlatGuard::True),
+            Guard::CompOp(op, l, r) => self.add(FlatGuard::CompOp(op.clone(), l.clone(), r.clone())),
+            Guard::Port(p) => self.add(FlatGuard::Port(p.clone())),
+        }
+    }
+}

--- a/calyx/src/ir/flat_guard.rs
+++ b/calyx/src/ir/flat_guard.rs
@@ -2,7 +2,7 @@ use super::{Port, RRC};
 use super::guard::{PortComp, Guard};
 
 #[derive(Debug, Copy, Clone)]
-pub struct GuardRef(u16);
+pub struct GuardRef(u32);
 
 impl std::fmt::Display for GuardRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/calyx/src/ir/flat_guard.rs
+++ b/calyx/src/ir/flat_guard.rs
@@ -4,6 +4,12 @@ use super::guard::{PortComp, Guard};
 #[derive(Debug, Copy, Clone)]
 pub struct GuardRef(u16);
 
+impl std::fmt::Display for GuardRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum FlatGuard {
     Or(GuardRef, GuardRef),
@@ -83,7 +89,9 @@ impl GuardPool {
     }
 
     /// Iterate over *all* the guards in the pool.
-    pub fn iter(&self) -> impl Iterator<Item = &FlatGuard> {
-        self.0.iter()
+    pub fn iter(&self) -> impl Iterator<Item = (GuardRef, &FlatGuard)> {
+        self.0.iter().enumerate().map(|(i, g)| {
+            (GuardRef(i.try_into().unwrap()), g)
+        })
     }
 }

--- a/calyx/src/ir/flat_guard.rs
+++ b/calyx/src/ir/flat_guard.rs
@@ -20,6 +20,16 @@ pub enum FlatGuard {
     Port(RRC<Port>),
 }
 
+impl FlatGuard {
+    pub fn is_true(&self) -> bool {
+        match self {
+            FlatGuard::True => true,
+            FlatGuard::Port(p) => p.borrow().is_constant(1, 1),
+            _ => false,
+        }
+    }
+}
+
 /// A GuardPool stores FlatGuard. It can have multiple "roots," or it can have just one (as in when
 /// we are just replacing a single guard with this). It has an important invariant: GuardRefs are
 /// always within the same pool (obviously), and they can only go "backward," in the sense that

--- a/calyx/src/ir/flat_guard.rs
+++ b/calyx/src/ir/flat_guard.rs
@@ -4,17 +4,17 @@ use super::{Port, RRC};
 #[derive(Debug, Copy, Clone)]
 pub struct GuardRef(u32);
 
-impl std::fmt::Display for GuardRef {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 impl GuardRef {
     /// Check whether this refers to a `FlatGuard::True`. (We can do this because the first guard
     /// in the pool is always `True`.)
     pub fn is_true(&self) -> bool {
         self.0 == 0
+    }
+
+    /// Get the underlying number for this reference. Clients should only rely on this being unique
+    /// for non-equal guards in a single pool; no other aspects of the number are relevant.
+    pub fn index(&self) -> u32 {
+        self.0
     }
 }
 

--- a/calyx/src/ir/mod.rs
+++ b/calyx/src/ir/mod.rs
@@ -14,6 +14,7 @@ mod component;
 mod context;
 mod control;
 mod guard;
+mod flat_guard;
 mod id;
 mod primitives;
 mod printer;
@@ -31,6 +32,7 @@ pub use control::{
     Cloner, Control, Empty, Enable, If, Invoke, Par, Seq, StaticEnable, While,
 };
 pub use guard::{Guard, PortComp};
+pub use flat_guard::{FlatGuard, GuardPool, GuardRef};
 pub use id::Id;
 pub use primitives::{PortDef, Primitive, Width};
 pub use printer::Printer;

--- a/calyx/src/ir/mod.rs
+++ b/calyx/src/ir/mod.rs
@@ -13,8 +13,8 @@ mod common;
 mod component;
 mod context;
 mod control;
-mod guard;
 mod flat_guard;
+mod guard;
 mod id;
 mod primitives;
 mod printer;
@@ -31,8 +31,8 @@ pub use context::{BackendConf, Context, LibrarySignatures};
 pub use control::{
     Cloner, Control, Empty, Enable, If, Invoke, Par, Seq, StaticEnable, While,
 };
-pub use guard::{Guard, PortComp};
 pub use flat_guard::{FlatGuard, GuardPool, GuardRef};
+pub use guard::{Guard, PortComp};
 pub use id::Id;
 pub use primitives::{PortDef, Primitive, Width};
 pub use printer::Printer;

--- a/runt.toml
+++ b/runt.toml
@@ -125,6 +125,26 @@ fud exec --to jq \
 timeout = 120
 
 [[tests]]
+name = "correctness dynamic flat"
+paths = [
+  "tests/correctness/*.futil",
+  "tests/correctness/ref-cells/*.futil",
+  "tests/correctness/sync/*.futil"
+]
+cmd = """
+fud exec --to jq \
+         --through verilog \
+         --through dat \
+         -s verilog.data {}.data \
+         -s futil.exec './target/debug/futil' \
+         -s futil.flags ' -d tdst --flat' \
+         -s verilog.cycle_limit 500 \
+         -s jq.expr ".memories" \
+         {} -q
+"""
+timeout = 120
+
+[[tests]]
 name = "correctness static timing"
 paths = [
   "tests/correctness/*.futil",
@@ -135,6 +155,25 @@ fud exec --to jq \
          --through verilog \
          --through dat \
          -s futil.exec './target/debug/futil' \
+         -s verilog.cycle_limit 500 \
+         -s verilog.data {}.data \
+         -s jq.expr ".memories" \
+         {} -q
+"""
+timeout = 120
+
+[[tests]]
+name = "correctness static timing flat"
+paths = [
+  "tests/correctness/*.futil",
+  "tests/correctness/ref-cells/*.futil"
+]
+cmd = """
+fud exec --to jq \
+         --through verilog \
+         --through dat \
+         -s futil.exec './target/debug/futil' \
+         -s futil.flags ' --flat' \
          -s verilog.cycle_limit 500 \
          -s verilog.data {}.data \
          -s jq.expr ".memories" \

--- a/runt.toml
+++ b/runt.toml
@@ -125,26 +125,6 @@ fud exec --to jq \
 timeout = 120
 
 [[tests]]
-name = "correctness dynamic flat"
-paths = [
-  "tests/correctness/*.futil",
-  "tests/correctness/ref-cells/*.futil",
-  "tests/correctness/sync/*.futil"
-]
-cmd = """
-fud exec --to jq \
-         --through verilog \
-         --through dat \
-         -s verilog.data {}.data \
-         -s futil.exec './target/debug/futil' \
-         -s futil.flags ' -d tdst --flat' \
-         -s verilog.cycle_limit 500 \
-         -s jq.expr ".memories" \
-         {} -q
-"""
-timeout = 120
-
-[[tests]]
 name = "correctness static timing"
 paths = [
   "tests/correctness/*.futil",
@@ -162,8 +142,29 @@ fud exec --to jq \
 """
 timeout = 120
 
+# Variants of the above but for `--nested` (non-ANF Verilog emission) mode.
 [[tests]]
-name = "correctness static timing flat"
+name = "correctness dynamic nested"
+paths = [
+  "tests/correctness/*.futil",
+  "tests/correctness/ref-cells/*.futil",
+  "tests/correctness/sync/*.futil"
+]
+cmd = """
+fud exec --to jq \
+         --through verilog \
+         --through dat \
+         -s verilog.data {}.data \
+         -s futil.exec './target/debug/futil' \
+         -s futil.flags ' -d tdst --nested' \
+         -s verilog.cycle_limit 500 \
+         -s jq.expr ".memories" \
+         {} -q
+"""
+timeout = 120
+
+[[tests]]
+name = "correctness static timing nested"
 paths = [
   "tests/correctness/*.futil",
   "tests/correctness/ref-cells/*.futil"
@@ -173,7 +174,7 @@ fud exec --to jq \
          --through verilog \
          --through dat \
          -s futil.exec './target/debug/futil' \
-         -s futil.flags ' --flat' \
+         -s futil.flags ' --nested' \
          -s verilog.cycle_limit 500 \
          -s verilog.data {}.data \
          -s jq.expr ".memories" \

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -487,7 +487,7 @@ fn emit_guard_disjoint_check(
     }
     // Construct concat with all guards.
     let mut concat = v::ExprConcat::default();
-    assignments.iter().for_each(|(src, gr)| {
+    assignments.iter().for_each(|(_, gr)| {
         let expr = if flat {
             v::Expr::new_ref(guard_ref_to_name(*gr))
         } else {
@@ -709,33 +709,6 @@ fn emit_guard<F: std::io::Write>(
         FlatGuard::Not(o) => write!(f, "~{}", gr(*o)),
         FlatGuard::True => write!(f, "1"),
         FlatGuard::Port(p) => write!(f, "{}", port_to_ref(p)),
-    }
-}
-
-fn guard_to_nested_expr(guard: ir::GuardRef, pool: &ir::GuardPool) -> v::Expr {
-    match pool.get(guard) {
-        FlatGuard::And(l, r) => v::Expr::new_bit_and(
-            guard_to_nested_expr(*l, pool),
-            guard_to_nested_expr(*r, pool),
-        ),
-        FlatGuard::Or(l, r) => v::Expr::new_bit_or(
-            guard_to_nested_expr(*l, pool),
-            guard_to_nested_expr(*r, pool),
-        ),
-        FlatGuard::CompOp(op, l, r) => {
-            let op = match op {
-                ir::PortComp::Eq => v::Expr::new_eq,
-                ir::PortComp::Neq => v::Expr::new_neq,
-                ir::PortComp::Gt => v::Expr::new_gt,
-                ir::PortComp::Lt => v::Expr::new_lt,
-                ir::PortComp::Geq => v::Expr::new_geq,
-                ir::PortComp::Leq => v::Expr::new_leq,
-            };
-            op(port_to_ref(&l), port_to_ref(&r))
-        }
-        FlatGuard::Not(g) => v::Expr::new_not(guard_to_nested_expr(*g, pool)),
-        FlatGuard::Port(p) => port_to_ref(&p),
-        FlatGuard::True => v::Expr::new_ulit_bin(1, &1.to_string()),
     }
 }
 

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -321,6 +321,7 @@ fn emit_component<F: io::Write>(
     let mut pool = ir::GuardPool::new();
     let grouped_asgns: Vec<_> = map
         .values()
+        .sorted_by_key(|(port, _)| port.borrow().canonical())
         .map(|(dst, asgns)| {
             let flat_asgns: Vec<_> = asgns
                 .iter()

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -343,7 +343,7 @@ fn emit_component<F: io::Write>(
 
         // Emit Verilog for the flattened guards.
         for (idx, guard) in pool.iter() {
-            write!(f, "logic {} = ", VerilogGuardRef::from(idx))?;
+            write!(f, "logic {} = ", VerilogGuardRef(idx))?;
             emit_guard(guard, f)?;
             writeln!(f, ";")?;
         }
@@ -489,7 +489,7 @@ fn emit_guard_disjoint_check(
     let mut concat = v::ExprConcat::default();
     assignments.iter().for_each(|(_, gr)| {
         let expr = if flat {
-            v::Expr::new_ref(VerilogGuardRef::from(*gr).to_string())
+            v::Expr::new_ref(VerilogGuardRef(*gr).to_string())
         } else {
             let guard = pool.get(*gr);
             guard_to_expr(guard, &pool)
@@ -617,7 +617,7 @@ fn emit_assignment_flat<F: io::Write>(
             if guard.is_true() {
                 return writeln!(f, "assign {} = {};", port_to_ref(&dst), port_to_ref(&src));
             } else if src.borrow().is_constant(1, 1) {
-                return writeln!(f, "assign {} = {};", port_to_ref(&dst), VerilogGuardRef::from(*guard));
+                return writeln!(f, "assign {} = {};", port_to_ref(&dst), VerilogGuardRef(*guard));
             }
         }
     }
@@ -628,7 +628,7 @@ fn emit_assignment_flat<F: io::Write>(
         writeln!(
             f,
             "  {} ? {} :",
-            VerilogGuardRef::from(*guard),
+            VerilogGuardRef(*guard),
             port_to_ref(&src)
         )?;
     }
@@ -706,17 +706,11 @@ impl std::fmt::Display for VerilogGuardRef {
     }
 }
 
-impl From<GuardRef> for VerilogGuardRef {
-    fn from(g: GuardRef) -> Self {
-        VerilogGuardRef(g)
-    }
-}
-
 fn emit_guard<F: std::io::Write>(
     guard: &ir::FlatGuard,
     f: &mut F,
 ) -> io::Result<()> {
-    let gr = VerilogGuardRef::from;
+    let gr = VerilogGuardRef;
     match guard {
         FlatGuard::Or(l, r) => write!(f, "{} | {}", gr(*l), gr(*r)),
         FlatGuard::And(l, r) => write!(f, "{} & {}", gr(*l), gr(*r)),

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -578,12 +578,13 @@ fn emit_assignment(
         // Flatten the mux expression if there is exactly one assignment with a true guard.
         if assignments.len() == 1 {
             let (src, gr) = &assignments[0];
-            let guard = pool.get(*gr);
-            if guard.is_true() {
+            if gr.is_true() {
                 port_to_ref(&src)
             } else if src.borrow().is_constant(1, 1) {
+                let guard = pool.get(*gr);
                 guard_to_expr(guard, pool)
             } else {
+                let guard = pool.get(*gr);
                 v::Expr::new_mux(
                     guard_to_expr(guard, pool),
                     port_to_ref(&src),

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -564,9 +564,9 @@ fn emit_assignment_flat<F: io::Write>(
     // Use a cascade of ternary expressions to assign the right RHS to dst.
     writeln!(f, "assign {} =", port_to_ref(&dst))?;
     for (src, guard) in assignments {
-        writeln!(f, "  {} ? {}", guard_ref_to_name(guard), port_to_ref(&src))?;
+        writeln!(f, "  {} ? {} :", guard_ref_to_name(guard), port_to_ref(&src))?;
     }
-    writeln!(f, "  : {};", default)
+    writeln!(f, " {};", default)
 }
 
 fn port_to_ref(port_ref: &RRC<ir::Port>) -> v::Expr {

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -337,11 +337,9 @@ fn emit_component<F: io::Write>(
 
     if flat_assign {
         // Emit "flattened" assignments as ANF statements.
-        writeln!(f, "always @* begin")?;
-
         // Emit Verilog for the flattened guards.
         for (idx, guard) in pool.iter() {
-            write!(f, "logic {} = ", VerilogGuardRef(idx))?;
+            write!(f, "wire {} = ", VerilogGuardRef(idx))?;
             emit_guard(guard, f)?;
             writeln!(f, ";")?;
         }
@@ -354,12 +352,14 @@ fn emit_component<F: io::Write>(
                 if let Some(check) =
                     emit_guard_disjoint_check(dst, &asgns, &pool, true)
                 {
-                    writeln!(f, "{check}")?;
+                    writeln!(f, "always_comb begin")?;
+                    writeln!(f, "  {check}")?;
+                    writeln!(f, "end")?;
                 }
             }
         }
 
-        writeln!(f, "end")?;
+
     } else {
         // Build a top-level always block to contain verilator checks for assignments
         let mut checks = v::ParallelProcess::new_always_comb();

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -333,8 +333,8 @@ fn emit_component<F: io::Write>(
             (dst, flat_asgns)
         })
         .collect();
-        
-     // Build a top-level always block to contain verilator checks for assignments
+
+    // Build a top-level always block to contain verilator checks for assignments
     let mut checks = v::ParallelProcess::new_always_comb();
 
     if flat_assign {
@@ -353,7 +353,9 @@ fn emit_component<F: io::Write>(
             emit_assignment_flat(dst, &asgns, f)?;
 
             if enable_verification {
-                if let Some(check) = emit_guard_disjoint_check(dst, &asgns, &pool, true) {
+                if let Some(check) =
+                    emit_guard_disjoint_check(dst, &asgns, &pool, true)
+                {
                     checks.add_seq(check);
                 }
             }
@@ -363,13 +365,14 @@ fn emit_component<F: io::Write>(
     } else {
         // Emit nested assignments.
         for (dst, asgns) in grouped_asgns {
-            let stmt = v::Stmt::new_parallel(
-                emit_assignment(dst, &asgns, &pool)
-            );
+            let stmt =
+                v::Stmt::new_parallel(emit_assignment(dst, &asgns, &pool));
             writeln!(f, "{stmt}")?;
 
             if enable_verification {
-                if let Some(check) = emit_guard_disjoint_check(dst, &asgns, &pool, false) {
+                if let Some(check) =
+                    emit_guard_disjoint_check(dst, &asgns, &pool, false)
+                {
                     checks.add_seq(check);
                 }
             }
@@ -569,10 +572,8 @@ fn emit_assignment(
             fold_assigns(v::Expr::X)
         }
     } else {
-        let init = v::Expr::new_ulit_dec(
-            dst.borrow().width as u32,
-            &0.to_string(),
-        );
+        let init =
+            v::Expr::new_ulit_dec(dst.borrow().width as u32, &0.to_string());
 
         // Flatten the mux expression if there is exactly one assignment with a true guard.
         if assignments.len() == 1 {
@@ -660,7 +661,9 @@ fn guard_to_expr(guard: &ir::FlatGuard, pool: &ir::GuardPool) -> v::Expr {
             ir::PortComp::Geq => v::Expr::new_geq,
             ir::PortComp::Leq => v::Expr::new_leq,
         },
-        FlatGuard::Not(..) | FlatGuard::Port(..) | FlatGuard::True => unreachable!(),
+        FlatGuard::Not(..) | FlatGuard::Port(..) | FlatGuard::True => {
+            unreachable!()
+        }
     };
 
     match guard {
@@ -683,7 +686,10 @@ fn guard_ref_to_name(guard: GuardRef) -> String {
     format!("_guard{}", guard)
 }
 
-fn emit_guard<F: std::io::Write>(guard: &ir::FlatGuard, f: &mut F) -> io::Result<()> {
+fn emit_guard<F: std::io::Write>(
+    guard: &ir::FlatGuard,
+    f: &mut F,
+) -> io::Result<()> {
     use guard_ref_to_name as gr;
 
     match guard {

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -611,13 +611,28 @@ fn emit_assignment_flat<F: io::Write>(
         if data {
             // For data ports (for whom unassigned values are undefined), we can drop the guard
             // entirely and assume it is always true (because it would be UB if it were ever false).
-            return writeln!(f, "assign {} = {};", VerilogPortRef(&dst), VerilogPortRef(&src));
+            return writeln!(
+                f,
+                "assign {} = {};",
+                VerilogPortRef(&dst),
+                VerilogPortRef(&src)
+            );
         } else {
             // For non-data ("control") ports, we have special cases for true guards and constant-1 RHSes.
             if guard.is_true() {
-                return writeln!(f, "assign {} = {};", VerilogPortRef(&dst), VerilogPortRef(&src));
+                return writeln!(
+                    f,
+                    "assign {} = {};",
+                    VerilogPortRef(&dst),
+                    VerilogPortRef(&src)
+                );
             } else if src.borrow().is_constant(1, 1) {
-                return writeln!(f, "assign {} = {};", VerilogPortRef(&dst), VerilogGuardRef(*guard));
+                return writeln!(
+                    f,
+                    "assign {} = {};",
+                    VerilogPortRef(&dst),
+                    VerilogGuardRef(*guard)
+                );
             }
         }
     }

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -328,6 +328,8 @@ fn emit_component<F: io::Write>(
         (dst, flat_asgns)
     }).collect();
 
+    writeln!(f, "always @* begin")?;
+
     // Emit Verilog for the flattened guards.
     for (idx, guard) in pool.iter() {
         writeln!(f, "logic {} = {};", guard_ref_to_name(idx), flat_guard_to_expr(guard))?;
@@ -337,6 +339,8 @@ fn emit_component<F: io::Write>(
     for (dst, asgns) in grouped_asgns {
         emit_assignment_flat(dst.clone(), asgns, f)?;
     }
+
+    writeln!(f, "end")?;
 
     if !synthesis_mode {
         writeln!(f, "{checks}")?;

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -490,6 +490,12 @@ fn is_data_port(pr: &RRC<ir::Port>) -> bool {
 fn emit_assignment(
     (dst_ref, assignments): &(RRC<ir::Port>, Vec<&ir::Assignment>),
 ) -> v::Parallel {
+    // HACK HACK HACK JUST FOR FUN
+    let mut pool = ir::GuardPool::new();
+    for asgn in assignments {
+        let flat_guard = pool.flatten(&asgn.guard);
+    }
+
     // Mux over the assignment with the given default value.
     let fold_assigns = |init: v::Expr| -> v::Expr {
         assignments.iter().rfold(init, |acc, e| {

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -494,6 +494,8 @@ fn emit_assignment(
     let mut pool = ir::GuardPool::new();
     for asgn in assignments {
         let flat_guard = pool.flatten(&asgn.guard);
+        dbg!(&asgn.guard);
+        dbg!(pool.display(flat_guard));
     }
 
     // Mux over the assignment with the given default value.

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -566,12 +566,7 @@ fn emit_assignment_flat<F: io::Write>(
     assignments: Vec<(RRC<ir::Port>, GuardRef)>,
     f: &mut F,
 ) -> io::Result<()> {
-    // The default value depends on whether we are assigning to a data or control port.
-    let default = if is_data_port(&dst) {
-        "'x".to_owned()
-    } else {
-        format!("{}'d0", dst.borrow().width)
-    };
+    let data = is_data_port(&dst);
 
     // TODO This doesn't do either of the little rewrites that the proper `emit_assignment` does
     // when there is a single assignment.
@@ -586,7 +581,13 @@ fn emit_assignment_flat<F: io::Write>(
             port_to_ref(&src)
         )?;
     }
-    writeln!(f, "  {};", default)
+
+    // The default value depends on whether we are assigning to a data or control port.
+    if data {
+        writeln!(f, "  'x;")
+    } else {
+        writeln!(f, "  {}'d0;", dst.borrow().width)
+    }
 }
 
 fn port_to_ref(port_ref: &RRC<ir::Port>) -> v::Expr {

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -747,6 +747,7 @@ impl<'a> std::fmt::Display for VerilogPortRef<'a> {
                 }
             }
             ir::PortParent::Group(_) => unreachable!(),
+            ir::PortParent::StaticGroup(_) => unreachable!(),
         }
     }
 }

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -494,7 +494,9 @@ fn emit_assignment(
     let mut pool = ir::GuardPool::new();
     for asgn in assignments {
         let flat_guard = pool.flatten(&asgn.guard);
-        dbg!(&asgn.guard);
+        // TODO save the ref
+    }
+    for flat_guard in pool.iter() {
         dbg!(pool.display(flat_guard));
     }
 

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -334,7 +334,6 @@ fn emit_component<F: io::Write>(
         })
         .collect();
 
-
     if flat_assign {
         // Emit "flattened" assignments as ANF statements.
         // Emit Verilog for the flattened guards.
@@ -358,8 +357,6 @@ fn emit_component<F: io::Write>(
                 }
             }
         }
-
-
     } else {
         // Build a top-level always block to contain verilator checks for assignments
         let mut checks = v::ParallelProcess::new_always_comb();

--- a/src/backend/verilog.rs
+++ b/src/backend/verilog.rs
@@ -566,7 +566,7 @@ fn emit_assignment_flat<F: io::Write>(
     for (src, guard) in assignments {
         writeln!(f, "  {} ? {} :", guard_ref_to_name(guard), port_to_ref(&src))?;
     }
-    writeln!(f, " {};", default)
+    writeln!(f, "  {};", default)
 }
 
 fn port_to_ref(port_ref: &RRC<ir::Port>) -> v::Expr {

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -42,9 +42,9 @@ pub struct Opts {
     #[argh(switch)]
     pub disable_init: bool,
 
-    /// emit flat assignments (only relevant to the Verilog backend)
-    #[argh(switch, long = "flat")]
-    pub flat_assign: bool,
+    /// emit nested assignments (only relevant to the Verilog backend)
+    #[argh(switch, long = "nested")]
+    pub nested_assign: bool,
 
     /// select a backend
     #[argh(option, short = 'b', default = "BackendOpt::default()")]

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -42,6 +42,10 @@ pub struct Opts {
     #[argh(switch)]
     pub disable_init: bool,
 
+    /// emit flat assignments (only relevant to the Verilog backend)
+    #[argh(switch, long = "flat")]
+    pub flat_assign: bool,
+
     /// select a backend
     #[argh(option, short = 'b', default = "BackendOpt::default()")]
     pub backend: BackendOpt,

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() -> CalyxResult<()> {
         synthesis_mode: opts.enable_synthesis,
         enable_verification: !opts.disable_verify,
         initialize_inputs: !opts.disable_init,
-        flat_assign: opts.flat_assign,
+        flat_assign: !opts.nested_assign,
     };
     // Extra options for the passes
     ctx.extra_opts = opts.extra_opts.drain(..).collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ fn main() -> CalyxResult<()> {
         synthesis_mode: opts.enable_synthesis,
         enable_verification: !opts.disable_verify,
         initialize_inputs: !opts.disable_init,
+        flat_assign: opts.flat_assign,
     };
     // Extra options for the passes
     ctx.extra_opts = opts.extra_opts.drain(..).collect();

--- a/tests/backend/verilog/big-const.expect
+++ b/tests/backend/verilog/big-const.expect
@@ -525,7 +525,7 @@ std_const # (
 ) c (
     .out(c_out)
 );
+wire _guard0 = 1;
 assign done = 1'd1;
-
 // COMPONENT END: main
 endmodule

--- a/tests/backend/verilog/data-instance.expect
+++ b/tests/backend/verilog/data-instance.expect
@@ -567,19 +567,29 @@ std_add # (
     .out(data_add_multi_out),
     .right(data_add_multi_right)
 );
+wire _guard0 = 1;
+wire _guard1 = g;
+wire _guard2 = g;
+wire _guard3 = g;
+wire _guard4 = g;
+wire _guard5 = g;
+wire _guard6 = ~_guard5;
 assign add_left =
- g ? 2'd2 : 2'd0;
+  _guard1 ? 2'd2 :
+  2'd0;
 assign con_add_left =
- g ? 2'd2 : 2'd0;
+  _guard2 ? 2'd2 :
+  2'd0;
 assign data_add_left = 2'd2;
 assign data_add_multi_left =
- g ? 2'd2 :
- ~g ? 2'd3 : 'x;
-assign done = 1'd1;
+  _guard4 ? 2'd2 :
+  _guard6 ? 2'd3 :
+  'x;
 always_comb begin
-    if(~$onehot0({~g, g})) begin
-        $fatal(2, "Multiple assignment to port `data_add_multi.left'.");
-    end
+  if(~$onehot0({_guard6, _guard4})) begin
+    $fatal(2, "Multiple assignment to port `data_add_multi.left'.");
 end
+end
+assign done = 1'd1;
 // COMPONENT END: main
 endmodule

--- a/tests/backend/verilog/memory-with-external-attribute.expect
+++ b/tests/backend/verilog/memory-with-external-attribute.expect
@@ -578,10 +578,10 @@ std_mem_d1 # (
     .write_data(m1_write_data),
     .write_en(m1_write_en)
 );
+wire _guard0 = 1;
 assign m0_clk = clk;
 assign m0_reset = reset;
 assign m1_clk = clk;
 assign done = m1_done;
-
 // COMPONENT END: main
 endmodule


### PR DESCRIPTION
Our discussion about Verilog generation times on Monday kinda hooked me a bit. We talked a little about how Calyx is mostly a "wide" language as opposed to a "deep" language, in the sense that its syntax is not very nested, with one big exception: guards. Guards are very much a "deep" part of the language; they are unbounded expression trees. "Deep" structures like this are bad for performance, and in particular they are connected to some of the bad performance in Verilog generation that we've been seeing in #1360.

We talked a bit about a *long-term* project to make the language more "wide" than "deep," which is essentially described in #1051 and which @EclecticGriffin is already beginning to address in #1183.

But after the conversation, it occurred to me that, in the very short term, we could try out a limited-scope experiment with this kind of data structure without boiling the ocean. In particular, what if we built a "flattened" representation for guards *only*, because they are are the biggest problem? If such a representation could work, we could try it out non-disruptively by translating the old (pointer-based) representation into the new one only where we want to use it, leaving the old representation as the one most of the codebase sees.

Namely, we could try using the flat representation *in Verilog generation only* and see how that works out. We would pay the cost for conversion from the pointer-based to the flattened representation, but perhaps the resulting backend performance would be worth it. As a spoiler, it turns out to be worth it!!

### Intent

This is mostly just a proof of concept; I wanted to see what would happen. We may totally decide to abandon this PR and never merge it! But I thought code would be the easiest way to get the idea across. However, since it did sort of work out in a positive way, maybe we want to discuss how to build on this approach to make it more practical.

This PR writeup is rather long because it contains a mix of concrete proposals/outcomes and detailed background. Some readers might find parts of the detailed background obvious (especially the immediately next section, "Flat Data Structure"); the most actionable sections are "ANF Verilog Generation" and "Performance" if you're skimming. And some parts might be short on explanation; **please** ask questions if anything is not fully explained. The main point of this PR is as a discussion starting point, more so than as an actual feature.

### Flat Data Structure

I added a new `FlatGuard` type to the IR but did not remove the existing pointer-based `Guard`. The new representation is a bog-standard arena-style expression tree: `FlatGuard` looks exactly like `Guard` except that its children are not `Box<Guard>` but indices into a vector.

Here's a line from `Guard`:
https://github.com/cucapra/calyx/blob/939151ae283eb44db53634983dae60cacfa489db/calyx/src/ir/guard.rs#L29

And the corresponding line from `FlatGuard`:
https://github.com/cucapra/calyx/blob/939151ae283eb44db53634983dae60cacfa489db/calyx/src/ir/flat_guard.rs#L24

That `GuardRef` is just a [newtype][] for a `u32`. It's an index into a `GuardPool`, which is just a newtype for a `Vec<FlatGuard>`. So, to be clear, a `FlatGuard` is not very useful by itself (unless it is a "leaf"); you need a `GuardPool` to be able to look up its children.

I added a `GuardPool::flatten` method that translates from an old `Guard` to an equivalent `FlatGuard` by recursively adding the entire expression tree to the pool.

### ANF Verilog Generation

The reason I thought this would be a good fit for making the Verilog backend faster is that this representation makes it *really easy* to emit guards in [A-normal form][anf] (ANF), i.e., as "flat" instead of "deep" Verilog. Using a real example, instead of emitting this Verilog code:

```verilog
assign st_fsm_in =
 st_fsm_out == 3'd4 ? 3'd0 :
 st_fsm_out < 3'd4 & tdst_go_out ? fsm_incr_out : 3'd0;
```

We can instead emit this:

```verilog
wire _guard21 = st_fsm_out == 3'd4;
wire _guard22 = st_fsm_out < 3'd4;
wire _guard23 = tdst_go_out;
wire _guard24 = _guard22 & _guard23;
assign st_fsm_in =
  _guard21 ? 3'd0 :
  _guard24 ? fsm_incr_out :
  3'd0;
```

That is, every node in the syntax tree becomes its own `wire` declaration. It's not fun to read, but it is semantically equivalent!

But why on earth would generating the ANF version of the code be faster? It's more verbose! You have all these extra names and stuff!

The reason is all about saving memory futzing: we can generate this code in a "streaming" way that doesn't involve a lot of memory allocation and deallocation. By generating one little statement at a time and getting it off our plate, we don't have to do deep recursion into nested data structures while building stuff up in memory.

Another way to put it is: Our current Verilog generation code relies on [a Verilog AST library][vast]. Why? There are some convenience things about not needing to remember if "not" is spelled `~` or `!`, but a big reason is that it works out all the parentheses and stuff for deeply nested expressions. By building up an AST data structure in one phase and *then* serializing it to a string in another phase, the AST library can make sure the expression looks right to a Verilog parser. But in ANF, there is no need for any of that extra assurance. There are *never* any parentheses needed, and the expressions we generate are absurdly simple. The AST library doesn't buy us very much; it's basically just as easy to `writeln!()` the strings directly ourselves.

The `FlatGuard` data structure makes this ridiculously easy to do without any recursion at all. We can just iterate through the `Vec<FlatGuard>` in order, generating an ANF statement for every `FlatGuard` independently. We generate a name `_guard*` where `*` is just the index in the vector. When a later statement needs to refer to its child expressions, it has their indices in the form of `GuardRef`s (remember, those are just `u32`s): it can print out the appropriate `_guard*` names to refer those previous declarations (without even looking at the underlying `FlatGuard`s for the children).

### Nested Verilog Generation

I wanted to make it possible (the default, actually) to keep the old nested style of Verilog generation. This will minimize disruption (all tests still pass), and it's a nice option to have anyway because it's so much easier for humans to read nested expressions than ANF lists.

Fortunately, the flat guard representation makes this very easy to do! There are two ways to look at the contents of a `GuardPool`: one is the "in-order" way we just used for ANF generation, but you can still look at it in a recursive, tree-style way—just like the old pointer-based `Guard`. All you have to do is recursively traverse the `GuardRef`s to child `FlatGuard`s by looking them up in the pool. Here's that code for a recursive traversal of a `FlatGuard`, which is not very different from the old recursive traversal code for `Guard`:
https://github.com/cucapra/calyx/blob/939151ae283eb44db53634983dae60cacfa489db/src/backend/verilog.rs#L695-L708

Namely, it's just a matter replacing `*foo` dereferncing with `pool.get(foo)`, which is our new, flat flavor of dereferencing. (Now, someday, maybe Rust will gain first-class support for allocation arenas, like Cyclone used to have, that would make this even nicer and more indistinguishable from using `Box`!)

There is a new compiler CLI argument, `--flat`, that enables ANF-style Verilog generation. The default is to use the normal, nested Verilog style. The important thing to realize, however, is that *both of them work on the same flat representation*. That is, the Verilog backend first flattens all the guards, regardless of the `--flat` flag. *Then* it checks which style you want and traverses the same flat data structure accordingly:
https://github.com/cucapra/calyx/blob/939151ae283eb44db53634983dae60cacfa489db/src/backend/verilog.rs#L337

I think the most instructive part of the code to look at would be to contrast the [nested-style `emit_assignment`](https://github.com/cucapra/calyx/blob/939151ae283eb44db53634983dae60cacfa489db/src/backend/verilog.rs#L544), which I only changed a little bit in this PR, with the [ANF-style `emit_assignment_flat`](https://github.com/cucapra/calyx/blob/939151ae283eb44db53634983dae60cacfa489db/src/backend/verilog.rs#L598), which is new. Namely, the latter `write!`s strings directly and does not use [VAST][] at all.

The point of this section has been to convince you that a "flat" representation can also be viewed as a tree, just like a pointer-based representation. It leads a double life. So code that wants to work with trees can remain happy.

### Correctness

CI is green. That means the default (not `--flat`) mode matches the output from the old version exactly.

I have also tested the new `--flat` mode in two correctness test suites. See [these Runt suite configs][runt]. It would hypothetically be possible to test `--flat` for *every* test we have in the entire suite, but I have not done that yet.

[runt]: https://github.com/cucapra/calyx/blob/939151ae283eb44db53634983dae60cacfa489db/runt.toml#L107-L182

### Performance

I measured the time taken on Havarti to generate Verilog for `DRB1.futil`, from #1360. I am reporting the time from Calyx's own per-stage logging, i.e., it is *just* for the Verilog backend (which is the vast majority of the end-to-end time). Here's the command I benchmarked:

	cargo run --release -- --log INFO -b verilog -d cell-share DRB1.futil > /dev/null

I compared our baseline (i.e., the `master`  branch) with both old-style (nested) and new-style (ANF) code generation on this `flat-guard` branch. (Both include @EclecticGriffin's buffering fix from #1385, which, as an aside, was very helpful for the new version because it involves even more small writes.)

Mean & standard deviation Verilog generation times over 3 runs on Havarti, in seconds:

* `master`: 65 ± 1
* `flat-guard`, nested mode: 68.87 ± 0.04
* `flat-guard`, flat mode: 19.57 ± 0.06

So this PR makes the normal mode 6% slower, but its new nested mode is 3.3× faster.

I am honestly surprised about both results. I would have thought nested mode would have been much slower than `master`: that case has added a kinda-useless data structure conversion and not reduced AST library use. The fact that it's only 6% slower is pretty neat! And I was not expecting a 3.3× win for flat codegen, given that it's emitting more total bytes. Rad!

### Next Steps

With some massaging, we could consider merging this as-is just as a way to make Verilog generation faster. (As always, I am not a very good Rust programmer, so any critique would be very helpful!!!) Maybe we want to consider making it the default mode. I dunno. If we do, these are some things I would want to address next:

* More testing. Flip the switch for all test suites in CI.
* Maybe use an existing library like [`cranelift-entity`](https://crates.io/crates/cranelift-entity) instead of my own homegrown `Vec` thing.
* Hash consing. Seems like we could save a lot of space by deduplicating guards. (I already have special-case deduplication for true guards.)

Longer term, we could try to replace `Guard` with `FlatGuard` everywhere, eventually removing `Guard` entirely. We could do this incrementally by exposing translating back to a `Guard` when clients need it, but keeping the internal representation flat. The hard part with this would be dealing with guard mutation. But maybe those can be functionalized easily enough; who knows.

Or perhaps we never merge this PR, and we just learn some lessons from it. Namely, the lessons are that flat representations are cool and fast and they need not be all that disruptive. That would be cool too. I'm just glad to have done a little exploration to understand how easy it is to generate ANF code quickly while retaining the ability to generate nested code from the same data structure!

[newtype]: https://doc.rust-lang.org/rust-by-example/generics/new_types.html
[anf]: https://en.wikipedia.org/wiki/A-normal_form
[vast]: https://github.com/vegaluisjose/vast