### PR TITLE
[mrxl, calyx-py]: Specify a dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,9 +77,12 @@ jobs:
         git fetch --all
         git checkout $GITHUB_SHA
 
-    - name: Install MrXL
+    - name: Install calyx-py & MrXL
       working-directory: /home/calyx
       run: |
+        cd calyx-py
+        FLIT_ROOT_INSTALL=1 flit install --symlink
+        cd -
         cd frontends/mrxl
         FLIT_ROOT_INSTALL=1 flit install --symlink
 

--- a/calyx-py/pyproject.toml
+++ b/calyx-py/pyproject.toml
@@ -3,10 +3,13 @@ requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "calyx"
+name = "calyx-ast"
 authors = [{name = "The Calyx Authors"}]
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
 readme = "README.md"
 requires-python = ">=3.4"
 urls.Source = "https://github.com/cucapra/calyx"
+
+[tool.flit.module]
+name = "calyx"

--- a/calyx-py/pyproject.toml
+++ b/calyx-py/pyproject.toml
@@ -1,9 +1,12 @@
 [build-system]
-requires = ["flit_core >=2,<4"]
+requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
-[tool.flit.metadata]
-module = "calyx"
-author = "The Calyx Authors"
+[project]
+name = "calyx"
+authors = [{name = "The Calyx Authors"}]
+classifiers = ["License :: OSI Approved :: MIT License"]
+dynamic = ["version", "description"]
+readme = "README.md"
 requires-python = ">=3.4"
-home-page = "https://github.com/cucapra/calyx"
+urls.Source = "https://github.com/cucapra/calyx"

--- a/frontends/mrxl/pyproject.toml
+++ b/frontends/mrxl/pyproject.toml
@@ -1,17 +1,17 @@
 [build-system]
-requires = ["flit_core >=2,<4"]
+requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
-[tool.flit.metadata]
-module = "mrxl"
-author = "The Calyx Authors"
-home-page = "https://docs.calyxir.org/frontends/mrxl.html"
+[project]
+name = "mrxl"
+authors = [{name = "The Calyx Authors"}]
 classifiers = ["License :: OSI Approved :: MIT License"]
-description-file = "README.md"
+dynamic = ["version", "description"]
+readme = "README.md"
 requires-python = ">=3.4"
-requires = [
-         "lark-parser",
+dependencies = [
+    "lark-parser",
 ]
 
-[tool.flit.scripts]
+[project.scripts]
 mrxl = "mrxl.main:main"

--- a/frontends/mrxl/pyproject.toml
+++ b/frontends/mrxl/pyproject.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 requires-python = ">=3.4"
 dependencies = [
     "lark-parser",
+    "calyx-ast",
 ]
 
 [project.scripts]


### PR DESCRIPTION
The main point here was to specify, in the metadata for MrXL, that it depends on the calyx-py library. This leads to a hopefully-helpful error if someone tries to install MrXL before installing calyx-py.

Along the way, I:

* Moved both `pyproject.toml` files to the modern (PEP 517 standard) format.
* Added a "package name" `calyx-ast` we can use to specify the dependency. `calyx-py` seems redundant, and [`calyx` is taken on PyPI](https://pypi.org/project/calyx/), so this was the next best thing and decently descriptive.