### PR TITLE
Dry run fixes

### DIFF
--- a/docs/tutorial/frontend-tut.md
+++ b/docs/tutorial/frontend-tut.md
@@ -89,8 +89,8 @@ The above command takes a MrXL program, `sos.mrxl`, and generates results with V
 
 # Compiling MrXL into Calyx
 
-Any frontend can support new commands that are relevant to the domain of interest, so long as those commands can themselves be compiled into Calyx.
-We will now step back from our example and study [the MrXL-to-Calyx compiler][impl], written in Python.
+Calyx is an infrastructure for designing *domain-specific languages* (DSL) which can generate efficient hardware.
+The rest of the tutorial will show you how to implement such a DSL by studying [the MrXL-to-Calyx compiler][impl], written in Python.
 
 We have placed a few simplifying restrictions on MrXL programs:
 1. Every array in a MrXL program has the same length.


### PR DESCRIPTION
## Sequence of Steps

- Install the docker container
    - Recommend installing a specific version of the docker image instead of latest.
- Walkthrough "Building a Frontend for Calyx"
    - Currently tells people how to install `calyx-py` and `mrxl`, but these are already installed in the docker container.
    - The Calyx-based simulation command uses `--through verilator`. Should we be using `icarus-verilog` instead? 
    - Explain why we might need different physical banks in the "`Decl` nodes" section. Put this explanation under a `<details>` tag.
    - In "Compiling `map` operations", point the reader to the file where the unimplemented `my_map_impl` is defined so they can go work on it.
    - Nit: replace `---` with `–`.
- "Further Steps"
    - Point people to the primitives or `-` and `/`.
    - Find and link and explainer about "reduction trees".


## TODOs
- [x] We should use the *same simulator* throughout the tutorial.
- [x] Remove comments from commands that are meant to be copied. Commands with `\` and `#` don't work.
- [ ] Run a `runt` command that ensures that `mrxl` and relevant things are working.