### PR TITLE
Reset `@external` cells

### DIFF
--- a/calyx-opt/src/passes/reset_insertion.rs
+++ b/calyx-opt/src/passes/reset_insertion.rs
@@ -27,11 +27,6 @@ impl Visitor for ResetInsertion {
 
         for cell_ref in builder.component.cells.iter() {
             let cell = cell_ref.borrow();
-            if cell.get_attribute(ir::BoolAttr::External).is_some() {
-                // External cells should not have their state reset,
-                // since we assume they may be initialized.
-                continue;
-            }
             if let Some(port) = cell.find_with_attr(ir::BoolAttr::Reset) {
                 builder.component.continuous_assignments.push(
                     builder.build_assignment(

--- a/examples/futil/dot-product.expect
+++ b/examples/futil/dot-product.expect
@@ -67,6 +67,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     v0.write_en = upd2_go.out ? 1'd1;
     v0.clk = clk;
     v0.addr0 = upd2_go.out ? const2.out;
+    v0.reset = reset;
     v0.write_data = upd2_go.out ? add0.out;
     comb_reg.write_en = cond00_go.out ? 1'd1;
     comb_reg.clk = clk;
@@ -78,6 +79,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     tdcc_go.in = go;
     A0.clk = clk;
     A0.addr0 = msp_go.out ? i0.out;
+    A0.reset = reset;
     cond00_go.in = !cond00_done.out & fsm.out == 4'd1 & tdcc_go.out | !cond00_done.out & fsm.out == 4'd8 & tdcc_go.out ? 1'd1;
     invoke3_done.in = B_read0_0.done;
     mult_pipe0.clk = clk;
@@ -92,6 +94,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     invoke2_done.in = A_read0_0.done;
     B0.clk = clk;
     B0.addr0 = msp_go.out ? i0.out;
+    B0.reset = reset;
     B_read0_0.write_en = invoke3_go.out | msp_go.out ? 1'd1;
     B_read0_0.clk = clk;
     B_read0_0.reset = reset;

--- a/examples/futil/vectorized-add.expect
+++ b/examples/futil/vectorized-add.expect
@@ -60,9 +60,11 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     tdcc_go.in = go;
     A0.clk = clk;
     A0.addr0 = msp_go.out ? i0.out;
+    A0.reset = reset;
     Sum0.write_en = upd2_go.out ? 1'd1;
     Sum0.clk = clk;
     Sum0.addr0 = upd2_go.out ? i0.out;
+    Sum0.reset = reset;
     Sum0.write_data = upd2_go.out ? add0.out;
     cond00_go.in = !cond00_done.out & fsm.out == 3'd1 & tdcc_go.out | !cond00_done.out & fsm.out == 3'd5 & tdcc_go.out ? 1'd1;
     invoke0_done.in = i0.done;
@@ -71,6 +73,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     le0.right = cond00_go.out ? const1.out;
     B0.clk = clk;
     B0.addr0 = msp_go.out ? i0.out;
+    B0.reset = reset;
     B_read0_0.write_en = msp_go.out ? 1'd1;
     B_read0_0.clk = clk;
     B_read0_0.reset = reset;

--- a/tests/backend/verilog/memory-with-external-attribute.expect
+++ b/tests/backend/verilog/memory-with-external-attribute.expect
@@ -580,6 +580,7 @@ std_mem_d1 # (
 );
 wire _guard0 = 1;
 assign m1_clk = clk;
+assign m1_reset = reset;
 assign done = m1_done;
 assign m0_clk = clk;
 assign m0_reset = reset;


### PR DESCRIPTION
We previously skipped code that would thread `reset` signals through into `@external` cells. The comment around that code says that those memories might be initialized and that's the reason to skip the code but I'm not sure if that's the right reason. The memory primitives should clear the internal signals (like `read_done` etc.) when `reset` is asserted and not blow away all the internal state.

Fixes #1354.