### PR TITLE
[frontend-tutorial] move map into its own little corner

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -707,3 +707,15 @@ def par(*args) -> ast.ParComp:
     So `par([a,b])` becomes `par {seq {a; b;}}` while `par(a, b)` becomes `par {a; b;}`.
     """
     return ast.ParComp([as_control(x) for x in args])
+
+
+def seq(*args) -> ast.SeqComp:
+    """Build a sequential composition of control expressions.
+
+    Prefer use of python list syntax over this function. Use only when not directly
+    modifying the control program with the `+=` operator.
+    Each argument will become its own sequential arm in the resulting composition.
+    So `seq([a,b], c)` becomes `seq { seq {a; b;} c }` while `seq(a, b, c)` becomes `seq
+    {a; b; c;}`.
+    """
+    return ast.SeqComp([as_control(x) for x in args])

--- a/frontends/mrxl/mrxl/gen_calyx.py
+++ b/frontends/mrxl/mrxl/gen_calyx.py
@@ -11,9 +11,11 @@ from calyx.py_ast import (
     While,
     ParComp,
     Control,
+    Empty,
 )
 from . import ast
 import calyx.builder as cb
+from . import map as map_impl
 
 
 class CompileError(Exception):
@@ -165,7 +167,8 @@ def gen_reduce_impl(
     return control
 
 
-def gen_map_impl(
+# ANCHOR: my_map_impl
+def my_map_impl(
     comp: cb.ComponentBuilder,
     dest: str,
     stmt: ast.Map,
@@ -184,92 +187,9 @@ def gen_map_impl(
       - a group that implements the loop condition, checking if the index
         has reached the end of the input array
     """
-
-    # Parallel loops representing the `map` body
-    map_loops = []
-
-    arr_size = arr_size // bank_factor
-    for bank in range(bank_factor):
-        suffix = f"b{bank}_{s_idx}"
-        idx = comp.reg(f"idx_{suffix}", 32)
-
-        # Increment the index
-        incr = incr_group(comp, idx, suffix)
-        # Check if we've reached the end of the loop
-        (port, cond) = cond_group(comp, idx, arr_size, suffix)
-
-        # Perform the computation
-        body = stmt.body
-        if isinstance(body, ast.LitExpr):  # Body is a constant
-            raise NotImplementedError()
-        if isinstance(body, ast.VarExpr):  # Body is a variable
-            raise NotImplementedError()
-
-        # Mapping from binding to arrays
-        name2arr = {bind.dst[0]: f"{bind.src}_b{bank}" for bind in stmt.binds}
-
-        def expr_to_port(expr: ast.BaseExpr):
-            if isinstance(expr, ast.LitExpr):
-                return cb.const(32, expr.value)
-            if isinstance(expr, ast.VarExpr):
-                return CompPort(CompVar(name2arr[expr.name]), "read_data")
-            raise CompileError(f"Unhandled expression: {type(expr)}")
-
-        # ANCHOR: map_op
-        if body.operation == "mul":
-            operation = comp.cell(
-                f"mul_{suffix}", Stdlib.op("mult_pipe", 32, signed=False)
-            )
-        else:
-            operation = comp.add(f"add_{suffix}", 32)
-        # ANCHOR_END: map_op
-
-        assert (
-            len(stmt.binds) <= 2
-        ), "Map statements with more than 2 arguments not supported"
-        # ANCHOR: map_inputs
-        with comp.group(f"eval_body_{suffix}") as evl:
-            # Index each array
-            for bind in stmt.binds:
-                # Map bindings have exactly one dest
-                mem = comp.get_cell(f"{name2arr[bind.dst[0]]}")
-                mem.addr0 = idx.out
-            # ANCHOR_END: map_inputs
-            # Provide inputs to the op
-            operation.left = expr_to_port(body.lhs)
-            operation.right = expr_to_port(body.rhs)
-            # ANCHOR: map_write
-            out_mem = comp.get_cell(f"{dest}_b{bank}")
-            out_mem.addr0 = idx.out
-            out_mem.write_data = operation.out
-            # Multipliers are sequential so we need to manipulate go/done signals
-            if body.operation == "mul":
-                operation.go = 1
-                out_mem.write_en = operation.done
-            else:
-                out_mem.write_en = 1
-            evl.done = out_mem.done
-            # ANCHOR_END: map_write
-
-        # Control to execute the groups
-        map_loops.append(
-            # ANCHOR: map_loop
-            While(
-                CompPort(CompVar(port), "out"),
-                CompVar(cond),
-                SeqComp(
-                    [
-                        Enable(f"eval_body_{suffix}"),
-                        Enable(incr),
-                    ]
-                ),
-            )
-            # ANCHOR_END: map_loop
-        )
-
-    control = ParComp(map_loops)
-
-    return control
+    # TODO: Implement map!
+    return Empty()
+    # ANCHOR_END: my_map_impl
 
 
 def gen_stmt_impl(
@@ -278,6 +198,7 @@ def gen_stmt_impl(
     arr_size: int,
     name2par: Dict[str, int],
     statement_idx: int,
+    use_my_map_impl: bool,
 ) -> Control:
     """
     Returns Calyx cells, wires, and control needed to implement
@@ -296,8 +217,17 @@ def gen_stmt_impl(
 
     name2par maps memory names to banking factors.
     """
-    if isinstance(stmt.operation, ast.Map):
-        return gen_map_impl(
+    if isinstance(stmt.operation, ast.Map) and use_my_map_impl:
+        return my_map_impl(
+            comp,
+            stmt.dst,
+            stmt.operation,
+            arr_size,
+            name2par[stmt.dst],
+            statement_idx,
+        )
+    elif isinstance(stmt.operation, ast.Map):
+        return map_impl.gen_map_impl(
             comp,
             stmt.dst,
             stmt.operation,
@@ -400,7 +330,7 @@ def reg_to_mem_group(
     return group_name
 
 
-def emit(prog: ast.Prog):
+def emit(prog: ast.Prog, use_my_map_impl: bool = False):
     """
     Returns a string containing a Calyx program, compiled from `prog`, a MrXL
     program.
@@ -467,7 +397,9 @@ def emit(prog: ast.Prog):
     control: List[Control] = []
     # Generate Calyx for each statement
     for i, stmt in enumerate(prog.stmts):
-        control.append(gen_stmt_impl(main, stmt, arr_size, par_factor, i))
+        control.append(
+            gen_stmt_impl(main, stmt, arr_size, par_factor, i, use_my_map_impl)
+        )
 
     # For each output register, move the value of the register into the external array
     if reg_to_mem:

--- a/frontends/mrxl/mrxl/main.py
+++ b/frontends/mrxl/mrxl/main.py
@@ -29,6 +29,14 @@ def main():
         action="store_true",
         help="Convert <datafile> to calyx input (instead of compiling)",
     )
+
+    parser.add_argument(
+        "-m",
+        "--my-map",
+        action="store_true",
+        help="Use my_map instead of the default map implementation",
+    )
+
     parser.add_argument(
         "filename",
         metavar="<file>",
@@ -59,6 +67,6 @@ def main():
             raise ValueError("Must provide data if converting")
         emit_data(ast, data)  # type: ignore
     else:
-        emit(ast)
+        emit(ast, args.my_map)
 
     sys.exit(0)

--- a/frontends/mrxl/mrxl/map.py
+++ b/frontends/mrxl/mrxl/map.py
@@ -1,0 +1,119 @@
+from calyx.py_ast import (
+    CompVar,
+    Stdlib,
+    SeqComp,
+    CompPort,
+    Enable,
+    While,
+    ParComp,
+)
+from . import ast
+import calyx.builder as cb
+
+
+def gen_map_impl(
+    comp: cb.ComponentBuilder,
+    dest: str,
+    stmt: ast.Map,
+    arr_size: int,
+    bank_factor: int,
+    s_idx: int,
+):
+    """
+    Returns a dictionary containing Calyx cells, wires and
+    control needed to implement a `map` statement.
+    See gen_stmt_impl for format of the dictionary.
+
+    Generates these groups:
+      - a group that implements the body of the `map` statement
+      - a group that increments an index to access the `map` input array
+      - a group that implements the loop condition, checking if the index
+        has reached the end of the input array
+    """
+    from .gen_calyx import incr_group, cond_group, CompileError
+
+    # Parallel loops representing the `map` body
+    map_loops = []
+
+    arr_size = arr_size // bank_factor
+    for bank in range(bank_factor):
+        suffix = f"b{bank}_{s_idx}"
+        idx = comp.reg(f"idx_{suffix}", 32)
+
+        # Increment the index
+        incr = incr_group(comp, idx, suffix)
+        # Check if we've reached the end of the loop
+        (port, cond) = cond_group(comp, idx, arr_size, suffix)
+
+        # Perform the computation
+        body = stmt.body
+        if isinstance(body, ast.LitExpr):  # Body is a constant
+            raise NotImplementedError()
+        if isinstance(body, ast.VarExpr):  # Body is a variable
+            raise NotImplementedError()
+
+        # Mapping from binding to arrays
+        name2arr = {bind.dst[0]: f"{bind.src}_b{bank}" for bind in stmt.binds}
+
+        def expr_to_port(expr: ast.BaseExpr):
+            if isinstance(expr, ast.LitExpr):
+                return cb.const(32, expr.value)
+            if isinstance(expr, ast.VarExpr):
+                return CompPort(CompVar(name2arr[expr.name]), "read_data")
+            raise CompileError(f"Unhandled expression: {type(expr)}")
+
+        # ANCHOR: map_op
+        if body.operation == "mul":
+            operation = comp.cell(
+                f"mul_{suffix}", Stdlib.op("mult_pipe", 32, signed=False)
+            )
+        else:
+            operation = comp.add(f"add_{suffix}", 32)
+        # ANCHOR_END: map_op
+
+        assert (
+            len(stmt.binds) <= 2
+        ), "Map statements with more than 2 arguments not supported"
+        # ANCHOR: map_inputs
+        with comp.group(f"eval_body_{suffix}") as evl:
+            # Index each array
+            for bind in stmt.binds:
+                # Map bindings have exactly one dest
+                mem = comp.get_cell(f"{name2arr[bind.dst[0]]}")
+                mem.addr0 = idx.out
+            # ANCHOR_END: map_inputs
+            # Provide inputs to the op
+            operation.left = expr_to_port(body.lhs)
+            operation.right = expr_to_port(body.rhs)
+            # ANCHOR: map_write
+            out_mem = comp.get_cell(f"{dest}_b{bank}")
+            out_mem.addr0 = idx.out
+            out_mem.write_data = operation.out
+            # Multipliers are sequential so we need to manipulate go/done signals
+            if body.operation == "mul":
+                operation.go = 1
+                out_mem.write_en = operation.done
+            else:
+                out_mem.write_en = 1
+            evl.done = out_mem.done
+            # ANCHOR_END: map_write
+
+        # Control to execute the groups
+        map_loops.append(
+            # ANCHOR: map_loop
+            While(
+                CompPort(CompVar(port), "out"),
+                CompVar(cond),
+                SeqComp(
+                    [
+                        Enable(f"eval_body_{suffix}"),
+                        Enable(incr),
+                    ]
+                ),
+            )
+            # ANCHOR_END: map_loop
+        )
+
+    control = ParComp(map_loops)
+
+    return control


### PR DESCRIPTION
An initial stab at re-configuring `mrxl` so that it can optionally take a flag to use a custom implementation of `map` rather than our artisanal in-house option. I also adjusted some of the prose to reflect this addition but left all the existing text intact, so it's more of an optional thing.

Anyway leaving this as a draft so that other people have a chance to look this over. The one wrinkle is that the dummy version of `my_map_impl` can generate potentially invalid programs per the ongoing discussion in #1526. Currently if the program is just a `map` the interpreter will run forever since it thinks it's a fully functional group. This is an easy fix, but also potentially not relevant? I'm unsure.