### PR TITLE
Disable generation of initial blocks

### DIFF
--- a/fud/fud/main.py
+++ b/fud/fud/main.py
@@ -48,7 +48,7 @@ def register_stages(registry):
     registry.register(
         futil.FutilStage(
             "verilog",
-            "-b verilog",
+            "-b verilog --disable-init",
             "Compile Calyx to Verilog instrumented for simulation",
         )
     )


### PR DESCRIPTION
Attempt to fix #1089 by simply disabling generation of `initial` blocks. Closes #1089. 