### PR TITLE
[calyx-py] Minor builder extensions

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -250,7 +250,7 @@ def if_(port: ExprBuilder, cond: Optional[GroupBuilder], body) -> ast.If:
 def invoke(cell: CellBuilder, **kwargs) -> ast.Invoke:
     """Build an `invoke` control statement.
 
-    The keyword arguments should have the form `in_*` and `out_*`, where
+    The keyword arguments should have the form `in_*`, `out_*`, or `ref_*`, where
     `*` is the name of an input or output port on the invoked cell.
     """
     return ast.Invoke(
@@ -264,6 +264,11 @@ def invoke(cell: CellBuilder, **kwargs) -> ast.Invoke:
             (k[4:], ExprBuilder.unwrap(v))
             for (k, v) in kwargs.items()
             if k.startswith("out_")
+        ],
+        [
+            (k[4:], ExprBuilder.unwrap(v))
+            for (k, v) in kwargs.items()
+            if k.startswith("ref_")
         ],
     )
 

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -574,6 +574,6 @@ LO = const(1, 0)
 HI = const(1, 1)
 
 
-def par(*args: Union[GroupBuilder, ast.Control, ast.Group, ast.Invoke]) -> ast.ParComp:
+def par(*args) -> ast.ParComp:
     """Build a parallel composition of control expressions."""
     return ast.ParComp([as_control(x) for x in args])

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -20,12 +20,21 @@ class Builder:
         )
         self.imported = set()
         self.import_("primitives/core.futil")
+        self._index: Dict[str, ComponentBuilder] = {}
 
     def component(self, name: str, cells=None) -> ComponentBuilder:
         cells = cells or []
         comp_builder = ComponentBuilder(self, name, cells)
         self.program.components.append(comp_builder.component)
+        self._index[name] = comp_builder
         return comp_builder
+
+    def get_component(self, name: str) -> ComponentBuilder:
+        comp_builder = self._index.get(name)
+        if comp_builder is None:
+            raise Exception(f"Component `{name}' not found in program.")
+        else:
+            return comp_builder
 
     def import_(self, filename: str):
         """Add an `import` statement to the program."""

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -142,6 +142,24 @@ class ComponentBuilder:
         self.index[name] = builder
         return builder
 
+    def sub_component(
+        self,
+        cell_name: str,
+        sub_comp_name: str | ComponentBuilder,
+        check_undeclared=True,
+    ) -> CellBuilder:
+        """Create a cell for a Calyx sub-component."""
+        if isinstance(sub_comp_name, str):
+            assert not check_undeclared or (
+                sub_comp_name in self.prog._index
+                or sub_comp_name in self.prog.program.components
+            ), f"Declaration of component '{sub_comp_name}' not found in program"
+
+        if isinstance(sub_comp_name, ComponentBuilder):
+            sub_comp_name = sub_comp_name.component.name
+
+        return self.cell(cell_name, ast.CompInst(sub_comp_name, []))
+
     def reg(self, name: str, size: int) -> CellBuilder:
         return self.cell(name, ast.Stdlib.register(size))
 

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -21,7 +21,7 @@ class Builder:
         self.imported = set()
         self.import_("primitives/core.futil")
 
-    def component(self, name: str, cells=None):
+    def component(self, name: str, cells=None) -> ComponentBuilder:
         cells = cells or []
         comp_builder = ComponentBuilder(self, name, cells)
         self.program.components.append(comp_builder.component)
@@ -66,7 +66,7 @@ class ComponentBuilder:
         return ThisBuilder()
 
     @property
-    def control(self):
+    def control(self) -> ControlBuilder:
         return ControlBuilder(self.component.controls)
 
     @control.setter
@@ -131,7 +131,7 @@ class ComponentBuilder:
         self.index[name] = builder
         return builder
 
-    def reg(self, name: str, size: int):
+    def reg(self, name: str, size: int) -> CellBuilder:
         return self.cell(name, ast.Stdlib.register(size))
 
     def const(self, name: str, width: int, value: int) -> CellBuilder:
@@ -146,12 +146,12 @@ class ComponentBuilder:
         idx_size: int,
         is_external=False,
         is_ref=False,
-    ):
+    ) -> CellBuilder:
         return self.cell(
             name, ast.Stdlib.mem_d1(bitwidth, len, idx_size), is_external, is_ref
         )
 
-    def add(self, name: str, size: int):
+    def add(self, name: str, size: int) -> CellBuilder:
         self.prog.import_("primitives/binary_operators.futil")
         return self.cell(name, ast.Stdlib.op("add", size, signed=False))
 
@@ -485,14 +485,14 @@ class GroupBuilder:
         TLS.groups.pop()
 
 
-def const(width: int, value: int):
+def const(width: int, value: int) -> ExprBuilder:
     """Build a sized integer constant expression.
 
     This is available as a shorthand in cases where automatic width
     inference fails. Otherwise, you can just use plain Python integer
     values.
     """
-    return ExprBuilder(ast.ConstantPort(width, value))
+    return ExprBuilder(ast.Atom(ast.ConstantPort(width, value)))
 
 
 def infer_width(expr):

--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -23,6 +23,7 @@ class Builder:
         self._index: Dict[str, ComponentBuilder] = {}
 
     def component(self, name: str, cells=None) -> ComponentBuilder:
+        """Create a new component builder."""
         cells = cells or []
         comp_builder = ComponentBuilder(self, name, cells)
         self.program.components.append(comp_builder.component)
@@ -30,6 +31,7 @@ class Builder:
         return comp_builder
 
     def get_component(self, name: str) -> ComponentBuilder:
+        """Retrieve a component builder by name."""
         comp_builder = self._index.get(name)
         if comp_builder is None:
             raise Exception(f"Component `{name}' not found in program.")

--- a/calyx-py/calyx/gen_exp.py
+++ b/calyx-py/calyx/gen_exp.py
@@ -4,7 +4,6 @@ from calyx.py_ast import (
     CompVar,
     Stdlib,
     Component,
-    CompInst,
     Program,
 )
 from calyx.utils import float_to_fixed_point
@@ -186,7 +185,7 @@ def generate_cells(
 
     # One extra `fp_pow` instance to compute e^{int_value}.
     for i in range(1, degree + 1):
-        comp.cell(f"pow{i}", CompInst("fp_pow", []))
+        comp.sub_component(f"pow{i}", "fp_pow", check_undeclared=False)
 
 
 def divide_and_conquer_sums(comp: ComponentBuilder, degree: int):
@@ -620,8 +619,8 @@ def generate_fp_pow_full(
         gen_comb_lt(comp, "base_lt_zero", comp.this().base, lt, const_zero),
 
     new_exp_val = comp.reg("new_exp_val", width)
-    e = comp.cell("e", CompInst("exp", []))
-    ln = comp.cell("l", CompInst("ln", []))
+    e = comp.sub_component("e", "exp", check_undeclared=False)
+    ln = comp.sub_component("l", "ln", check_undeclared=False)
 
     with comp.group("set_new_exp") as set_new_exp:
         mult.left = ln.out
@@ -728,7 +727,7 @@ def build_base_not_e(degree, width, int_width, is_signed) -> Program:
     x = main.mem_d1("x", width, 1, 1, is_external=True)
     b = main.mem_d1("b", width, 1, 1, is_external=True)
     ret = main.mem_d1("ret", width, 1, 1, is_external=True)
-    f = main.cell("f", CompInst("fp_pow_full", []))
+    f = main.sub_component("f", "fp_pow_full")
 
     with main.group("read_base") as read_base:
         b.addr0 = 0
@@ -777,7 +776,7 @@ def build_base_is_e(degree, width, int_width, is_signed) -> Program:
     t = main.reg("t", width)
     x = main.mem_d1("x", width, 1, 1, is_external=True)
     ret = main.mem_d1("ret", width, 1, 1, is_external=True)
-    e = main.cell("e", CompInst("exp", []))
+    e = main.sub_component("e", "exp")
 
     with main.group("init") as init:
         x.addr0 = 0

--- a/calyx-py/calyx/gen_ln.py
+++ b/calyx-py/calyx/gen_ln.py
@@ -3,7 +3,6 @@ from math import log
 from calyx.py_ast import (
     Stdlib,
     Component,
-    CompInst,
     Import,
 )
 from calyx.utils import float_to_fixed_point
@@ -292,9 +291,11 @@ def generate_ln(width: int, int_width: int, is_signed: bool) -> List[Component]:
         int_width,
         is_signed,
     )
-    pade_approx = comp.cell("pade_approx", CompInst("ln_pade_approx", []))
+    pade_approx = comp.sub_component(
+        "pade_approx", "ln_pade_approx", check_undeclared=False
+    )
     res_reg = comp.reg("res_reg", width)
-    msb = comp.cell("msb", CompInst("msb_calc", []))
+    msb = comp.sub_component("msb", "msb_calc", check_undeclared=False)
     # these 3 appear unused, not sure why
     slice0 = comp.cell("slice0", Stdlib.slice(width, int_width))
     rsh = comp.cell("rsh", Stdlib.op("rsh", width, is_signed))
@@ -395,7 +396,7 @@ if __name__ == "__main__":
     x = main.reg("x", width)
     in_ = main.mem_d1("in", width, 1, 1, is_external=True)
     out = main.mem_d1("out", width, 1, 1, is_external=True)
-    ln = main.cell("l", CompInst("ln", []))
+    ln = main.sub_component("l", "ln")
 
     with main.group("read_in_mem") as read_in_mem:
         in_.read_addr = 0


### PR DESCRIPTION
Small batch of changes to improve the builder.

- add a `sub_component` constructor for `ComponentBuilder` to create a cell instantiating a Calyx sub-comp
- add a `get_component` method to `Builder` to lookup `ComponentBuilder`'s by name
- extend the `invoke` constructor function to take `ref_*` arguments
- misc docstrings and type labels

Of these it's mostly the `invoke` thing that was needed by @anshumanmohan 