### PR TITLE
Fixed-point conversion fixes

### DIFF
--- a/fud/fud/stages/verilator/json_to_dat.py
+++ b/fud/fud/stages/verilator/json_to_dat.py
@@ -93,7 +93,7 @@ def parse_fp_widths(format):
 def convert(x, round: bool, is_signed: bool, width: int, int_width=None):
     with_prefix = False
     # If `int_width` is not defined, then this is a `Bitnum`
-    if not int_width:
+    if int_width is None:
         return Bitnum(x, width, is_signed).hex_string(with_prefix)
 
     try:
@@ -149,7 +149,7 @@ def convert2dat(output_dir, data, extension, round: bool):
             "is_signed": is_signed,
             "width": width,
         }
-        if int_width:
+        if int_width is not None:
             shape[k]["int_width"] = int_width
 
         with path.open("w") as f:

--- a/fud/fud/stages/verilator/numeric_types.py
+++ b/fud/fud/stages/verilator/numeric_types.py
@@ -198,9 +198,9 @@ class FixedPoint(NumericType):
             raise InvalidNumericType(
                 f"The value: `{value}` is not representable in fixed point."
             )
-        required_int_width = int(log2(int_partition) if int_partition > 0 else 0)
+        required_int_width = int(log2(int_partition)) + 1 if int_partition > 0 else 0
         required_frac_width = int(required_frac_width)
-        int_overflow = required_int_width > self.int_width - 1
+        int_overflow = required_int_width > self.int_width
         frac_overflow = required_frac_width > self.frac_width
         if int_overflow or frac_overflow:
             raise InvalidNumericType(
@@ -216,7 +216,7 @@ has led to overflow.
         int_bits = np.binary_repr(int_partition, self.int_width)
         frac_bits = np.binary_repr(
             round(frac_partition * (2**self.frac_width)), self.frac_width
-        )
+        ) if self.frac_width > 0 else ""
         # Given the binary form of the integer part and fractional part of
         # the decimal, simply append the two strings.
         bits = int_bits + frac_bits


### PR DESCRIPTION
Small fixes for `fud`'s fixed-point conversion routines. Addresses the following issues:

- When `frac_width` is zero, the result has an extra zero inserted in the LSB position.
- On overflow, the number of required integer bits was being incorrectly reported. Moreover, the conversion failed for formats with zero integer bits.