### PR TITLE
`comb-prop`: Remove assignments before applying rewrites

### DIFF
--- a/calyx-opt/src/passes/dead_cell_removal.rs
+++ b/calyx-opt/src/passes/dead_cell_removal.rs
@@ -23,6 +23,33 @@ impl Named for DeadCellRemoval {
     }
 }
 
+impl DeadCellRemoval {
+    /// Retain the write if the destination is a hole or if the parent of the
+    /// destination is read from.
+    fn retain_write<T: Clone + Eq + ToString>(
+        &self,
+        wire_reads: &HashSet<ir::Id>,
+        asgn: &ir::Assignment<T>,
+    ) -> bool {
+        let dst = asgn.dst.borrow();
+        if dst.is_hole() {
+            true
+        } else {
+            let parent = &dst.get_parent_name();
+            let out =
+                self.all_reads.contains(parent) || wire_reads.contains(parent);
+            if !out {
+                log::debug!(
+                    "`{}' because `{}' is unused",
+                    ir::Printer::assignment_to_str(asgn),
+                    parent
+                )
+            }
+            out
+        }
+    }
+}
+
 impl Visitor for DeadCellRemoval {
     fn start_if(
         &mut self,
@@ -107,48 +134,23 @@ impl Visitor for DeadCellRemoval {
 
             // Remove writes to ports on unused cells.
             for gr in comp.get_groups().iter() {
-                gr.borrow_mut().assignments.retain(|asgn| {
-                    let dst = asgn.dst.borrow();
-                    if dst.is_hole() {
-                        true
-                    } else {
-                        let parent = &dst.get_parent_name();
-                        self.all_reads.contains(parent)
-                            || wire_reads.contains(parent)
-                    }
-                })
+                gr.borrow_mut()
+                    .assignments
+                    .retain(|asgn| self.retain_write(&wire_reads, asgn))
             }
             // Remove writes to ports on unused cells.
             for gr in comp.get_static_groups().iter() {
-                gr.borrow_mut().assignments.retain(|asgn| {
-                    let dst = asgn.dst.borrow();
-                    if dst.is_hole() {
-                        true
-                    } else {
-                        let parent = &dst.get_parent_name();
-                        self.all_reads.contains(parent)
-                            || wire_reads.contains(parent)
-                    }
-                })
+                gr.borrow_mut()
+                    .assignments
+                    .retain(|asgn| self.retain_write(&wire_reads, asgn))
             }
             for cgr in comp.comb_groups.iter() {
-                cgr.borrow_mut().assignments.retain(|asgn| {
-                    let dst = asgn.dst.borrow();
-                    let parent = &dst.get_parent_name();
-                    self.all_reads.contains(parent)
-                        || wire_reads.contains(parent)
-                })
+                cgr.borrow_mut()
+                    .assignments
+                    .retain(|asgn| self.retain_write(&wire_reads, asgn))
             }
-            comp.continuous_assignments.retain(|asgn| {
-                let dst = asgn.dst.borrow();
-                if dst.is_hole() {
-                    true
-                } else {
-                    let parent = &dst.get_parent_name();
-                    self.all_reads.contains(parent)
-                        || wire_reads.contains(parent)
-                }
-            });
+            comp.continuous_assignments
+                .retain(|asgn| self.retain_write(&wire_reads, asgn));
 
             // Remove unused cells
             let removed = comp.cells.retain(|c| {

--- a/tests/passes/comb-prop/comb-prop.expect
+++ b/tests/passes/comb-prop/comb-prop.expect
@@ -18,6 +18,7 @@ component main(a: 4, b: 4, c: 1, @go go: 1, @clk clk: 1, @reset reset: 1) -> (@d
       lt.right = r.out;
       lt.left = b;
     }
+    w4.in = c;
     w2.in = b;
     w1.in = a;
   }

--- a/tests/passes/comb-prop/inline-write.expect
+++ b/tests/passes/comb-prop/inline-write.expect
@@ -12,6 +12,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       p.write_en = 1'd1;
       write_p[done] = p.done;
     }
+    p.in = w1.out;
   }
 
   control {

--- a/tests/passes/comb-prop/multiple-reads-from-write.expect
+++ b/tests/passes/comb-prop/multiple-reads-from-write.expect
@@ -13,6 +13,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       p.write_en = 1'd1;
       write_p[done] = p.done;
     }
+    p.in = w1.out;
     w3.in = w1.out;
   }
 


### PR DESCRIPTION
- more debugging information from dead-cell-removal
- remove rewritten assignments before rewrite application
