### PR TITLE
Try setting up Depot for Docker builds

### DIFF
--- a/.github/workflows/depot.yml
+++ b/.github/workflows/depot.yml
@@ -1,0 +1,23 @@
+name: Docker Images via Depot
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: depot/setup-action@v1
+      - uses: depot/build-push-action@v1
+        with:
+          project: zmf9xmg5nl
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: cucapra/calyx:latest

--- a/.github/workflows/depot.yml
+++ b/.github/workflows/depot.yml
@@ -13,7 +13,6 @@ jobs:
       id-token: write
       packages: write
     steps:
-      - uses: actions/checkout@v3
       - uses: depot/setup-action@v1
       - uses: depot/build-push-action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Built with Depot](https://depot.dev/badges/built-with-depot.svg)](https://depot.dev/?utm_source=capra)
+
 <h1>
 <p align="center">
 <img src="https://calyxir.org/img/logo-text.svg" width="300">


### PR DESCRIPTION
We ran into timeouts trying to build ARM Docker images on GitHub Actions (cf #1512, for example). [Depot](https://depot.dev) looks like a good solution here: it is a CI service specifically for doing Docker builds, and aside from being faster than the Actions runners, it also natively supports ARM builds in addition to x86 ones. (It also has built-in support for building multiarch images.) I contacted the folks from Depot and they generously donated a sponsored account, so I'd like to try this out. (They asked us to add a badge to our README to acknowledge the donation; I've done this.)

This setup builds a new Docker image for the `:latest` tag on every push to `master`. I hope this (a) helps me debug the action to see if it works, and (b) provides a "cutting-edge" image for people who want the latest source. If this does work and I don't roll it back immediately, we can subsequently look into also tagging specific versions of the Docker image (e.g., `cucapra/calyx:0.3.0`) upon release.