### PR TITLE
MrXL: `reduce` must go to register

### DIFF
--- a/frontends/mrxl/mrxl/gen_futil.py
+++ b/frontends/mrxl/mrxl/gen_futil.py
@@ -81,7 +81,9 @@ def gen_reduce_impl(
     # Split up the accumulator and the array element
     bind = stmt.bind[0]
     [acc, x] = bind.dest
-    name2arr = {acc: f"{dest}_b0", x: f"{bind.src}_b0"}
+    # The source of a `reduce` must be a singly-banked array (thus the `b0`)
+    # The destination of a `reduce` must be a register
+    name2arr = {acc: f"{dest}", x: f"{bind.src}_b0"}
 
     def expr_to_port(expr: ast.BaseExpr):
         if isinstance(expr, ast.LitExpr):
@@ -100,15 +102,14 @@ def gen_reduce_impl(
     else:
         op = comp.add(f"add_{s_idx}", 32)
     with comp.group(f"reduce{s_idx}") as ev:
-        out = comp.get_cell(f"{dest}_b0")  # The accumulator is a register
+        out = comp.get_cell(f"{dest}")  # The accumulator is a register
 
-        # The source must be a singly-banked array
         inp = comp.get_cell(f"{bind.src}_b0")
         inp.addr0 = idx.out
         op.left = expr_to_port(body.lhs)
         op.right = expr_to_port(body.rhs)
         out.write_data = op.out
-        out.addr0 = 0
+        out.addr0 = cb.const(32, 0)  # Just the number 0 with width 32
         # Multipliers are sequential so we need to manipulate go/done signals
         if body.op == "mul":
             op.go = 1
@@ -168,7 +169,7 @@ def gen_map_impl(
         body = stmt.body
         if isinstance(body, ast.LitExpr):  # Body is a constant
             raise NotImplementedError()
-        elif isinstance(body, ast.VarExpr):  # Body is a variable
+        if isinstance(body, ast.VarExpr):  # Body is a variable
             raise NotImplementedError()
 
         # Mapping from binding to arrays

--- a/frontends/mrxl/mrxl/gen_futil.py
+++ b/frontends/mrxl/mrxl/gen_futil.py
@@ -102,7 +102,12 @@ def gen_reduce_impl(
     else:
         op = comp.add(f"add_{s_idx}", 32)
     with comp.group(f"reduce{s_idx}") as ev:
-        out = comp.get_cell(f"{dest}")  # The accumulator is a register
+        try:
+            out = comp.get_cell(f"{dest}")  # The accumulator is a register
+        except Exception as exc:
+            raise TypeError(
+                "The accumulator of a `reduce` is expected to be a register."
+            ) from exc
 
         inp = comp.get_cell(f"{bind.src}_b0")
         inp.addr0 = idx.out

--- a/frontends/mrxl/mrxl/gen_futil.py
+++ b/frontends/mrxl/mrxl/gen_futil.py
@@ -106,7 +106,9 @@ def gen_reduce_impl(
             out = comp.get_cell(f"{dest}")  # The accumulator is a register
         except Exception as exc:
             raise TypeError(
-                "The accumulator of a `reduce` is expected to be a register."
+                "The accumulator of a `reduce` operation is expected to be a "
+                "register. Consider checking the declaration of variable "
+                f"`{dest}`."
             ) from exc
 
         inp = comp.get_cell(f"{bind.src}_b0")

--- a/frontends/mrxl/test/dot.mrxl
+++ b/frontends/mrxl/test/dot.mrxl
@@ -1,5 +1,5 @@
 input avec: int[4]
 input bvec: int[4]
-output dot: int[4]
+output dot: int
 prodvec := map 1 (a <- avec, b <- bvec) { a * b }
 dot := reduce 1 (a, b <- prodvec) 0 { a + b }

--- a/frontends/mrxl/test/dot.mrxl.data
+++ b/frontends/mrxl/test/dot.mrxl.data
@@ -1,38 +1,38 @@
 {
-    "avec": {
-        "data": [
-            1,
-            2,
-            3,
-            4
-        ],
-        "format": {
-            "numeric_type": "bitnum",
-            "is_signed": false,
-            "width": 32
-        }
-    },
-    "bvec": {
-        "data": [
-            9,
-            8,
-            7,
-            6
-        ],
-        "format": {
-            "numeric_type": "bitnum",
-            "is_signed": false,
-            "width": 32
-        }
-    },
-    "dot": {
-        "data": [
-            0, 0, 0, 0
-        ],
-        "format": {
-            "numeric_type": "bitnum",
-            "is_signed": false,
-            "width": 32
-        }
+  "avec": {
+    "data": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "format": {
+      "numeric_type": "bitnum",
+      "is_signed": false,
+      "width": 32
     }
+  },
+  "bvec": {
+    "data": [
+      9,
+      8,
+      7,
+      6
+    ],
+    "format": {
+      "numeric_type": "bitnum",
+      "is_signed": false,
+      "width": 32
+    }
+  },
+  "dot": {
+    "data": [
+      0
+    ],
+    "format": {
+      "numeric_type": "bitnum",
+      "is_signed": false,
+      "width": 32
+    }
+  }
 }

--- a/frontends/mrxl/test/sum.mrxl
+++ b/frontends/mrxl/test/sum.mrxl
@@ -1,3 +1,3 @@
 input avec: int[16]
-output out: int[16]
+output out: int
 out := reduce 1 (a, b <- avec) 0 { a + b }

--- a/frontends/mrxl/test/sum.mrxl.data
+++ b/frontends/mrxl/test/sum.mrxl.data
@@ -24,7 +24,9 @@
     }
   },
   "out": {
-    "data": [0],
+    "data": [
+      0
+    ],
     "format": {
       "numeric_type": "bitnum",
       "is_signed": false,


### PR DESCRIPTION
MrXL already had the requirement that the answer of a `reduce` operation be stored in a register, not an array. The compiler `gen_futil.py` was already assuming this. It was banking the output cell trivially (just tagging on the suffix `_b0`).

This PR firms this up. It does away with that trivial banking and _requires_ that the output of a `reduce` go into a register. 

Compiling the program
```
input avec: int[16]
output out: int[16] 
out := reduce 1 (a, b <- avec) 0 { a + b }
```
will now fail, with the exception 
```
TypeError: The accumulator of a `reduce` operation is expected to be a register. Consider checking the declaration of variable `out`.
```

The following will work:
```
input avec: int[16]
output out: int
out := reduce 1 (a, b <- avec) 0 { a + b }
```