### PR TITLE
`fud` can accept argument file for stage configuration

### DIFF
--- a/fud/fud/config.py
+++ b/fud/fud/config.py
@@ -129,6 +129,17 @@ class DynamicDict:
                 data = data[k]
         data[lastkey] = val
 
+    def _merge_helper(self, store, cur_key=()):
+        for k, v in store.items():
+            if isinstance(v, dict):
+                self._merge_helper(v, cur_key + (k,))
+            else:
+                self[cur_key + (k,)] = v
+
+    def merge_dict(self, store):
+        """Recursively Merge a dictionary into the current dictionary"""
+        self._merge_helper(store)
+
     def __delitem__(self, keys):
         if isinstance(keys, str):
             keys = (keys,)
@@ -379,14 +390,17 @@ class Configuration:
 
         return path
 
+    def get(self, keys):
+        return self.config.get(keys)
+
+    def update_all(self, dict):
+        self.config.merge_dict(dict)
+
     def __getitem__(self, keys):
         try:
             return self.config[keys]
         except KeyError:
             raise errors.UnsetConfiguration(keys)
-
-    def get(self, keys):
-        return self.config.get(keys)
 
     def __setitem__(self, keys, val):
         self.config[keys] = val

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -311,7 +311,15 @@ def main():
         if args.config_file is not None:
             # Parse the TOML file
             override = toml.load(args.config_file)
-            cfg.update_all(override)
+            for key, value in override.items():
+                if key != "stages":
+                    log.warn(
+                        f"Ignoring key `{key}' in config file."
+                        + " Only 'stages' is allowed as a top-level key."
+                    )
+            # Hide all unused keys
+            override = override["stages"]
+            cfg.update_all({"stages": override})
 
         # Build the registry if stage information is going to be used.
         if args.command in ("exec", "info"):

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -392,7 +392,7 @@ def config_run(parser):
 
     # Alternatively, provide a TOML file with stage options
     parser.add_argument(
-        "--config",
+        "--stage-config",
         help="Path to a TOML file with stage configuration options",
         dest="config_file",
     )

--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -296,10 +296,22 @@ def main():
     try:
         cfg = Configuration()
 
+        # Only allow either config_file or dynamic configurations
+        if args.stage_dynamic_config and args.config_file:
+            run_parser.error(
+                "Please provide either a configuration file or"
+                + " dynamic configurations",
+            )
+
         # update the stages config with arguments provided via cmdline
-        if "stage_dynamic_config" in args and args.stage_dynamic_config is not None:
+        if args.stage_dynamic_config is not None:
             for key, value in args.stage_dynamic_config:
                 cfg[["stages"] + key.split(".")] = value
+
+        if args.config_file is not None:
+            # Parse the TOML file
+            override = toml.load(args.config_file)
+            cfg.update_all(override)
 
         # Build the registry if stage information is going to be used.
         if args.command in ("exec", "info"):
@@ -367,6 +379,7 @@ def config_run(parser):
     parser.add_argument(
         "-o", dest="output_file", help="Name of the output file (default: STDOUT)"
     )
+    # Provide configuration for stage options
     parser.add_argument(
         "-s",
         "--stage-val",
@@ -376,6 +389,14 @@ def config_run(parser):
         dest="stage_dynamic_config",
         action="append",
     )
+
+    # Alternatively, provide a TOML file with stage options
+    parser.add_argument(
+        "--config",
+        help="Path to a TOML file with stage configuration options",
+        dest="config_file",
+    )
+
     parser.add_argument(
         "-n",
         "--dry-run",


### PR DESCRIPTION
With the growing number of tools used in a `fud` pipeline, it can get unwieldy to write down long stage override commands. This PR adds a `--stage-config` that allows users to pass a TOML file to override the stage options. Instead of writing:
```
fud e --to dat -s verilog.data foo.json -s verilog.cycle_limit 4 --through icarus-verilog
```

The user can define a file:
```toml
[stages.verilog]
data = "foo.json"
cycle_limit = 4
```
And run it using:
```
fud e --to dat --stage-config conf.toml --through icarus-verilog
```

In the future, it would be nice to be able to specify the `--through` stuff in the configuration file as well. Closes #1264.