### PR TITLE
Strip suffix in discover external

### DIFF
--- a/tests/passes/discover-external.expect
+++ b/tests/passes/discover-external.expect
@@ -2,18 +2,18 @@ import "primitives/core.futil";
 component mlir_funcSYCL_class_vector_addition<"toplevel"=1>(@clk clk: 1, @reset reset: 1, @go go: 1) -> (@done done: 1) {
   cells {
     add = std_add(32);
-    @external @generated ext_mem0_ = std_mem_d1(32, 16, 1);
-    @external @generated ext_mem1_ = std_mem_d1(32, 16, 1);
+    @external @generated ext_mem0 = std_mem_d1(32, 16, 1);
+    @external @generated ext_mem1 = std_mem_d1(32, 16, 1);
   }
   wires {
     group incr {
-      ext_mem0_.addr0 = 1'd0;
-      add.left = ext_mem0_.read_data;
+      ext_mem0.addr0 = 1'd0;
+      add.left = ext_mem0.read_data;
       add.right = 32'd1;
-      ext_mem1_.write_data = add.out;
-      ext_mem1_.addr0 = 1'd0;
-      ext_mem1_.write_en = 1'd1;
-      incr[done] = ext_mem1_.done;
+      ext_mem1.write_data = add.out;
+      ext_mem1.addr0 = 1'd0;
+      ext_mem1.write_en = 1'd1;
+      incr[done] = ext_mem1.done;
     }
   }
   control {

--- a/tests/passes/discover-external.futil
+++ b/tests/passes/discover-external.futil
@@ -1,4 +1,4 @@
-// -p validate -p discover-external -p validate -x discover-external:default=16
+// -p validate -p discover-external -p validate -x discover-external:default=16 -x discover-external:strip-suffix=_
 import "primitives/core.futil";
 component mlir_funcSYCL_class_vector_addition<"toplevel"=1>(
   ext_mem0_read_data: 32,


### PR DESCRIPTION
Add the `strip-suffix` flag for the `discover-external` pass. To use:
```
calyx -p validate -p discover-external -p validate -x discover-external:default=16 -x discover-external:strip-suffix=_
```