### PR TITLE
Rewrite Static Synatx 

### DIFF
--- a/calyx-frontend/src/ast.rs
+++ b/calyx-frontend/src/ast.rs
@@ -236,7 +236,7 @@ pub struct StaticGroup {
     pub name: Id,
     pub wires: Vec<StaticWire>,
     pub attributes: Attributes,
-    pub latency: u64,
+    pub latency: NonZeroU64,
 }
 
 /// Data for the `->` structure statement.

--- a/calyx-frontend/src/parser.rs
+++ b/calyx-frontend/src/parser.rs
@@ -702,7 +702,7 @@ impl CalyxParser {
         let span = Self::get_span(&input);
         Ok(match_nodes!(
             input.into_children();
-            [static_word(_), name_with_attribute((name, attrs)), bitwidth(latency), static_wire(wire)..] => ast::StaticGroup {
+            [static_word(_), latency_annotation(latency), name_with_attribute((name, attrs)), static_wire(wire)..] => ast::StaticGroup {
                 name,
                 attributes: attrs.add_span(span),
                 wires: wire.collect(),

--- a/calyx-frontend/src/syntax.pest
+++ b/calyx-frontend/src/syntax.pest
@@ -256,7 +256,7 @@ group = {
 }
 
 static_group = {
-      static_word ~ "group" ~ name_with_attribute ~ "<" ~ bitwidth ~  ">" ~ "{"
+      static_word ~ latency_annotation ~ "group" ~ name_with_attribute ~ "{"
       ~ static_wire*
       ~ "}"
 }
@@ -287,7 +287,7 @@ seq = {
 }
 
 static_seq = {
-      at_attributes ~  static_word ~ "seq" ~ latency_annotation? ~ "{"
+      at_attributes ~  static_word ~ latency_annotation? ~ "seq"  ~ "{"
       ~ stmt*
       ~ "}"
 }
@@ -299,7 +299,7 @@ par = {
 }
 
 static_par = {
-      at_attributes ~  static_word ~ "par" ~ latency_annotation? ~ "{"
+      at_attributes ~  static_word ~ latency_annotation? ~ "par"  ~ "{"
       ~ stmt*
       ~ "}"
 }
@@ -322,7 +322,7 @@ if_stmt = {
 }
 
 static_if_stmt = {
-      at_attributes ~ static_word ~ "if" ~  latency_annotation? ~ port ~ block ~ ("else" ~ (static_if_stmt | block))?
+      at_attributes ~ static_word ~  latency_annotation? ~ "if"  ~ port ~ block ~ ("else" ~ (static_if_stmt | block))?
 }
 
 while_stmt = {

--- a/calyx-ir/src/from_ast.rs
+++ b/calyx-ir/src/from_ast.rs
@@ -323,12 +323,12 @@ fn add_static_group(
     group: ast::StaticGroup,
     builder: &mut Builder,
 ) -> CalyxResult<()> {
-    if group.latency == 0 {
+    if group.latency.get() == 0 {
         return Err(Error::malformed_structure(
             "static group with 0 latency".to_string(),
         ));
     }
-    let ir_group = builder.add_static_group(group.name, group.latency);
+    let ir_group = builder.add_static_group(group.name, group.latency.get());
     let assigns = build_static_assignments(group.wires, builder)?;
 
     ir_group.borrow_mut().attributes = group.attributes;

--- a/calyx-ir/src/printer.rs
+++ b/calyx-ir/src/printer.rs
@@ -365,9 +365,9 @@ impl Printer {
         write!(f, "{}", " ".repeat(indent_level))?;
         write!(
             f,
-            "static group {}<{}>",
+            "static<{}> group {}",
+            group.get_latency(),
             group.name().id,
-            group.get_latency()
         )?;
         if !group.attributes.is_empty() {
             write!(f, "{}", Self::format_attributes(&group.attributes))?;
@@ -414,7 +414,7 @@ impl Printer {
                 latency,
             }) => {
                 write!(f, "{}", Self::format_at_attributes(attributes))?;
-                writeln!(f, "static seq <{}> {{", latency)?;
+                writeln!(f, "static<{}> seq  {{", latency)?;
                 for stmt in stmts {
                     Self::write_static_control(stmt, indent_level + 2, f)?;
                 }
@@ -426,7 +426,7 @@ impl Printer {
                 latency,
             }) => {
                 write!(f, "{}", Self::format_at_attributes(attributes))?;
-                writeln!(f, "static par <{}> {{", latency)?;
+                writeln!(f, "static<{}> par {{", latency)?;
                 for stmt in stmts {
                     Self::write_static_control(stmt, indent_level + 2, f)?;
                 }
@@ -449,7 +449,7 @@ impl Printer {
                 write!(f, "{}", Self::format_at_attributes(attributes))?;
                 write!(
                     f,
-                    "static if <{}> {} ",
+                    "static<{}> if  {} ",
                     latency,
                     Self::port_to_str(&port.borrow()),
                 )?;
@@ -475,7 +475,7 @@ impl Printer {
                 write!(f, "{}", Self::format_at_attributes(attributes))?;
                 write!(
                     f,
-                    "static invoke<{}> {}",
+                    "static<{}> invoke {}",
                     latency,
                     comp.borrow().name()
                 )?;

--- a/tests/correctness/static-control/bounded-while.futil
+++ b/tests/correctness/static-control/bounded-while.futil
@@ -7,7 +7,7 @@ component main() -> () {
       add = std_add(32);
     }
     wires {
-        static group one <1>{
+        static<1> group one {
             add.left = m.read_data;
             add.right = 32'd1;
             m.write_data = add.out;

--- a/tests/correctness/static-control/if-start.futil
+++ b/tests/correctness/static-control/if-start.futil
@@ -9,14 +9,14 @@ component main() -> () {
       r = std_reg(1);
     }
     wires {
-        static group one <1>{
+        static<1> group one {
             add.left = m.read_data;
             add.right = 32'd1;
             m.write_data = add.out;
             m.addr0 = 1'd0;
             m.write_en = 1'd1;
         }
-        static group four <4> {
+        static<4> group four {
         }
         cond.addr0 = 1'd0;
     }

--- a/tests/correctness/static-control/nested-one-cycle-body.futil
+++ b/tests/correctness/static-control/nested-one-cycle-body.futil
@@ -7,7 +7,7 @@ component main() -> () {
       add = std_add(32);
     }
     wires {
-        static group one <1>{
+        static<1> group one {
             add.left = m.read_data;
             add.right = 32'd1;
             m.write_data = add.out;

--- a/tests/correctness/static-control/nested-while.futil
+++ b/tests/correctness/static-control/nested-while.futil
@@ -9,7 +9,7 @@ component main() -> () {
       r1 = std_reg(1);
     }
     wires {
-        static group one <1> {
+        static<1> group one {
             add.left = m.read_data;
             add.right = 32'd1;
             m.write_data = add.out;

--- a/tests/correctness/static-control/seq-component-chain.futil
+++ b/tests/correctness/static-control/seq-component-chain.futil
@@ -16,7 +16,7 @@ component main() -> () {
     mult_pipe0 = std_mult_pipe(32);
   }
   wires {
-    static group let1<4>{
+    static<4> group let1 {
       mult_pipe0.left = 32'd10;
       mult_pipe0.right = 32'd20;
       mult_pipe0.go = %[0:3] ? 1'd1;
@@ -25,7 +25,7 @@ component main() -> () {
       x.addr0 = 1'd0;
       x.write_en = %3 ? 1'd1;
     }
-    static group let2<4> {
+    static<4> group let2 {
       mult_pipe0.left = 32'd30;
       mult_pipe0.right = 32'd40;
       mult_pipe0.go = %[0:3] ? 1'd1;
@@ -34,7 +34,7 @@ component main() -> () {
       y.addr0 = 1'd0;
       y.write_en = %3 ? 1'd1;
     }
-    static group let3<4> {
+    static<4> group let3 {
       mult_pipe0.left = 32'd50;
       mult_pipe0.right = 32'd60;
       mult_pipe0.go = %[0:3] ? 1'd1;

--- a/tests/correctness/static-control/static-island.futil
+++ b/tests/correctness/static-control/static-island.futil
@@ -18,13 +18,13 @@ component main() -> () {
            lt_cond.write_en = 1'd1; 
            check_mem_cond[done] = lt_cond.done; 
         }
-        static group add_five_reg<1> {
+        static<1> group add_five_reg {
             add.left = r.out;
             add.right = 32'd5;
             r.in = add.out;
             r.write_en = 1'd1; 
         }
-        static group write_mem <1> {
+        static<1> group write_mem  {
             m.addr0 = 1'd0;
             add.left = m.read_data;
             add.right = r.out;

--- a/tests/correctness/static-control/static-mult-dot-product.futil
+++ b/tests/correctness/static-control/static-mult-dot-product.futil
@@ -17,14 +17,14 @@ component main() -> () {
         ge_4 = std_reg(1);
     }
     wires {
-        static group init<1>{
+        static<1> group init{
             lt_10.in = 1'd1;
             lt_10.write_en = 1'd1;
             ge_4.in = 1'd0;
             ge_4.write_en = 1'd1;
         }
 
-        static group incr<1> {
+        static<1> group incr {
             add.left = idx.out;
             add.right = 4'd1;
             idx.in = add.out;
@@ -44,14 +44,14 @@ component main() -> () {
         }
 
         // The multiplier registers its inputs after a cycle.
-        static group start_mult<1> {
+        static<1> group start_mult {
             left.addr0 = idx.out;
             right.addr0 = idx.out;
             mul.left = left.read_data;
             mul.right = right.read_data;
         }
 
-        static group do_write<1> {
+        static<1> group do_write {
             sub.left = idx.out;
             sub.right = 4'd4;
             out.addr0 = sub.out;

--- a/tests/correctness/static-control/three-cycles.futil
+++ b/tests/correctness/static-control/three-cycles.futil
@@ -7,7 +7,7 @@ component main() -> () {
       add = std_add(32);
     }
     wires {
-        static group one <1>{
+        static<1> group one {
             add.left = m.read_data;
             add.right = 32'd1;
             m.write_data = add.out;

--- a/tests/passes/cell-share/static-par.expect
+++ b/tests/passes/cell-share/static-par.expect
@@ -10,27 +10,27 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     sl = std_slice(16, 4);
   }
   wires {
-    static group wr_a<1> {
+    static<1> group wr_a {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group wr_b<1> {
+    static<1> group wr_b {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group wr_x<1> {
+    static<1> group wr_x {
       x.write_en = 1'd1;
       x.in = 4'd2;
     }
-    static group wr_c<1> {
+    static<1> group wr_c {
       c.write_en = 1'd1;
       c.in = 16'd4;
     }
-    static group wr_d<1> {
+    static<1> group wr_d {
       d.write_en = 1'd1;
       d.in = 16'd4;
     }
-    static group read_c<1> {
+    static<1> group read_c {
       sl.in = c.out;
       x.write_en = 1'd1;
       x.in = sl.out;
@@ -39,24 +39,24 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
 
   control {
     seq {
-      static par <2> {
-        static if <1> lt.out {
+      static<2> par {
+        static<1> if  lt.out {
           wr_a;
         } else {
           wr_b;
         }
-        static seq <2> {
+        static<2> seq  {
           wr_x;
           wr_b;
         }
       }
-      static par <3> {
-        static seq <3> {
+      static<3> par {
+        static<3> seq  {
           wr_c;
           wr_x;
           read_c;
         }
-        static seq <3> {
+        static<3> seq  {
           wr_x;
           wr_d;
           wr_x;

--- a/tests/passes/cell-share/static-par.futil
+++ b/tests/passes/cell-share/static-par.futil
@@ -11,27 +11,27 @@ component main() -> () {
     sl = std_slice(16, 4);
   }
   wires {
-    static group wr_a <1> {
+    static<1> group wr_a {
       a.write_en = 1'd1; 
       a.in = 32'd2; 
     }
-    static group wr_b <1> {
+    static<1> group wr_b {
       b.write_en = 1'd1; 
       b.in = 32'd2; 
     }
-    static group wr_x <1> {
+    static<1> group wr_x {
       x.write_en = 1'd1; 
       x.in = 4'd2; 
     }
-    static group wr_c <1> {
+    static<1> group wr_c {
       c.write_en = 1'd1; 
       c.in = 16'd4; 
     }
-    static group wr_d <1> {
+    static<1> group wr_d {
       d.write_en = 1'd1;
       d.in = 16'd4; 
     }
-    static group read_c <1>{
+    static<1> group read_c {
       sl.in = c.out; 
       x.write_en = 1'd1; 
       x.in = sl.out; 

--- a/tests/passes/compile-static/rewrite_group_go.futil
+++ b/tests/passes/compile-static/rewrite_group_go.futil
@@ -29,14 +29,14 @@ component main() -> () {
       dyn_C[done] = c.done; 
     }
 
-    static group A<2>{
+    static<2> group A{
       a.in = 2'd0;
       a.write_en = %0 ? 1'd1;
       b.in = 2'd1;
       b.write_en = %1 ? 1'd1;
     }
 
-    static group run_A_thrice <6>{
+    static<6> group run_A_thrice{
       A[go] = 1'd1; 
     }
   }

--- a/tests/passes/dom-map-static/par-if.expect
+++ b/tests/passes/dom-map-static/par-if.expect
@@ -32,29 +32,29 @@ component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (
     lt = std_lt(4);
   }
   wires {
-    static group A<4> {
+    static<4> group A {
     }
-    static group B<1> {
+    static<1> group B {
     }
-    static group C<3> {
+    static<3> group C {
     }
-    static group D<2> {
+    static<2> group D {
     }
-    static group E<3> {
+    static<3> group E {
     }
-    static group F<2> {
+    static<2> group F {
     }
-    static group G<4> {
+    static<4> group G {
     }
-    static group H<3> {
+    static<3> group H {
     }
-    static group J<3> {
+    static<3> group J {
     }
-    static group X<1> {
+    static<1> group X {
     }
-    static group Y<2> {
+    static<2> group Y {
     }
-    static group Z<5> {
+    static<5> group Z {
     }
     comb group less_than {
       lt.left = 4'd3;
@@ -63,17 +63,17 @@ component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (
   }
 
   control {
-    @NODE_ID(0) static par <15> {
-      @NODE_ID static seq <15> {
+    @NODE_ID(0) static<15> par {
+      @NODE_ID static<15> seq  {
         @NODE_ID(2) A;
         @NODE_ID(3) B;
-        @BEGIN_ID(4) @END_ID(13) static if <7> lt.out {
-          @NODE_ID(5) static par <7> {
-            @NODE_ID(6) static seq <7> {
+        @BEGIN_ID(4) @END_ID(13) static<7> if  lt.out {
+          @NODE_ID(5) static<7> par {
+            @NODE_ID(6) static<7> seq  {
               @NODE_ID(7) G;
               @NODE_ID(8) H;
             }
-            @NODE_ID(9) static seq <3> {
+            @NODE_ID(9) static<3> seq  {
               @NODE_ID(10) X;
               @NODE_ID(11) Y;
             }
@@ -83,7 +83,7 @@ component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (
         }
         @NODE_ID(14) J;
       }
-      @NODE_ID(15) static seq <10> {
+      @NODE_ID(15) static<10> seq  {
         @NODE_ID(16) C;
         @NODE_ID(17) D;
         @NODE_ID(18) E;

--- a/tests/passes/dom-map-static/par-if.futil
+++ b/tests/passes/dom-map-static/par-if.futil
@@ -5,29 +5,29 @@ component example() -> () {
     lt = std_lt(4); 
   }
   wires {
-    static group A <4> {
+    static<4> group A {
     }
-    static group B <1> {
+    static<1> group B {
     }
-    static group C <3> {
+    static<3> group C {
     }
-    static group D <2> {
+    static<2> group D {
     }
-    static group E <3> {
+    static<3> group E {
     }
-    static group F <2> {
+    static<2> group F {
     }
-    static group G <4> {
+    static<4> group G {
     }
-    static group H <3> {
+    static<3> group H {
     }
-    static group J <3> {
+    static<3> group J {
     }
-    static group X <1> {
+    static<1> group X {
     }
-    static group Y <2> {
+    static<2> group Y {
     }
-    static group Z <5> {
+    static<5> group Z {
     }
     comb group less_than {
       lt.left = 4'd3;

--- a/tests/passes/dom-map-static/repeat.expect
+++ b/tests/passes/dom-map-static/repeat.expect
@@ -16,19 +16,19 @@ component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (
     lt = std_lt(4);
   }
   wires {
-    static group A<4> {
+    static<4> group A {
     }
-    static group B<1> {
+    static<1> group B {
     }
-    static group C<3> {
+    static<3> group C {
     }
-    static group D<5> {
+    static<5> group D {
     }
   }
 
   control {
-    @NODE_ID(0) static par <17> {
-      @NODE_ID static seq <17> {
+    @NODE_ID(0) static<17> par {
+      @NODE_ID static<17> seq  {
         @NODE_ID(2) A;
         @NODE_ID(3) static repeat 10 {
           @NODE_ID(4) B;

--- a/tests/passes/dom-map-static/repeat.futil
+++ b/tests/passes/dom-map-static/repeat.futil
@@ -5,13 +5,13 @@ component example() -> () {
     lt = std_lt(4); 
   }
   wires {
-    static group A <4> {
+    static<4> group A {
     }
-    static group B <1> {
+    static<1> group B {
     }
-    static group C <3> {
+    static<3> group C {
     }
-    static group D <5> {
+    static<5> group D {
     }
   }
   control {

--- a/tests/passes/domination-map/if-dominated.expect
+++ b/tests/passes/domination-map/if-dominated.expect
@@ -15,19 +15,19 @@ component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (
     lt = std_lt(4);
   }
   wires {
-    static group A<4> {
+    static<4> group A {
     }
-    static group B<1> {
+    static<1> group B {
     }
-    static group C<2> {
+    static<2> group C {
     }
   }
 
   control {
-    @NODE_ID(0) static par <5> {
-      @NODE_ID static seq <5> {
+    @NODE_ID(0) static<5> par {
+      @NODE_ID static<5> seq  {
         @NODE_ID(2) A;
-        @BEGIN_ID(3) @END_ID(5) static if <1> lt.out {
+        @BEGIN_ID(3) @END_ID(5) static<1> if  lt.out {
           @NODE_ID(4) B;
         }
       }

--- a/tests/passes/domination-map/if-dominated.futil
+++ b/tests/passes/domination-map/if-dominated.futil
@@ -5,11 +5,11 @@ component example() -> () {
     lt = std_lt(4); 
   }
   wires {
-    static group A<4>{
+    static<4> group A{
     }
-    static group B<1>{
+    static<1> group B{
     }
-    static group C<2>{
+    static<2> group C {
     }
   }
   control {

--- a/tests/passes/domination-map/static-par.expect
+++ b/tests/passes/domination-map/static-par.expect
@@ -27,43 +27,43 @@ component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (
     }
     group H {
     }
-    static group B<4> {
+    static<4> group B {
     }
-    static group C<4> {
+    static<4> group C {
     }
-    static group D<2> {
+    static<2> group D {
     }
-    static group E<3> {
+    static<3> group E {
     }
-    static group F<2> {
+    static<2> group F {
     }
-    static group G<2> {
+    static<2> group G {
     }
-    static group X<4> {
+    static<4> group X {
     }
-    static group Y<2> {
+    static<2> group Y {
     }
-    static group Z<2> {
+    static<2> group Z {
     }
   }
 
   control {
     @NODE_ID(0) seq {
       @NODE_ID A;
-      @NODE_ID(2) static par <10> {
-        @NODE_ID(3) static seq <10> {
+      @NODE_ID(2) static<10> par {
+        @NODE_ID(3) static<10> seq  {
           @NODE_ID(4) B;
           @NODE_ID(5) C;
           @NODE_ID(6) D;
         }
-        @NODE_ID(7) static seq <7> {
+        @NODE_ID(7) static<7> seq  {
           @NODE_ID(8) E;
           @NODE_ID(9) F;
           @NODE_ID(10) G;
         }
-        @BEGIN_ID(11) @END_ID(17) static if <6> lt.out {
-          @NODE_ID(12) static par <6> {
-            @NODE_ID(13) static seq <6> {
+        @BEGIN_ID(11) @END_ID(17) static<6> if  lt.out {
+          @NODE_ID(12) static<6> par {
+            @NODE_ID(13) static<6> seq  {
               @NODE_ID(14) X;
               @NODE_ID(15) Y;
             }

--- a/tests/passes/domination-map/static-par.futil
+++ b/tests/passes/domination-map/static-par.futil
@@ -7,23 +7,23 @@ component example() -> () {
   wires {
     group A{
     }
-    static group B <4>{
+    static<4> group B {
     }
-    static group C <4>{
+    static<4> group C {
     }
-    static group D <2>{
+    static<2> group D {
     }
-    static group E <3>{
+    static<3> group E {
     }
-    static group F <2>{
+    static<2> group F {
     }
-    static group G <2>{
+    static<2> group G {
     }
-    static group X <4>{
+    static<4> group X {
     }
-    static group Y <2>{
+    static<2> group Y {
     }
-    static group Z <2>{
+    static<2> group Z {
     }
     group H {
     }

--- a/tests/passes/infer-share-pass/static-par.expect
+++ b/tests/passes/infer-share-pass/static-par.expect
@@ -7,15 +7,15 @@ component example<"state_share"=1>(in: 32, @go go: 1, @clk clk: 1, @reset reset:
     adder = std_add(32);
   }
   wires {
-    static group A<1> {
+    static<1> group A {
       a.in = 32'd2;
       a.write_en = 1'd1;
     }
-    static group B<1> {
+    static<1> group B {
       b.write_en = 1'd1;
       b.in = 32'd7;
     }
-    static group read_A<1> {
+    static<1> group read_A {
       adder.left = a.out;
       adder.right = 32'd2;
       a.in = adder.out;
@@ -25,9 +25,9 @@ component example<"state_share"=1>(in: 32, @go go: 1, @clk clk: 1, @reset reset:
   }
 
   control {
-    @NODE_ID(0) static par <2> {
+    @NODE_ID(0) static<2> par {
       @NODE_ID A;
-      @NODE_ID(2) static seq <2> {
+      @NODE_ID(2) static<2> seq  {
         @NODE_ID(3) B;
         @NODE_ID(4) read_A;
       }

--- a/tests/passes/infer-share-pass/static-par.futil
+++ b/tests/passes/infer-share-pass/static-par.futil
@@ -13,15 +13,15 @@ component example(in: 32) -> (out: 32) {
     adder = std_add(32);
   }
   wires {
-    static group A <1>{
+    static<1> group A {
       a.in = 32'd2; 
       a.write_en = 1'd1; 
     }
-    static group B <1>{
+    static<1> group B {
       b.write_en = 1'd1; 
       b.in = 32'd7; 
     }
-    static group read_A <1> {
+    static<1> group read_A {
       adder.left = a.out; 
       adder.right = 32'd2; 
       a.in = adder.out; 

--- a/tests/passes/par-timing-map/nested-par.expect
+++ b/tests/passes/par-timing-map/nested-par.expect
@@ -41,63 +41,63 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     j = std_reg(32);
   }
   wires {
-    static group A<4> {
+    static<4> group A {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group B<4> {
+    static<4> group B {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group C<4> {
+    static<4> group C {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group D<1> {
+    static<1> group D {
       d.write_en = 1'd1;
       d.in = 32'd2;
     }
-    static group E<4> {
+    static<4> group E {
       d.write_en = 1'd1;
       d.in = 32'd2;
     }
-    static group F<4> {
+    static<4> group F {
       d.write_en = 1'd1;
       d.in = 32'd2;
     }
-    static group G<2> {
+    static<2> group G {
       g.write_en = 1'd1;
       g.in = 32'd2;
     }
-    static group H<2> {
+    static<2> group H {
       g.write_en = 1'd1;
       g.in = 32'd2;
     }
-    static group I<1> {
+    static<1> group I {
       i.write_en = 1'd1;
       i.in = 32'd2;
     }
-    static group J<1> {
+    static<1> group J {
       i.write_en = 1'd1;
       i.in = 32'd2;
     }
   }
 
   control {
-    @NODE_ID(0) static par <12> {
-      @NODE_ID static seq <12> {
+    @NODE_ID(0) static<12> par {
+      @NODE_ID static<12> seq  {
         @NODE_ID(2) A;
         @NODE_ID(3) B;
         @NODE_ID(4) C;
       }
-      @NODE_ID(5) static seq <10> {
+      @NODE_ID(5) static<10> seq  {
         @NODE_ID(6) D;
-        @NODE_ID(7) static par <8> {
-          @NODE_ID(8) static seq <8> {
+        @NODE_ID(7) static<8> par {
+          @NODE_ID(8) static<8> seq  {
             @NODE_ID(9) E;
             @NODE_ID(10) F;
           }
-          @NODE_ID(11) static seq <4> {
+          @NODE_ID(11) static<4> seq  {
             @NODE_ID(12) G;
             @NODE_ID(13) H;
           }
@@ -105,7 +105,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
         @NODE_ID(14) D;
       }
       @NODE_ID(15) static repeat 4 {
-        @NODE_ID(16) static seq <2> {
+        @NODE_ID(16) static<2> seq  {
           @NODE_ID(17) I;
           @NODE_ID(18) J;
         }

--- a/tests/passes/par-timing-map/nested-par.futil
+++ b/tests/passes/par-timing-map/nested-par.futil
@@ -15,43 +15,43 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     j = std_reg(32);
   }
   wires {
-    static group A <4>{
+    static<4> group A {
       a.write_en = 1'd1; 
       a.in = 32'd2; 
     }
-    static group B <4>{
+    static<4> group B {
       b.write_en = 1'd1; 
       b.in = 32'd2; 
     }
-    static group C <4> {
+    static<4> group C {
       c.write_en = 1'd1; 
       c.in = 32'd2; 
     }
-    static group D <1> {
+    static<1> group D {
       d.write_en = 1'd1; 
       d.in = 32'd2; 
     }
-    static group E <4> {
+    static<4> group E {
       e.write_en = 1'd1; 
       e.in = 32'd2; 
     }
-    static group F <4> {
+    static<4> group F {
       f.write_en = 1'd1; 
       f.in = 32'd2; 
     }
-    static group G <2> {
+    static<2> group G {
       g.write_en = 1'd1; 
       g.in = 32'd2; 
     }
-    static group H <2> {
+    static<2> group H {
       h.write_en = 1'd1; 
       h.in = 32'd2; 
     }
-    static group I <1> {
+    static<1> group I {
       i.write_en = 1'd1; 
       i.in = 32'd2; 
     }
-    static group J <1>{
+    static<1> group J {
       j.write_en = 1'd1; 
       j.in = 32'd2; 
     }

--- a/tests/passes/par-timing-map/nested-while.expect
+++ b/tests/passes/par-timing-map/nested-while.expect
@@ -28,31 +28,31 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     g = std_reg(32);
   }
   wires {
-    static group A<3> {
+    static<3> group A {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group B<3> {
+    static<3> group B {
       b.write_en = 1'd1;
       b.in = 32'd2;
     }
-    static group C<4> {
+    static<4> group C {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group D<4> {
+    static<4> group D {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group E<4> {
+    static<4> group E {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group F<4> {
+    static<4> group F {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group G<4> {
+    static<4> group G {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
@@ -60,12 +60,12 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
 
   control {
     @NODE_ID(0) seq {
-      @NODE_ID static par <74> {
+      @NODE_ID static<74> par {
         @NODE_ID(2) static repeat 2 {
-          @NODE_ID(3) static seq <37> {
+          @NODE_ID(3) static<37> seq  {
             @NODE_ID(4) static repeat 3 {
-              @NODE_ID(5) static seq <11> {
-                @NODE_ID(6) static par <3> {
+              @NODE_ID(5) static<11> seq  {
+                @NODE_ID(6) static<3> par {
                   @NODE_ID(7) A;
                   @NODE_ID(8) B;
                 }
@@ -78,7 +78,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
           }
         }
       }
-      @NODE_ID(12) static seq <12> {
+      @NODE_ID(12) static<12> seq  {
         @NODE_ID(13) E;
         @NODE_ID(14) F;
         @NODE_ID(15) G;

--- a/tests/passes/par-timing-map/nested-while.futil
+++ b/tests/passes/par-timing-map/nested-while.futil
@@ -12,31 +12,31 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     g = std_reg(32);
   }
   wires {
-    static group A <3>{
+    static<3> group A {
       a.write_en = 1'd1; 
       a.in = 32'd2; 
     }
-    static group B <3>{
+    static<3> group B {
       b.write_en = 1'd1; 
       b.in = 32'd2; 
     }
-    static group C <4>{
+    static<4> group C {
       c.write_en = 1'd1; 
       c.in = 32'd2;  
     }
-    static group D <4>{
+    static<4> group D {
       d.write_en = 1'd1; 
       d.in = 32'd2; 
     }
-    static group E <4>{
+    static<4> group E {
       e.write_en = 1'd1; 
       e.in = 32'd2; 
     }
-    static group F <4>{
+    static<4> group F {
       f.write_en = 1'd1; 
       f.in = 32'd2; 
     }
-    static group G <4>{
+    static<4> group G {
       g.write_en = 1'd1; 
       g.in = 32'd2; 
     }

--- a/tests/passes/par-timing-map/simple.expect
+++ b/tests/passes/par-timing-map/simple.expect
@@ -50,19 +50,19 @@ component comp(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       d.in = 32'd2;
       C[done] = d.done;
     }
-    static group D<2> {
+    static<2> group D {
       d.write_en = 1'd1;
       d.in = 32'd2;
     }
-    static group E<1> {
+    static<1> group E {
       d.write_en = 1'd1;
       d.in = 32'd2;
     }
-    static group F<1> {
+    static<1> group F {
       f.write_en = 1'd1;
       f.in = 32'd2;
     }
-    static group G<2> {
+    static<2> group G {
       f.write_en = 1'd1;
       f.in = 32'd2;
     }
@@ -77,12 +77,12 @@ component comp(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     } else {
       @NODE_ID(4) seq {
         @NODE_ID(5) C;
-        @NODE_ID(6) static par <3> {
-          @NODE_ID(7) static seq <3> {
+        @NODE_ID(6) static<3> par {
+          @NODE_ID(7) static<3> seq  {
             @NODE_ID(8) D;
             @NODE_ID(9) E;
           }
-          @NODE_ID(10) static seq <3> {
+          @NODE_ID(10) static<3> seq  {
             @NODE_ID(11) F;
             @NODE_ID(12) G;
           }
@@ -100,28 +100,28 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     d = std_reg(32);
   }
   wires {
-    static group A<2> {
+    static<2> group A {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group B<3> {
+    static<3> group B {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group C<3> {
+    static<3> group C {
       a.write_en = 1'd1;
       a.in = 32'd2;
     }
-    static group D<4> {
+    static<4> group D {
       d.write_en = 1'd1;
       d.in = 32'd2;
     }
   }
 
   control {
-    @NODE_ID(0) static par <6> {
-      @NODE_ID static seq <6> {
-        @NODE_ID(2) static if <3> lt.out {
+    @NODE_ID(0) static<6> par {
+      @NODE_ID static<6> seq  {
+        @NODE_ID(2) static<3> if  lt.out {
           @NODE_ID(3) A;
         } else {
           @NODE_ID(4) B;

--- a/tests/passes/par-timing-map/simple.futil
+++ b/tests/passes/par-timing-map/simple.futil
@@ -27,19 +27,19 @@ component comp(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       c.in = 32'd2; 
       C[done] = c.done;  
     }
-    static group D <2> {
+    static<2> group D {
       d.write_en = 1'd1; 
       d.in = 32'd2; 
     }
-    static group E <1>{
+    static<1> group E {
       e.write_en = 1'd1; 
       e.in = 32'd2; 
     }
-    static group F<1> {
+    static<1> group F {
       f.write_en = 1'd1; 
       f.in = 32'd2; 
     }
-    static group G <2> {
+    static<2> group G  {
       g.write_en = 1'd1; 
       g.in = 32'd2; 
     }
@@ -69,19 +69,19 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     d = std_reg(32);
   }
   wires {
-    static group A <2> {
+    static<2> group A {
       a.write_en = 1'd1; 
       a.in = 32'd2; 
     }
-    static group B <3> {
+    static<3> group B {
       b.write_en = 1'd1; 
       b.in = 32'd2; 
     }
-    static group C <3> {
+    static<3> group C {
       c.write_en = 1'd1; 
       c.in = 32'd2; 
     }
-    static group D <4>{
+    static<4> group D {
       d.write_en = 1'd1; 
       d.in = 32'd2; 
     }

--- a/tests/passes/simplify-static-guards/basic.expect
+++ b/tests/passes/simplify-static-guards/basic.expect
@@ -10,7 +10,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     gt = std_lt(32);
   }
   wires {
-    static group my_group<10> {
+    static<10> group my_group {
       a.write_en = (%2 | lt.out) & %[1:5] ? 1'd1;
       b.write_en = (lt.out | gt.out) & %2 ? 1'd1;
       c.write_en = (%[5:7] | lt.out) & %4 ? 1'd1;

--- a/tests/passes/simplify-static-guards/basic.futil
+++ b/tests/passes/simplify-static-guards/basic.futil
@@ -12,7 +12,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     gt = std_lt(32);
   }
   wires {
-    static group my_group<10> {
+    static<10> group my_group {
       a.write_en = (%[2:3] | lt.out) & %[1:5] ? 1'd1; // don't simplify 
       b.write_en = %[2:3] & (lt.out | gt.out) & %[1:5] ? 1'd1;  // %[1:5] is redundant 
       c.write_en = %[2:5] & (%[5:7] | lt.out) & %[3:7] & %[4:10] ? 1'd1;  // %[5:7] shouldn't change, but can simplify rest to %[4:5]

--- a/tests/passes/static-inliner/nested-repeat.expect
+++ b/tests/passes/static-inliner/nested-repeat.expect
@@ -4,14 +4,14 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     a = std_reg(2);
   }
   wires {
-    static group A<1> {
+    static<1> group A {
       a.in = 2'd0;
       a.write_en = %0 ? 1'd1;
     }
-    static group static_repeat<6> {
+    static<6> group static_repeat {
       static_repeat0[go] = 1'd1;
     }
-    static group static_repeat0<3> {
+    static<3> group static_repeat0 {
       A[go] = 1'd1;
     }
   }

--- a/tests/passes/static-inliner/nested-repeat.futil
+++ b/tests/passes/static-inliner/nested-repeat.futil
@@ -7,7 +7,7 @@ component main() -> () {
     a = std_reg(2);
   }
   wires {
-    static group A<1>{
+    static<1> group A {
       a.in = 2'd0;
       a.write_en = %0 ? 1'd1;
     }

--- a/tests/passes/static-inliner/par-if.expect
+++ b/tests/passes/static-inliner/par-if.expect
@@ -12,7 +12,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     @generated cond_wire = std_wire(1);
   }
   wires {
-    static group static_par<4> {
+    static<4> group static_par {
       cond.in = %[0:2] ? lt.out;
       cond_wire.in = %0 ? lt.out;
       cond.write_en = %0 ? 1'd1;

--- a/tests/passes/static-inliner/par-if.futil
+++ b/tests/passes/static-inliner/par-if.futil
@@ -16,25 +16,25 @@ component main() -> () {
   }
 
   wires {
-    static group A<2>{
+    static<2> group A {
       a.in = 2'd0;
       a.write_en = %0 ? 1'd1;
       b.in = 2'd1;
       b.write_en = %1 ? 1'd1;
     }
 
-    static group A3<3>{
+    static<3> group A3 {
       mult.left = 2'd1; 
       mult.right = 2'd3;
       mult.go = 1'd1; 
     }
 
-    static group C<1>{
+    static<1> group C {
       c.in = 2'd2;
       c.write_en = %0 ? 1'd1;
     }
 
-    static group D<1>{
+    static<1> group D{
       c.in = 2'd2;
       c.write_en = %0 ? 1'd1;
     }

--- a/tests/passes/static-inliner/repeat-seq.expect
+++ b/tests/passes/static-inliner/repeat-seq.expect
@@ -17,10 +17,10 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       b.in = 2'd2;
       dyn_B[done] = b.done;
     }
-    static group static_repeat<12> {
+    static<12> group static_repeat {
       static_seq[go] = 1'd1;
     }
-    static group static_seq<4> {
+    static<4> group static_seq {
       a.in = %[0:2] ? 2'd0;
       a.write_en = %0 ? 1'd1;
       b.in = %[0:2] ? 2'd1;

--- a/tests/passes/static-inliner/repeat-seq.futil
+++ b/tests/passes/static-inliner/repeat-seq.futil
@@ -21,19 +21,19 @@ component main() -> () {
       b.in = 2'd2; 
       dyn_B[done] = b.done; 
     }
-    static group A<2>{
+    static<2> group A{
       a.in = 2'd0;
       a.write_en = %0 ? 1'd1;
       b.in = 2'd1;
       b.write_en = %1 ? 1'd1;
     }
 
-    static group C<1>{
+    static<1> group C{
       c.in = 2'd2;
       c.write_en = %0 ? 1'd1;
     }
 
-    static group D<1>{
+    static<1> group D {
       d.in = 2'd2;
       d.write_en = %0 ? 1'd1;
     }


### PR DESCRIPTION
Static latencies now appear next to the static guards, e.g., `static<4> group group_name` or `static<2> seq` 
Implements the suggestion from #1405 (and if we decide that this is the syntax we want to go with, then maybe resolves it?) 