### PR TITLE
[calyx-py] Translate `gen_exp.py` to use the new builder

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -562,3 +562,14 @@ def ctx_asgn(lhs: ExprBuilder, rhs: Union[ExprBuilder, CondExprBuilder]):
     assert TLS.groups, "assignment outside `with group`"
     group_builder: GroupBuilder = TLS.groups[-1]
     group_builder.asgn(lhs, rhs)
+
+
+"""A one bit low signal"""
+LO = const(1, 0)
+"""A one bit high signal"""
+HI = const(1, 1)
+
+
+def par(*args: Union[GroupBuilder, ast.Control, ast.Group, ast.Invoke]) -> ast.ParComp:
+    """Build a parallel composition of control expressions."""
+    return ast.ParComp([as_control(x) for x in args])

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -91,7 +91,7 @@ class ComponentBuilder:
                 f"Group `{name}' not found in component {self.component.name}"
             )
 
-    def group(self, name: str) -> GroupBuilder:
+    def group(self, name: str, static_delay: Optional[int] = None) -> GroupBuilder:
         group = ast.Group(ast.CompVar(name), connections=[])
         self.component.wires.append(group)
         builder = GroupBuilder(group, self)

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -96,7 +96,7 @@ class ComponentBuilder:
             )
 
     def group(self, name: str, static_delay: Optional[int] = None) -> GroupBuilder:
-        group = ast.Group(ast.CompVar(name), connections=[])
+        group = ast.Group(ast.CompVar(name), connections=[], static_delay=static_delay)
         self.component.wires.append(group)
         builder = GroupBuilder(group, self)
         self.index[name] = builder
@@ -190,7 +190,7 @@ def as_control(obj):
         assert False, f"unsupported control type {type(obj)}"
 
 
-def while_(port: ExprBuilder, cond: Optional[GroupBuilder], body):
+def while_(port: ExprBuilder, cond: Optional[GroupBuilder], body) -> ast.While:
     """Build a `while` control statement."""
     if cond:
         assert isinstance(
@@ -202,7 +202,7 @@ def while_(port: ExprBuilder, cond: Optional[GroupBuilder], body):
     return ast.While(port.expr, cg, as_control(body))
 
 
-def if_(port: ExprBuilder, cond: Optional[GroupBuilder], body):
+def if_(port: ExprBuilder, cond: Optional[GroupBuilder], body) -> ast.If:
     """Build an `if` control statement."""
     if cond:
         assert isinstance(
@@ -214,7 +214,7 @@ def if_(port: ExprBuilder, cond: Optional[GroupBuilder], body):
     return ast.If(port.expr, cg, as_control(body))
 
 
-def invoke(cell: CellBuilder, **kwargs):
+def invoke(cell: CellBuilder, **kwargs) -> ast.Invoke:
     """Build an `invoke` control statement.
 
     The keyword arguments should have the form `in_*` and `out_*`, where

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -21,7 +21,8 @@ class Builder:
         self.imported = set()
         self.import_("primitives/core.futil")
 
-    def component(self, name: str, cells=[]):
+    def component(self, name: str, cells=None):
+        cells = cells or []
         comp_builder = ComponentBuilder(self, name, cells)
         self.program.components.append(comp_builder.component)
         return comp_builder
@@ -213,7 +214,7 @@ def if_(port: ExprBuilder, cond: Optional[GroupBuilder], body):
     return ast.If(port.expr, cg, as_control(body))
 
 
-def invoke(cell: "CellBuilder", **kwargs):
+def invoke(cell: CellBuilder, **kwargs):
     """Build an `invoke` control statement.
 
     The keyword arguments should have the form `in_*` and `out_*`, where

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import threading
 from typing import Dict, Union, Optional, List
 from . import py_ast as ast
@@ -64,13 +66,13 @@ class ComponentBuilder:
         return ControlBuilder(self.component.controls)
 
     @control.setter
-    def control(self, builder: Union[ast.Control, "ControlBuilder"]):
+    def control(self, builder: Union[ast.Control, ControlBuilder]):
         if isinstance(builder, ControlBuilder):
             self.component.controls = builder.stmt
         else:
             self.component.controls = builder
 
-    def get_cell(self, name: str) -> "CellBuilder":
+    def get_cell(self, name: str) -> CellBuilder:
         out = self.index.get(name)
         if out and isinstance(out, CellBuilder):
             return out
@@ -80,7 +82,7 @@ class ComponentBuilder:
                 f"Known cells: {list(map(lambda c: c.id.name, self.component.cells))}"
             )
 
-    def get_group(self, name: str) -> "GroupBuilder":
+    def get_group(self, name: str) -> GroupBuilder:
         out = self.index.get(name)
         if out and isinstance(out, GroupBuilder):
             return out
@@ -89,14 +91,14 @@ class ComponentBuilder:
                 f"Group `{name}' not found in component {self.component.name}"
             )
 
-    def group(self, name: str) -> "GroupBuilder":
+    def group(self, name: str) -> GroupBuilder:
         group = ast.Group(ast.CompVar(name), connections=[])
         self.component.wires.append(group)
         builder = GroupBuilder(group, self)
         self.index[name] = builder
         return builder
 
-    def comb_group(self, name: str) -> "GroupBuilder":
+    def comb_group(self, name: str) -> GroupBuilder:
         group = ast.CombGroup(ast.CompVar(name), connections=[])
         self.component.wires.append(group)
         builder = GroupBuilder(group, self)
@@ -106,7 +108,7 @@ class ComponentBuilder:
     def cell(
         self,
         name: str,
-        comp: Union[ast.CompInst, "ComponentBuilder"],
+        comp: Union[ast.CompInst, ComponentBuilder],
         is_external=False,
         is_ref=False,
     ) -> "CellBuilder":
@@ -123,6 +125,10 @@ class ComponentBuilder:
 
     def reg(self, name: str, size: int):
         return self.cell(name, ast.Stdlib.register(size))
+
+    def const(self, name: str, width: int, value: int):
+        """Utility wrapper for generating StdConstant cells"""
+        return self.cell(name, ast.Stdlib.constant(width, value))
 
     def mem_d1(
         self,

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -36,9 +36,12 @@ class Builder:
 class ComponentBuilder:
     """Builds Calyx components definitions."""
 
-    def __init__(self, prog: Builder, name: str, cells: List[ast.Cell] = []):
+    def __init__(
+        self, prog: Builder, name: str, cells: Optional[List[ast.Cell]] = None
+    ):
         """Contructs a new component in the current program. If `cells` is
         provided, the component will be initialized with those cells."""
+        cells = cells if cells else list()
         self.prog = prog
         self.component: ast.Component = ast.Component(
             name,
@@ -58,7 +61,7 @@ class ComponentBuilder:
     def output(self, name: str, size: int):
         self.component.outputs.append(ast.PortDef(ast.CompVar(name), size))
 
-    def this(self) -> "ThisBuilder":
+    def this(self) -> ThisBuilder:
         return ThisBuilder()
 
     @property

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -114,7 +114,7 @@ class ComponentBuilder:
         comp: Union[ast.CompInst, ComponentBuilder],
         is_external=False,
         is_ref=False,
-    ) -> "CellBuilder":
+    ) -> CellBuilder:
         # If we get a (non-primitive) component builder, instantiate it
         # with no parameters.
         if isinstance(comp, ComponentBuilder):
@@ -129,7 +129,7 @@ class ComponentBuilder:
     def reg(self, name: str, size: int):
         return self.cell(name, ast.Stdlib.register(size))
 
-    def const(self, name: str, width: int, value: int):
+    def const(self, name: str, width: int, value: int) -> CellBuilder:
         """Utility wrapper for generating StdConstant cells"""
         return self.cell(name, ast.Stdlib.constant(width, value))
 

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -373,7 +373,7 @@ class CellBuilder(CellLikeBuilder):
     def __init__(self, cell: ast.Cell):
         self._cell = cell
 
-    def port(self, name: str):
+    def port(self, name: str) -> ExprBuilder:
         """Build a port access expression."""
         return ExprBuilder(ast.Atom(ast.CompPort(self._cell.id, name)))
 

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -189,7 +189,7 @@ def as_control(obj):
         assert False, f"unsupported control type {type(obj)}"
 
 
-def while_(port: "ExprBuilder", cond: Optional["GroupBuilder"], body):
+def while_(port: ExprBuilder, cond: Optional[GroupBuilder], body):
     """Build a `while` control statement."""
     if cond:
         assert isinstance(
@@ -201,7 +201,7 @@ def while_(port: "ExprBuilder", cond: Optional["GroupBuilder"], body):
     return ast.While(port.expr, cg, as_control(body))
 
 
-def if_(port: "ExprBuilder", cond: Optional["GroupBuilder"], body):
+def if_(port: ExprBuilder, cond: Optional[GroupBuilder], body):
     """Build an `if` control statement."""
     if cond:
         assert isinstance(
@@ -275,11 +275,11 @@ class ExprBuilder:
     def __init__(self, expr: ast.GuardExpr):
         self.expr = expr
 
-    def __and__(self, other: "ExprBuilder"):
+    def __and__(self, other: ExprBuilder):
         """Construct an "and" logical expression with &."""
         return ExprBuilder(ast.And(self.expr, other.expr))
 
-    def __or__(self, other: "ExprBuilder"):
+    def __or__(self, other: ExprBuilder):
         """Construct an "or" logical expression with |."""
         return ExprBuilder(ast.Or(self.expr, other.expr))
 
@@ -287,7 +287,7 @@ class ExprBuilder:
         """Construct a "not" logical expression with ~."""
         return ExprBuilder(ast.Not(self.expr))
 
-    def __matmul__(self, rhs: "ExprBuilder"):
+    def __matmul__(self, rhs: ExprBuilder):
         """Construct a conditional expression with @.
 
         This produces a `CondExprBuilder`, which wraps a value
@@ -298,11 +298,11 @@ class ExprBuilder:
         """
         return CondExprBuilder(self, rhs)
 
-    def __eq__(self, other: "ExprBuilder"):
+    def __eq__(self, other: ExprBuilder):
         """Construct an equality comparison with ==."""
         return ExprBuilder(ast.Eq(self.expr, other.expr))
 
-    def __ne__(self, other: "ExprBuilder"):
+    def __ne__(self, other: ExprBuilder):
         """Construct an inequality comparison with ==."""
         return ExprBuilder(ast.Neq(self.expr, other.expr))
 

--- a/calyx-py/calyx/gen_ln.py
+++ b/calyx-py/calyx/gen_ln.py
@@ -1,311 +1,213 @@
 from typing import List
 from math import log
 from calyx.py_ast import (
-    Connect,
-    CompVar,
-    Cell,
-    Group,
-    ConstantPort,
-    CompPort,
     Stdlib,
     Component,
-    ThisPort,
-    HolePort,
-    PortDef,
-    SeqComp,
-    Enable,
-    ParComp,
     CompInst,
-    Invoke,
-    Program,
-    Control,
     Import,
 )
 from calyx.utils import float_to_fixed_point
 from fud.stages.verilator import numeric_types
 from calyx.gen_msb import gen_msb_calc
 
+from calyx.builder import Builder, ComponentBuilder, CellBuilder, HI, par, invoke
 
-def gen_constant_cell(name, value, width, int_width, is_signed) -> Cell:
+
+def gen_constant_cell(
+    comp: ComponentBuilder,
+    name: str,
+    value: str,
+    width: int,
+    int_width: int,
+    is_signed: bool,
+) -> CellBuilder:
     """
-    Generates a constant cell named `name`, and value, widht, int_width, and is_signed
+    Generates a constant cell named `name`, and value, width, int_width, and is_signed
     set according to their respective arguments.
     """
-    return Cell(
-        CompVar(name),
-        Stdlib.constant(
-            width,
-            numeric_types.FixedPoint(
-                value, width, int_width, is_signed
-            ).unsigned_integer(),
-        ),
+    return comp.const(
+        name,
+        width,
+        numeric_types.FixedPoint(value, width, int_width, is_signed).unsigned_integer(),
     )
 
 
-def multiply_cells(group_name, mult_cell, lhs, rhs):
+def multiply_cells(
+    comp: ComponentBuilder, group_name: str, mult_cell: str, lhs: str, rhs: str
+):
     """
     Returns a group named `group_name" that multiplies `lhs` and `rhs` using `mult_cell`
     """
-    return Group(
-        id=CompVar(group_name),
-        connections=[
-            Connect(
-                CompPort(CompVar(mult_cell), "go"),
-                ConstantPort(1, 1),
-            ),
-            Connect(
-                CompPort(CompVar(mult_cell), "left"),
-                CompPort(CompVar(rhs), "out"),
-            ),
-            Connect(
-                CompPort(CompVar(mult_cell), "right"),
-                CompPort(CompVar(lhs), "out"),
-            ),
-            Connect(
-                HolePort(CompVar(group_name), "done"),
-                CompPort(CompVar(mult_cell), "done"),
-            ),
-        ],
-    )
+    mult_cell_actual = comp.get_cell(mult_cell)
+    lhs_actual = comp.get_cell(lhs)
+    rhs_actual = comp.get_cell(rhs)
+
+    with comp.group(group_name) as group:
+        mult_cell_actual.go = HI
+        mult_cell_actual.left = rhs_actual.out
+        mult_cell_actual.right = lhs_actual.out
+        group.done = mult_cell_actual.done
 
 
-def generate_pade_cells(width: int, int_width: int, is_signed: bool) -> List[Cell]:
+def generate_pade_cells(
+    comp: ComponentBuilder, width: int, int_width: int, is_signed: bool
+):
     """
-    Generates cells for pade approximant componenet
+    Generates cells for pade approximant component
     """
     frac_width = width - int_width
-    n1 = gen_constant_cell(
+    gen_constant_cell(
+        comp,
         "n1",
         str(float_to_fixed_point(3.40547, frac_width)),
         width,
         int_width,
         is_signed,
     )
-    n2 = gen_constant_cell(
+    gen_constant_cell(
+        comp,
         "n2",
         str(float_to_fixed_point(2.43279, frac_width)),
         width,
         int_width,
         is_signed,
     )
-    n3 = gen_constant_cell(
-        "n3", str(float_to_fixed_point(5.8376, frac_width)), width, int_width, is_signed
+    gen_constant_cell(
+        comp,
+        "n3",
+        str(float_to_fixed_point(5.8376, frac_width)),
+        width,
+        int_width,
+        is_signed,
     )
-    d2 = gen_constant_cell(
-        "d2", str(float_to_fixed_point(6.0, frac_width)), width, int_width, is_signed
+    gen_constant_cell(
+        comp,
+        "d2",
+        str(float_to_fixed_point(6.0, frac_width)),
+        width,
+        int_width,
+        is_signed,
     )
-    d3 = gen_constant_cell(
-        "d3", str(float_to_fixed_point(2.25, frac_width)), width, int_width, is_signed
+    gen_constant_cell(
+        comp,
+        "d3",
+        str(float_to_fixed_point(2.25, frac_width)),
+        width,
+        int_width,
+        is_signed,
     )
-    mult_pipe = Cell(
-        CompVar("mult_pipe"),
+    comp.cell(
+        "mult_pipe",
         Stdlib.fixed_point_op(
             "mult_pipe", width, int_width, width - int_width, is_signed
         ),
     )
-    n_mult_pipe1 = Cell(
-        CompVar("n_mult_pipe1"),
+    comp.cell(
+        "n_mult_pipe1",
         Stdlib.fixed_point_op(
             "mult_pipe", width, int_width, width - int_width, is_signed
         ),
     )
-    n_mult_pipe2 = Cell(
-        CompVar("n_mult_pipe2"),
+    comp.cell(
+        "n_mult_pipe2",
         Stdlib.fixed_point_op(
             "mult_pipe", width, int_width, width - int_width, is_signed
         ),
     )
-    d_mult_pipe1 = Cell(
-        CompVar("d_mult_pipe1"),
+    comp.cell(
+        "d_mult_pipe1",
         Stdlib.fixed_point_op(
             "mult_pipe", width, int_width, width - int_width, is_signed
         ),
     )
-    d_mult_pipe2 = Cell(
-        CompVar("d_mult_pipe2"),
+    comp.cell(
+        "d_mult_pipe2",
         Stdlib.fixed_point_op(
             "mult_pipe", width, int_width, width - int_width, is_signed
         ),
     )
-    div_pipe = Cell(
-        CompVar("div_pipe"),
+    comp.cell(
+        "div_pipe",
         Stdlib.fixed_point_op(
             "div_pipe", width, int_width, width - int_width, is_signed
         ),
     )
-    add1 = Cell(
-        CompVar("add1"),
+    comp.cell(
+        "add1",
         Stdlib.fixed_point_op("add", width, int_width, width - int_width, is_signed),
     )
-    add2 = Cell(
-        CompVar("add2"),
+    comp.cell(
+        "add2",
         Stdlib.fixed_point_op("add", width, int_width, width - int_width, is_signed),
     )
-    add3 = Cell(
-        CompVar("add3"),
+    comp.cell(
+        "add3",
         Stdlib.fixed_point_op("add", width, int_width, width - int_width, is_signed),
     )
-    sub1 = Cell(
-        CompVar("sub1"),
+    comp.cell(
+        "sub1",
         Stdlib.fixed_point_op("sub", width, int_width, width - int_width, is_signed),
     )
-    numerator_reg = Cell(CompVar("num_reg"), Stdlib.register(width))
-    denominator_reg = Cell(CompVar("den_reg"), Stdlib.register(width))
-    res_reg = Cell(CompVar("res_reg"), Stdlib.register(width))
-    x_reg = Cell(CompVar("x_reg"), Stdlib.register(width))
-    x_sq_reg = Cell(CompVar("x_sq_reg"), Stdlib.register(width))
-    return [
-        n1,
-        n2,
-        n3,
-        d2,
-        d3,
-        mult_pipe,
-        n_mult_pipe1,
-        n_mult_pipe2,
-        d_mult_pipe1,
-        d_mult_pipe2,
-        div_pipe,
-        add1,
-        add2,
-        add3,
-        sub1,
-        numerator_reg,
-        denominator_reg,
-        res_reg,
-        x_reg,
-        x_sq_reg,
-    ]
+    comp.reg("num_reg", width)
+    comp.reg("den_reg", width)
+    comp.reg("res_reg", width)
+    comp.reg("x_reg", width)
+    comp.reg("x_sq_reg", width)
 
 
-def generate_pade_groups() -> List[Group]:
+def generate_pade_groups(comp: ComponentBuilder):
     """
     Generates groups for pade approximant componenet
     """
-    mult_groups = [
-        multiply_cells("get_x_sq", "mult_pipe", "x_reg", "x_reg"),
-        multiply_cells("num_term1", "n_mult_pipe1", "mult_pipe", "n1"),
-        multiply_cells("num_term2", "n_mult_pipe2", "x_reg", "n2"),
-        multiply_cells("den_term2", "d_mult_pipe2", "x_reg", "d2"),
-    ]
-    write_x_to_reg = Group(
-        id=CompVar("write_x_to_reg"),
-        connections=[
-            Connect(
-                CompPort(CompVar("x_reg"), "write_en"),
-                ConstantPort(1, 1),
-            ),
-            Connect(CompPort(CompVar("x_reg"), "in"), ThisPort(CompVar("x"))),
-            Connect(
-                HolePort(CompVar("write_x_to_reg"), "done"),
-                CompPort(CompVar("x_reg"), "done"),
-            ),
-        ],
-    )
-    get_numerator = Group(
-        id=CompVar("get_numerator"),
-        connections=[
-            Connect(
-                CompPort(CompVar("add1"), "left"),
-                CompPort(CompVar("n_mult_pipe1"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("add1"), "right"),
-                CompPort(CompVar("n_mult_pipe2"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("sub1"), "left"),
-                CompPort(CompVar("add1"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("sub1"), "right"),
-                CompPort(CompVar("n3"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("num_reg"), "in"),
-                CompPort(CompVar("sub1"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("num_reg"), "write_en"),
-                ConstantPort(1, 1),
-            ),
-            Connect(
-                HolePort(CompVar("get_numerator"), "done"),
-                CompPort(CompVar("num_reg"), "done"),
-            ),
-        ],
-    )
-    get_denominator = Group(
-        id=CompVar("get_denominator"),
-        connections=[
-            Connect(
-                CompPort(CompVar("add2"), "left"),
-                CompPort(CompVar("mult_pipe"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("add2"), "right"),
-                CompPort(CompVar("d_mult_pipe2"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("add3"), "left"),
-                CompPort(CompVar("add2"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("add3"), "right"),
-                CompPort(CompVar("d3"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("den_reg"), "in"),
-                CompPort(CompVar("add3"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("den_reg"), "write_en"),
-                ConstantPort(1, 1),
-            ),
-            Connect(
-                HolePort(CompVar("get_denominator"), "done"),
-                CompPort(CompVar("den_reg"), "done"),
-            ),
-        ],
-    )
-    get_res = Group(
-        id=CompVar("get_res"),
-        connections=[
-            Connect(CompPort(CompVar("res_reg"), "write_en"), ConstantPort(1, 1)),
-            Connect(
-                CompPort(CompVar("res_reg"), "in"),
-                CompPort(CompVar("div_pipe"), "out_quotient"),
-            ),
-            Connect(
-                HolePort(CompVar("get_res"), "done"),
-                CompPort(CompVar("res_reg"), "done"),
-            ),
-        ],
-    )
-    return mult_groups + [write_x_to_reg, get_numerator, get_denominator, get_res]
 
+    multiply_cells(comp, "get_x_sq", "mult_pipe", "x_reg", "x_reg"),
+    multiply_cells(comp, "num_term1", "n_mult_pipe1", "mult_pipe", "n1"),
+    multiply_cells(comp, "num_term2", "n_mult_pipe2", "x_reg", "n2"),
+    multiply_cells(comp, "den_term2", "d_mult_pipe2", "x_reg", "d2"),
 
-def generate_pade_control() -> Control:
-    """
-    Generates control for pade approximant componenet
-    """
-    return SeqComp(
-        [
-            Enable("write_x_to_reg"),
-            Enable("get_x_sq"),
-            ParComp([Enable("num_term1"), Enable("num_term2"), Enable("den_term2")]),
-            ParComp([Enable("get_numerator"), Enable("get_denominator")]),
-            Invoke(
-                CompVar("div_pipe"),
-                [
-                    ("left", CompPort(CompVar("num_reg"), "out")),
-                    ("right", CompPort(CompVar("den_reg"), "out")),
-                ],
-                [],
-            ),
-            Enable("get_res"),
-        ]
-    )
+    x_reg = comp.get_cell("x_reg")
+    add1 = comp.get_cell("add1")
+    add2 = comp.get_cell("add2")
+    add3 = comp.get_cell("add3")
+    n_mult_pipe1 = comp.get_cell("n_mult_pipe1")
+    n_mult_pipe2 = comp.get_cell("n_mult_pipe2")
+    d_mult_pipe2 = comp.get_cell("d_mult_pipe2")
+    sub1 = comp.get_cell("sub1")
+    n3 = comp.get_cell("n3")
+    d3 = comp.get_cell("d3")
+    num_reg = comp.get_cell("num_reg")
+    den_reg = comp.get_cell("den_reg")
+    mult_pipe = comp.get_cell("mult_pipe")
+    div_pipe = comp.get_cell("div_pipe")
+    res_reg = comp.get_cell("res_reg")
+
+    with comp.group("write_x_to_reg") as write_x_to_reg:
+        x_reg.write_en = HI
+        x_reg.in_ = comp.this().x
+        write_x_to_reg.done = x_reg.done
+
+    with comp.group("get_numerator") as get_numerator:
+        add1.left = n_mult_pipe1.out
+        add1.right = n_mult_pipe2.out
+        sub1.left = add1.out
+        sub1.right = n3.out
+        num_reg.in_ = sub1.out
+        num_reg.write_en = HI
+        get_numerator.done = num_reg.done
+
+    with comp.group("get_denominator") as get_denominator:
+        add2.left = mult_pipe.out
+        add2.right = d_mult_pipe2.out
+        add3.left = add2.out
+        add3.right = d3.out
+        den_reg.in_ = add3.out
+        den_reg.write_en = HI
+        get_denominator.done = den_reg.done
+
+    with comp.group("get_res") as get_res:
+        res_reg.write_en = HI
+        res_reg.in_ = div_pipe.out_quotient
+        get_res.done = res_reg.done
 
 
 def gen_pade_approx(width: int, int_width: int, is_signed: bool) -> List[Component]:
@@ -318,187 +220,34 @@ def gen_pade_approx(width: int, int_width: int, is_signed: bool) -> List[Compone
     Read About Pade Approximant here:
     https://en.wikipedia.org/wiki/Pad%C3%A9_approximant
     """
-    return [
-        Component(
-            "ln_pade_approx",
-            inputs=[PortDef(CompVar("x"), width)],
-            outputs=[PortDef(CompVar("out"), width)],
-            structs=generate_pade_cells(width, int_width, is_signed)
-            + generate_pade_groups()
-            + [Connect(ThisPort(CompVar("out")), CompPort(CompVar("res_reg"), "out"))],
-            controls=generate_pade_control(),
-        )
+    builder = Builder()
+    comp = builder.component("ln_pade_approx")
+    comp.input("x", width)
+    comp.output("out", width)
+
+    generate_pade_cells(comp, width, int_width, is_signed)
+    generate_pade_groups(comp)
+    with comp.continuous:
+        comp.this().out = comp.get_cell("res_reg").out
+
+    comp.control += [
+        comp.get_group("write_x_to_reg"),
+        comp.get_group("get_x_sq"),
+        par(
+            comp.get_group("num_term1"),
+            comp.get_group("num_term2"),
+            comp.get_group("den_term2"),
+        ),
+        par(comp.get_group("get_numerator"), comp.get_group("get_denominator")),
+        invoke(
+            comp.get_cell("div_pipe"),
+            in_left=comp.get_cell("num_reg").out,
+            in_right=comp.get_cell("den_reg").out,
+        ),
+        comp.get_group("get_res"),
     ]
 
-
-def gen_ln_cells(width: int, int_width: int, is_signed: bool) -> List[Cell]:
-    """
-    Generates cells for the ln component.
-    """
-    and1 = Cell(CompVar("and1"), Stdlib.op("and", width, signed=False))
-    n = Cell(CompVar("n"), Stdlib.register(width))
-    div_pipe = Cell(
-        CompVar("div_pipe"),
-        Stdlib.fixed_point_op(
-            "div_pipe", width, int_width, width - int_width, is_signed
-        ),
-    )
-    add1 = Cell(
-        CompVar("add1"),
-        Stdlib.fixed_point_op("add", width, int_width, width - int_width, is_signed),
-    )
-    mult_pipe = Cell(
-        CompVar("mult_pipe"),
-        Stdlib.fixed_point_op(
-            "mult_pipe", width, int_width, width - int_width, is_signed
-        ),
-    )
-    ln_2 = gen_constant_cell(
-        "ln_2",
-        str(float_to_fixed_point(log(2), width - int_width)),
-        width,
-        int_width,
-        is_signed,
-    )
-    pade_approx = Cell(CompVar("pade_approx"), CompInst("ln_pade_approx", []))
-    res_reg = Cell(CompVar("res_reg"), Stdlib.register(width))
-    msb_gen = Cell(CompVar("msb"), CompInst("msb_calc", []))
-    slice0 = Cell(CompVar("slice0"), Stdlib.slice(width, int_width))
-    rsh = Cell(CompVar("rsh"), Stdlib.op("rsh", width, is_signed))
-    shift_amount = Cell(CompVar("shift_amount"), Stdlib.constant(width, int_width))
-    return [
-        and1,
-        n,
-        div_pipe,
-        mult_pipe,
-        ln_2,
-        pade_approx,
-        res_reg,
-        add1,
-        msb_gen,
-        slice0,
-        rsh,
-        shift_amount,
-    ]
-
-
-def gen_ln_groups() -> List[Group]:
-    """
-    Generates groups for the ln component
-    """
-    get_n = Group(
-        id=CompVar("get_n"),
-        connections=[
-            Connect(
-                CompPort(CompVar("n"), "write_en"),
-                ConstantPort(1, 1),
-            ),
-            Connect(
-                CompPort(CompVar("n"), "in"),
-                CompPort(CompVar("msb"), "count"),
-            ),
-            Connect(
-                HolePort(CompVar("get_n"), "done"),
-                CompPort(CompVar("n"), "done"),
-            ),
-        ],
-    )
-
-    get_p = Group(
-        id=CompVar("get_p"),
-        connections=[
-            Connect(
-                CompPort(CompVar("div_pipe"), "go"),
-                ConstantPort(1, 1),
-            ),
-            Connect(
-                CompPort(CompVar("div_pipe"), "left"),
-                ThisPort(CompVar("x")),
-            ),
-            Connect(
-                CompPort(CompVar("div_pipe"), "right"),
-                CompPort(CompVar("msb"), "value"),
-            ),
-            Connect(
-                HolePort(CompVar("get_p"), "done"),
-                CompPort(CompVar("div_pipe"), "done"),
-            ),
-        ],
-    )
-
-    get_term_1 = Group(
-        id=CompVar("get_term1"),
-        connections=[
-            Connect(
-                CompPort(CompVar("mult_pipe"), "go"),
-                ConstantPort(1, 1),
-            ),
-            Connect(
-                CompPort(CompVar("mult_pipe"), "left"),
-                CompPort(CompVar("ln_2"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("mult_pipe"), "right"),
-                CompPort(CompVar("n"), "out"),
-            ),
-            Connect(
-                HolePort(CompVar("get_term1"), "done"),
-                CompPort(CompVar("mult_pipe"), "done"),
-            ),
-        ],
-    )
-
-    get_res = Group(
-        id=CompVar("get_res"),
-        connections=[
-            Connect(
-                CompPort(CompVar("add1"), "left"),
-                CompPort(CompVar("mult_pipe"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("add1"), "right"),
-                CompPort(CompVar("pade_approx"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("res_reg"), "in"),
-                CompPort(CompVar("add1"), "out"),
-            ),
-            Connect(
-                CompPort(CompVar("res_reg"), "write_en"),
-                ConstantPort(1, 1),
-            ),
-            Connect(
-                HolePort(CompVar("get_res"), "done"),
-                CompPort(CompVar("res_reg"), "done"),
-            ),
-        ],
-    )
-
-    return [get_n, get_p, get_term_1, get_res]
-
-
-def gen_ln_control() -> Control:
-    """
-    Generates control for the ln component
-    """
-    return SeqComp(
-        [
-            Invoke(
-                id=CompVar("msb"),
-                in_connects=[("in", ThisPort(CompVar("x")))],
-                out_connects=[],
-            ),
-            Enable("get_n"),
-            Enable("get_p"),
-            Enable("get_term1"),
-            Invoke(
-                id=CompVar("pade_approx"),
-                in_connects=[("x", CompPort(CompVar("div_pipe"), "out_quotient"))],
-                out_connects=[],
-            ),
-            Enable("get_res"),
-        ]
-    )
+    return [comp.component]
 
 
 def generate_ln(width: int, int_width: int, is_signed: bool) -> List[Component]:
@@ -510,24 +259,93 @@ def generate_ln(width: int, int_width: int, is_signed: bool) -> List[Component]:
     as a constant),and then add ln(p) using the pade approximant.
     We use the `msb_calc` component (located in gen_msb.py) to calculate the n and p values.
     """
+    builder = Builder()
+    comp = builder.component("ln")
+    comp.input("x", width)
+    comp.output("out", width)
+
+    # this is unused for some reason
+    and1 = comp.cell("and1", Stdlib.op("and", width, signed=False))
+
+    n = comp.reg("n", width)
+    div_pipe = comp.cell(
+        "div_pipe",
+        Stdlib.fixed_point_op(
+            "div_pipe", width, int_width, width - int_width, is_signed
+        ),
+    )
+    add1 = comp.cell(
+        "add1",
+        Stdlib.fixed_point_op("add", width, int_width, width - int_width, is_signed),
+    )
+    mult_pipe = comp.cell(
+        "mult_pipe",
+        Stdlib.fixed_point_op(
+            "mult_pipe", width, int_width, width - int_width, is_signed
+        ),
+    )
+    ln_2 = gen_constant_cell(
+        comp,
+        "ln_2",
+        str(float_to_fixed_point(log(2), width - int_width)),
+        width,
+        int_width,
+        is_signed,
+    )
+    pade_approx = comp.cell("pade_approx", CompInst("ln_pade_approx", []))
+    res_reg = comp.reg("res_reg", width)
+    msb = comp.cell("msb", CompInst("msb_calc", []))
+    # these 3 appear unused, not sure why
+    slice0 = comp.cell("slice0", Stdlib.slice(width, int_width))
+    rsh = comp.cell("rsh", Stdlib.op("rsh", width, is_signed))
+    shift_amount = comp.const("shift_amount", width, int_width)
+
+    with comp.group("get_n") as get_n:
+        n.write_en = HI
+        n.in_ = msb.count
+        get_n.done = n.done
+
+    with comp.group("get_p") as get_p:
+        div_pipe.go = HI
+        div_pipe.left = comp.this().x
+        div_pipe.right = msb.value
+        get_p.done = div_pipe.done
+
+    with comp.group("get_term1") as get_term1:
+        mult_pipe.go = HI
+        mult_pipe.left = ln_2.out
+        mult_pipe.right = n.out
+        get_term1.done = mult_pipe.done
+
+    with comp.group("get_res") as get_res:
+        add1.left = mult_pipe.out
+        add1.right = pade_approx.out
+        res_reg.in_ = add1.out
+        res_reg.write_en = HI
+        get_res.done = res_reg.done
+
+    with comp.continuous:
+        comp.this().out = res_reg.out
+
+    comp.control += [
+        invoke(
+            msb,
+            in_in=comp.this().x,
+        ),
+        get_n,
+        get_p,
+        get_term1,
+        invoke(
+            pade_approx,
+            in_x=div_pipe.out_quotient,
+        ),
+        get_res,
+    ]
+
     return (
         gen_pade_approx(width, int_width, is_signed)
         + gen_msb_calc(width, int_width)
-        + [
-            Component(
-                "ln",
-                inputs=[PortDef(CompVar("x"), width)],
-                outputs=[PortDef(CompVar("out"), width)],
-                structs=gen_ln_cells(width, int_width, is_signed)
-                + gen_ln_groups()
-                + [
-                    Connect(
-                        ThisPort(CompVar("out")), CompPort(CompVar("res_reg"), "out")
-                    )
-                ],
-                controls=gen_ln_control(),
-            )
-        ]
+        + [comp.component]
     )
 
 
@@ -560,84 +378,44 @@ if __name__ == "__main__":
             "Need to pass either `-f FILE` or all of `-d DEGREE -w WIDTH -i INT_WIDTH`"
         )
 
+    # NOTE (griffin): I'm gonna leave these but I am pretty sure this is a copy
+    # paste error
     # build 2 separate programs: 1 if base_is_e is true, the other if false
     # any_base_program is (obviously) the one for any base
-    program = Program(
-        imports=[
-            Import("primitives/core.futil"),
-            Import("primitives/binary_operators.futil"),
-        ],
-        components=generate_ln(width, int_width, is_signed),
-    )
-    # main component for testing purposes
-    main = Component(
-        "main",
-        inputs=[],
-        outputs=[],
-        structs=[
-            Cell(CompVar("x"), Stdlib.register(width)),
-            Cell(CompVar("in"), Stdlib.mem_d1(width, 1, 1), is_external=True),
-            Cell(
-                CompVar("out"),
-                Stdlib.mem_d1(width, 1, 1),
-                is_external=True,
-            ),
-            Cell(CompVar("l"), CompInst("ln", [])),
-            Group(
-                id=CompVar("read_in_mem"),
-                connections=[
-                    Connect(
-                        CompPort(CompVar("in"), "addr0"),
-                        ConstantPort(1, 0),
-                    ),
-                    Connect(
-                        CompPort(CompVar("x"), "in"),
-                        CompPort(CompVar("in"), "read_data"),
-                    ),
-                    Connect(
-                        CompPort(CompVar("x"), "write_en"),
-                        ConstantPort(1, 1),
-                    ),
-                    Connect(
-                        HolePort(CompVar("read_in_mem"), "done"),
-                        CompPort(CompVar("x"), "done"),
-                    ),
-                ],
-            ),
-            Group(
-                id=CompVar("write_to_memory"),
-                connections=[
-                    Connect(
-                        CompPort(CompVar("out"), "addr0"),
-                        ConstantPort(1, 0),
-                    ),
-                    Connect(
-                        CompPort(CompVar("out"), "write_en"),
-                        ConstantPort(1, 1),
-                    ),
-                    Connect(
-                        CompPort(CompVar("out"), "write_data"),
-                        CompPort(CompVar("l"), "out"),
-                    ),
-                    Connect(
-                        HolePort(CompVar("write_to_memory"), "done"),
-                        CompPort(CompVar("out"), "done"),
-                    ),
-                ],
-            ),
-        ],
-        controls=SeqComp(
-            [
-                Enable("read_in_mem"),
-                Invoke(
-                    id=CompVar("l"),
-                    in_connects=[("x", CompPort(CompVar("x"), "out"))],
-                    out_connects=[],
-                ),
-                Enable("write_to_memory"),
-            ]
-        ),
-    )
-    program.components.append(main)
 
-    program.emit()
+    builder = Builder()
+    builder.program.imports += [
+        Import("primitives/core.futil"),
+        Import("primitives/binary_operators.futil"),
+    ]
+    builder.program.components.append(generate_ln(width, int_width, is_signed))
+
+    # main component for testing purposes
+    main = builder.component("main")
+    x = main.reg("x", width)
+    in_ = main.mem_d1("in", width, 1, 1, is_external=True)
+    out = main.mem_d1("out", width, 1, 1, is_external=True)
+    ln = main.cell("l", CompInst("ln", []))
+
+    with main.group("read_in_mem") as read_in_mem:
+        in_.read_addr = 0
+        x.in_ = in_.read_data
+        x.write_en = HI
+        read_in_mem.done = x.done
+
+    with main.group("write_to_memory") as write_to_memory:
+        out.addr0 = 0
+        out.write_en = HI
+        out.write_data = ln.out
+        write_to_memory.done = out.done
+
+    main.control += [
+        read_in_mem,
+        invoke(
+            ln,
+            in_x=x.out,
+        ),
+        write_to_memory,
+    ]
+
+    builder.program.emit()

--- a/frontends/relay/dahlia_impl.py
+++ b/frontends/relay/dahlia_impl.py
@@ -3,7 +3,7 @@ from calyx.py_ast import *
 from dahlia_utils import *
 from calyx.gen_exp import generate_exp_taylor_series_approximation, generate_fp_pow_full
 from calyx.utils import float_to_fixed_point
-
+from calyx.builder import Builder
 ### Dahlia Implementations for Relay Call Nodes ###
 
 # Context: While implementing a Relay frontend for
@@ -858,6 +858,7 @@ def emit_components(func_defs: List[DahliaFuncDef], save_mem=True) -> str:
         width = int(type[type.find("<") + 1: sep])
         int_width = int(type[sep + 1: type.find(">")])
         exp_components = generate_fp_pow_full(
+            builder=Builder(),
             degree=8,
             width=width,
             int_width=int_width,
@@ -872,6 +873,7 @@ def emit_components(func_defs: List[DahliaFuncDef], save_mem=True) -> str:
         width = int(type[type.find("<") + 1: sep])
         int_width = int(type[sep + 1: type.find(">")])
         exp_components = generate_exp_taylor_series_approximation(
+            builder=Builder(),
             degree=8,
             width=width,
             int_width=int_width,


### PR DESCRIPTION
Part of #1301. This includes a small bevy of minor bug-fixes to the builder including a few instances of mutable defaults being used (a particularly troublesome anti-pattern) and a lot of type annotation adjustments.

A few experiential notes:
- ran into lots of trouble with set literals for par composition as the ordering is non-deterministic and it requires the contents to be hashable which is not the case for the base ast nodes as `dataclass`es don't implement hash unless they are frozen. This means you can't use things like the `invoke` builder in a set. The ordering issue is not necessarily a problem for general use but creates issues for the runt tests so I had to hack around it in a bunch of cases. Given that, it may make more logistic sense to use a tuple for par comp instead of a set, though it doesn't really match the desired intuition. An alternative might be creating a `ParBuilder` of sorts which can be added to as desired? But in most cases that'll probably be similar to just constructing the list manually and wrapping it with the `ParComp` constructor.
- might be worth re-exposing the `ConstantPort` constructor in the builder for situations where the width cannot be inferred
- similarly, may be useful to create a `bit_low` and `bit_high` utility method for interface signals as I had to manually give widths to a bunch of these
- might be worth creating a builder method for calyx sub-components as these currently rely on constructing `CompInst` nodes manually
- some better way to do cell construction would be nice since you have to use a helper method/manually construct the node and then pass it to the cell constructor. A possible solution would be generating a lookup table for cell names? Or a standardized construction for parameter names and primitive names, similar to how the `invoke` builder uses `in_=` to set up invoke connections.
- a misc difficulty in this translation was places where the program constructed nodes which used cells that did not exist but never actually used the node. Not particularly troublesome, but did slap me in the face a handful of times. Just had to rearrange a few things to make sure the cells were only requested when the appropriate branch condition was valid.