### PR TITLE
Temporary Directory for Vivado Synthesis Files Can be Specified Thru a Flag

### DIFF
--- a/fud/fud/stages/vivado/stage.py
+++ b/fud/fud/stages/vivado/stage.py
@@ -74,7 +74,10 @@ class VivadoBaseStage(Stage):
             """
             Make temporary directory to store Vivado synthesis files.
             """
-            return TmpDir()
+            if ["stages", self.name, "mktmp"] in config:
+                return TmpDir(config["stages", self.name, "mktmp"])
+            else:
+                return TmpDir()
 
         @builder.step()
         def local_move_files(

--- a/fud/fud/utils.py
+++ b/fud/fud/utils.py
@@ -78,8 +78,11 @@ class Directory:
 class TmpDir(Directory):
     """A temporary directory that is automatically deleted."""
 
-    def __init__(self):
-        self.tmpdir_obj = TemporaryDirectory()
+    def __init__(self, tmp_dir_name=None):
+        if tmp_dir_name is not None:
+            self.tmpdir_obj = TemporaryDirectory(dir=tmp_dir_name)
+        else:
+            self.tmpdir_obj = TemporaryDirectory()
         self.name = self.tmpdir_obj.name
 
     def remove(self):


### PR DESCRIPTION
(Minor, Not Super-Urgent PR) 
Sometimes when running resource estimates on havarti, `fud` would write some of the temporary (very large) Vivado synthesis files into a `/tmp` folder somewhere in `/home`, which would temporarily fill up havarti. Using this PR, we can tell `fud` where to store the temporary file (in this case somewhere in `/scratch`) as to not fill up space. 

Quick question: should this change to fud be documented somewhere? If so, I'll do it on this PR. 