### PR TITLE
[cider: flat-ir] Documentation pass + invoke

### DIFF
--- a/interp/src/flatten/flat_ir/base.rs
+++ b/interp/src/flatten/flat_ir/base.rs
@@ -4,7 +4,7 @@ use crate::flatten::structures::index_trait::{
     impl_index, impl_index_nonzero, IndexRange,
 };
 
-use super::prelude::Identifier;
+use super::{cell_prototype::CellPrototype, prelude::Identifier};
 
 // making these all u32 for now, can give the macro an optional type as the
 // second arg to contract or expand as needed
@@ -216,9 +216,10 @@ pub struct CellDefinitionInfo<C>
 where
     C: sealed::PortType,
 {
-    name: Identifier,
-    ports: IndexRange<C>,
-    parent: ComponentIdx,
+    pub name: Identifier,
+    pub ports: IndexRange<C>,
+    pub parent: ComponentIdx,
+    pub prototype: CellPrototype,
 }
 
 impl<C> CellDefinitionInfo<C>
@@ -229,20 +230,14 @@ where
         name: Identifier,
         ports: IndexRange<C>,
         parent: ComponentIdx,
+        prototype: CellPrototype,
     ) -> Self {
         Self {
             name,
             ports,
             parent,
+            prototype,
         }
-    }
-
-    pub fn name(&self) -> Identifier {
-        self.name
-    }
-
-    pub fn ports(&self) -> &IndexRange<C> {
-        &self.ports
     }
 }
 

--- a/interp/src/flatten/flat_ir/base.rs
+++ b/interp/src/flatten/flat_ir/base.rs
@@ -127,6 +127,7 @@ impl From<LocalPortOffset> for PortRef {
     }
 }
 
+/// An enum wrapping the two different types of port definitions (ref/local)
 pub enum PortDefinitionRef {
     Local(PortDefinitionIdx),
     Ref(RefPortDefinitionIdx),
@@ -144,10 +145,35 @@ impl From<PortDefinitionIdx> for PortDefinitionRef {
     }
 }
 
+/// A wrapper enum distinguishing between local offsets to cells and ref cells
+///
+/// TODO griffin: do some clever bit stuff to pack this into a single u32 rather
+/// than the 64 bits it current occupies due to the discriminant being 32 bits
+/// because of alignment
 #[derive(Debug, Copy, Clone)]
 pub enum CellRef {
     Local(LocalCellOffset),
     Ref(LocalRefCellOffset),
+}
+
+impl CellRef {
+    #[must_use]
+    pub fn as_local(&self) -> Option<&LocalCellOffset> {
+        if let Self::Local(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn as_ref(&self) -> Option<&LocalRefCellOffset> {
+        if let Self::Ref(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 impl From<LocalRefCellOffset> for CellRef {
@@ -162,20 +188,25 @@ impl From<LocalCellOffset> for CellRef {
     }
 }
 
+/// A global index for assignments in the IR
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
 pub struct AssignmentIdx(u32);
 impl_index!(AssignmentIdx);
 
+/// A global index for standard groups in the IR
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
 pub struct GroupIdx(u32);
 impl_index!(GroupIdx);
 
-// This is non-zero to make the option-types of this index used in the IR If and
-// While nodes the same size as the index itself.
+/// A global index for combinational groups in the IR
+///
+/// This is non-zero to make the option-types of this index used in the IR If and
+/// While nodes the same size as the index itself.
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
 pub struct CombGroupIdx(NonZeroU32);
 impl_index_nonzero!(CombGroupIdx);
 
+/// A global index for guards used in the IR
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
 pub struct GuardIdx(u32);
 impl_index!(GuardIdx);

--- a/interp/src/flatten/flat_ir/base.rs
+++ b/interp/src/flatten/flat_ir/base.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use crate::flatten::structures::index_trait::{
     impl_index, impl_index_nonzero, IndexRange,
 };
@@ -7,28 +9,81 @@ use super::prelude::Identifier;
 // making these all u32 for now, can give the macro an optional type as the
 // second arg to contract or expand as needed
 
-impl_index!(pub ComponentRef);
+/// The identifier for a component definition
+#[derive(Debug, Eq, Copy, Clone, PartialEq)]
+pub struct ComponentIdx(u32);
+impl_index!(ComponentIdx);
 
-// Definition indexes, used to address information
-impl_index!(pub CellDefinitionIdx);
-impl_index!(pub PortDefinitionIdx);
-impl_index!(pub RefCellDefinitionIdx);
-impl_index!(pub RefPortDefinitionIdx);
+/// An index for auxillary definition information for cells
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct CellDefinitionIdx(u32);
+impl_index!(CellDefinitionIdx);
+
+/// An index for auxillary definition information for ports
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct PortDefinitionIdx(u32);
+impl_index!(PortDefinitionIdx);
+
+/// An index for auxillary definition information for ref cells
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct RefCellDefinitionIdx(u32);
+impl_index!(RefCellDefinitionIdx);
+
+/// An index for auxillary definition information for ref ports
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct RefPortDefinitionIdx(u32);
+impl_index!(RefPortDefinitionIdx);
 
 // Global indices
-impl_index!(pub GlobalPortId);
-impl_index!(pub GlobalCellId);
-impl_index!(pub GlobalRefCellId);
+
+/// The index of a port instance in the global value map
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct GlobalPortId(u32);
+impl_index!(GlobalPortId);
+
+/// The index of a cell instance in the global value map
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct GlobalCellId(u32);
+impl_index!(GlobalCellId);
+
+/// The index of a ref cell instance in the global value map
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct GlobalRefCellId(u32);
+impl_index!(GlobalRefCellId);
 
 // Offset indices
-impl_index!(pub LocalPortOffset);
-impl_index!(pub LocalRefPortOffset);
-impl_index!(pub LocalCellOffset);
-impl_index!(pub LocalRefCellOffset);
 
+/// A local port offset for a component. These are used in the definition of
+/// assignments and can only be understood in the context of the component they
+/// are defined under.
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct LocalPortOffset(u32);
+impl_index!(LocalPortOffset);
+
+/// A local ref port offset for a component. These are used in the definition of
+/// assignments and can only be understood in the context of the component they
+/// are defined under.
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct LocalRefPortOffset(u32);
+impl_index!(LocalRefPortOffset);
+
+/// A local cell offset for a component. Primarily for alignment bookkeeping.
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct LocalCellOffset(u32);
+impl_index!(LocalCellOffset);
+
+/// A local ref cell offset for a component. Primarily for alignment bookkeeping.
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct LocalRefCellOffset(u32);
+impl_index!(LocalRefCellOffset);
+
+/// Enum used in assignments to encapsulate the different types of port references
 #[derive(Debug, Copy, Clone)]
 pub enum PortRef {
+    /// A port belonging to a non-ref cell/group in the current component or the
+    /// component itself
     Local(LocalPortOffset),
+    /// A port belonging to a ref cell in the current component
     Ref(LocalRefPortOffset),
 }
 
@@ -107,15 +162,23 @@ impl From<LocalCellOffset> for CellRef {
     }
 }
 
-impl_index!(pub AssignmentIdx);
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct AssignmentIdx(u32);
+impl_index!(AssignmentIdx);
 
-impl_index!(pub GroupIdx);
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct GroupIdx(u32);
+impl_index!(GroupIdx);
 
 // This is non-zero to make the option-types of this index used in the IR If and
 // While nodes the same size as the index itself.
-impl_index_nonzero!(pub CombGroupIdx);
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct CombGroupIdx(NonZeroU32);
+impl_index_nonzero!(CombGroupIdx);
 
-impl_index!(pub GuardIdx);
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct GuardIdx(u32);
+impl_index!(GuardIdx);
 
 #[derive(Debug, Clone)]
 pub struct CellDefinitionInfo<C>
@@ -124,7 +187,7 @@ where
 {
     name: Identifier,
     ports: IndexRange<C>,
-    parent: ComponentRef,
+    parent: ComponentIdx,
 }
 
 impl<C> CellDefinitionInfo<C>
@@ -134,7 +197,7 @@ where
     pub fn new(
         name: Identifier,
         ports: IndexRange<C>,
-        parent: ComponentRef,
+        parent: ComponentIdx,
     ) -> Self {
         Self {
             name,
@@ -156,7 +219,7 @@ pub type CellInfo = CellDefinitionInfo<LocalPortOffset>;
 pub type RefCellInfo = CellDefinitionInfo<LocalRefPortOffset>;
 
 pub enum ParentIdx {
-    Component(ComponentRef),
+    Component(ComponentIdx),
     Cell(CellDefinitionIdx),
     RefCell(RefCellDefinitionIdx),
     Group(GroupIdx),
@@ -180,8 +243,8 @@ impl From<CellDefinitionIdx> for ParentIdx {
     }
 }
 
-impl From<ComponentRef> for ParentIdx {
-    fn from(v: ComponentRef) -> Self {
+impl From<ComponentIdx> for ParentIdx {
+    fn from(v: ComponentIdx) -> Self {
         Self::Component(v)
     }
 }

--- a/interp/src/flatten/flat_ir/cell_prototype.rs
+++ b/interp/src/flatten/flat_ir/cell_prototype.rs
@@ -1,4 +1,4 @@
-use calyx_ir::{self as cir, RRC};
+use calyx_ir::{self as cir};
 use smallvec::SmallVec;
 
 use crate::primitives::prim_utils::get_params;

--- a/interp/src/flatten/flat_ir/cell_prototype.rs
+++ b/interp/src/flatten/flat_ir/cell_prototype.rs
@@ -36,8 +36,7 @@ impl CellPrototype {
         if let cir::CellType::Primitive {
             name,
             param_binding,
-            is_comb,
-            latency,
+            ..
         } = cell
         {
             let name: &str = name.as_ref();

--- a/interp/src/flatten/flat_ir/cell_prototype.rs
+++ b/interp/src/flatten/flat_ir/cell_prototype.rs
@@ -1,0 +1,73 @@
+use calyx_ir::{self as cir, RRC};
+use smallvec::SmallVec;
+
+use crate::primitives::prim_utils::get_params;
+
+use super::prelude::ComponentIdx;
+
+#[derive(Debug, Clone)]
+pub enum CellPrototype {
+    Component(ComponentIdx),
+    ConstantLiteral { value: u64, width: u64 },
+    Register { width: u64 },
+    ConstantPrimitive { value: u64, width: u64 },
+    // TODO Griffin: lots more
+    Unknown(String, Box<cir::Binding>),
+}
+
+impl From<ComponentIdx> for CellPrototype {
+    fn from(v: ComponentIdx) -> Self {
+        Self::Component(v)
+    }
+}
+
+impl CellPrototype {
+    #[must_use]
+    pub fn as_component(&self) -> Option<&ComponentIdx> {
+        if let Self::Component(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn construct_primitive(cell: &cir::CellType) -> Self {
+        if let cir::CellType::Primitive {
+            name,
+            param_binding,
+            is_comb,
+            latency,
+        } = cell
+        {
+            let name: &str = name.as_ref();
+            let params: &SmallVec<_> = param_binding;
+
+            match name {
+                "std_reg" => {
+                    get_params![params;
+                        width: "WIDTH"
+                    ];
+
+                    Self::Register { width }
+                }
+
+                "std_const" => {
+                    get_params![params;
+                        value: "VALUE",
+                        width: "WIDTH"
+                    ];
+
+                    Self::ConstantPrimitive { value, width }
+                }
+
+                _ => CellPrototype::Unknown(
+                    name.to_string(),
+                    param_binding.clone(),
+                ),
+            }
+        } else {
+            panic!("construct_primitive called on non-primitive cell");
+        }
+    }
+}

--- a/interp/src/flatten/flat_ir/component.rs
+++ b/interp/src/flatten/flat_ir/component.rs
@@ -220,4 +220,4 @@ impl IdxSkipSizes {
     }
 }
 
-pub type ComponentMap = IndexedMap<ComponentRef, ComponentCore>;
+pub type ComponentMap = IndexedMap<ComponentIdx, ComponentCore>;

--- a/interp/src/flatten/flat_ir/control/structures.rs
+++ b/interp/src/flatten/flat_ir/control/structures.rs
@@ -143,30 +143,32 @@ impl While {
 }
 
 /// Invoke control node
+///
+/// TODO Griffin: Consider making this smaller?
 #[derive(Debug)]
 pub struct Invoke {
     /// The cell being invoked
-    cell: LocalCellOffset,
+    pub cell: CellRef,
     /// Optional group enabled during invocation of the cell (the calyx `with`
     /// statement)
-    comb_group: Option<CombGroupIdx>,
+    pub comb_group: Option<CombGroupIdx>,
     /// The external cells passed as arguments to the invoked cell, an
     /// association list of the refcell offset in the invoked context, and the
     /// cell realizing it in the parent context
-    ref_cells: SmallVec<[(LocalRefCellOffset, CellRef); 1]>,
+    pub ref_cells: SmallVec<[(LocalRefCellOffset, CellRef); 1]>,
     /// The ports attached to the input of the invoked cell, an association list
     /// of the port ref in the **PARENT** context, and the port connected
     /// to it in the parent context i.e. (dst, src)
-    inputs: SmallVec<[(PortRef, PortRef); 1]>,
+    pub inputs: SmallVec<[(PortRef, PortRef); 1]>,
     /// The ports attached to the outputs of the invoked cell, an association list
     /// of the port ref in the **PARENT** context, and the port connected
     /// to it in the parent context. i.e. (dst, src)
-    outputs: SmallVec<[(PortRef, PortRef); 1]>,
+    pub outputs: SmallVec<[(PortRef, PortRef); 1]>,
 }
 
 impl Invoke {
     pub fn new<R, I, O>(
-        cell: LocalCellOffset,
+        cell: CellRef,
         comb_group: Option<CombGroupIdx>,
         ref_cells: R,
         inputs: I,

--- a/interp/src/flatten/flat_ir/control/structures.rs
+++ b/interp/src/flatten/flat_ir/control/structures.rs
@@ -155,13 +155,13 @@ pub struct Invoke {
     /// cell realizing it in the parent context
     ref_cells: SmallVec<[(LocalRefCellOffset, CellRef); 1]>,
     /// The ports attached to the input of the invoked cell, an association list
-    /// of the local port offset in the **PARENT** context, and the port connected
-    /// to it in the parent context
-    inputs: SmallVec<[(LocalPortOffset, PortRef); 1]>,
+    /// of the port ref in the **PARENT** context, and the port connected
+    /// to it in the parent context i.e. (dst, src)
+    inputs: SmallVec<[(PortRef, PortRef); 1]>,
     /// The ports attached to the outputs of the invoked cell, an association list
-    /// of the local port offset in the **PARENT** context, and the port connected
-    /// to it in the parent context
-    outputs: SmallVec<[(LocalPortOffset, PortRef); 1]>,
+    /// of the port ref in the **PARENT** context, and the port connected
+    /// to it in the parent context. i.e. (dst, src)
+    outputs: SmallVec<[(PortRef, PortRef); 1]>,
 }
 
 impl Invoke {
@@ -174,8 +174,8 @@ impl Invoke {
     ) -> Self
     where
         R: IntoIterator<Item = (LocalRefCellOffset, CellRef)>,
-        I: IntoIterator<Item = (LocalPortOffset, PortRef)>,
-        O: IntoIterator<Item = (LocalPortOffset, PortRef)>,
+        I: IntoIterator<Item = (PortRef, PortRef)>,
+        O: IntoIterator<Item = (PortRef, PortRef)>,
     {
         Self {
             cell,

--- a/interp/src/flatten/flat_ir/control/structures.rs
+++ b/interp/src/flatten/flat_ir/control/structures.rs
@@ -145,7 +145,46 @@ impl While {
 /// Invoke control node
 #[derive(Debug)]
 pub struct Invoke {
-    // TODO: add invoke stuff
+    /// The cell being invoked
+    cell: LocalCellOffset,
+    /// Optional group enabled during invocation of the cell (the calyx `with`
+    /// statement)
+    comb_group: Option<CombGroupIdx>,
+    /// The external cells passed as arguments to the invoked cell, an
+    /// association list of the refcell offset in the invoked context, and the
+    /// cell realizing it in the parent context
+    ref_cells: SmallVec<[(LocalRefCellOffset, CellRef); 1]>,
+    /// The ports attached to the input of the invoked cell, an association list
+    /// of the local port offset in the **PARENT** context, and the port connected
+    /// to it in the parent context
+    inputs: SmallVec<[(LocalPortOffset, PortRef); 1]>,
+    /// The ports attached to the outputs of the invoked cell, an association list
+    /// of the local port offset in the **PARENT** context, and the port connected
+    /// to it in the parent context
+    outputs: SmallVec<[(LocalPortOffset, PortRef); 1]>,
+}
+
+impl Invoke {
+    pub fn new<R, I, O>(
+        cell: LocalCellOffset,
+        comb_group: Option<CombGroupIdx>,
+        ref_cells: R,
+        inputs: I,
+        outputs: O,
+    ) -> Self
+    where
+        R: IntoIterator<Item = (LocalRefCellOffset, CellRef)>,
+        I: IntoIterator<Item = (LocalPortOffset, PortRef)>,
+        O: IntoIterator<Item = (LocalPortOffset, PortRef)>,
+    {
+        Self {
+            cell,
+            comb_group,
+            ref_cells: ref_cells.into_iter().collect(),
+            inputs: inputs.into_iter().collect(),
+            outputs: outputs.into_iter().collect(),
+        }
+    }
 }
 
 /// An enum representing the different types of control nodes

--- a/interp/src/flatten/flat_ir/control/structures.rs
+++ b/interp/src/flatten/flat_ir/control/structures.rs
@@ -5,14 +5,21 @@ use crate::flatten::{
     structures::{index_trait::impl_index, indexed_map::IndexedMap},
 };
 
-impl_index!(pub ControlIdx);
+#[derive(Debug, Eq, Copy, Clone, PartialEq)]
+pub struct ControlIdx(u32);
+impl_index!(ControlIdx);
+
+/// A map storing [ControlNodes](ControlNode) indexed by [ControlIdx]
 pub type ControlMap = IndexedMap<ControlIdx, ControlNode>;
 
+/// A vector of control indices
 pub type CtrlVec = SmallVec<[ControlIdx; 4]>;
 
+/// An empty control node
 #[derive(Debug)]
 pub struct Empty;
 
+/// A group enable node
 #[derive(Debug)]
 pub struct Enable(GroupIdx);
 
@@ -26,6 +33,7 @@ impl Enable {
     }
 }
 
+/// Sequence of control nodes
 #[derive(Debug)]
 pub struct Seq(CtrlVec);
 
@@ -42,6 +50,7 @@ impl Seq {
     }
 }
 
+/// Parallel compositions of control nodes
 #[derive(Debug)]
 pub struct Par(CtrlVec);
 
@@ -58,6 +67,7 @@ impl Par {
     }
 }
 
+/// An if-then-else control node
 #[derive(Debug)]
 pub struct If {
     cond_port: PortRef,
@@ -98,6 +108,7 @@ impl If {
     }
 }
 
+/// A while loop control node
 #[derive(Debug)]
 pub struct While {
     cond_port: PortRef,
@@ -131,11 +142,13 @@ impl While {
     }
 }
 
+/// Invoke control node
 #[derive(Debug)]
 pub struct Invoke {
     // TODO: add invoke stuff
 }
 
+/// An enum representing the different types of control nodes
 #[derive(Debug)]
 pub enum ControlNode {
     Empty(Empty),

--- a/interp/src/flatten/flat_ir/control/translator.rs
+++ b/interp/src/flatten/flat_ir/control/translator.rs
@@ -7,8 +7,8 @@ use crate::{
             component::{AuxillaryComponentInfo, ComponentCore},
             flatten_trait::{flatten_tree, FlattenTree, SingleHandle},
             prelude::{
-                Assignment, AssignmentIdx, CombGroup, CombGroupIdx,
-                ComponentIdx, GroupIdx, GuardIdx, PortRef,
+                Assignment, AssignmentIdx, CellRef, CombGroup, CombGroupIdx,
+                ComponentIdx, GroupIdx, GuardIdx, Identifier, PortRef,
             },
             wires::{core::Group, guards::Guard},
         },
@@ -23,6 +23,7 @@ use crate::{
 use super::{structures::*, utils::CompTraversal};
 
 type PortMapper = HashMap<*const cir::Port, PortRef>;
+type CellMapper = HashMap<*const cir::Cell, CellRef>;
 type ComponentMapper = HashMap<cir::Id, ComponentIdx>;
 
 /// An ephemeral structure used during the translation of a component.
@@ -32,8 +33,8 @@ pub struct GroupMapper {
 }
 
 pub fn translate(orig_ctx: &cir::Context) -> Context {
-    let mut primary_ctx = InterpretationContext::new();
-    let mut secondary_ctx = SecondaryContext::new();
+    let mut ctx = Context::new();
+
     let mut component_id_map = ComponentMapper::new();
 
     // TODO (griffin)
@@ -43,34 +44,27 @@ pub fn translate(orig_ctx: &cir::Context) -> Context {
     for comp in CompTraversal::new(&orig_ctx.components).iter() {
         // TODO Griffin: capture the entry-point component and store that
         // somewhere in the context
-        let _ = translate_component(
-            comp,
-            &mut primary_ctx,
-            &mut secondary_ctx,
-            &mut component_id_map,
-        );
+        let _ = translate_component(comp, &mut ctx, &mut component_id_map);
     }
-
-    (primary_ctx, secondary_ctx).into()
+    ctx
 }
 
 #[must_use]
 fn translate_group(
     group: &cir::Group,
-    interp_ctx: &mut InterpretationContext,
-    secondary_ctx: &mut SecondaryContext,
+    ctx: &mut Context,
     map: &PortMapper,
 ) -> Group {
-    let id = secondary_ctx.string_table.insert(group.name());
-    let base = interp_ctx.assignments.peek_next_idx();
+    let id = ctx.secondary.string_table.insert(group.name());
+    let base = ctx.primary.assignments.peek_next_idx();
 
     for assign in group.assignments.iter() {
-        let assign_new = translate_assignment(assign, interp_ctx, map);
-        interp_ctx.assignments.push(assign_new);
+        let assign_new = translate_assignment(assign, &mut ctx.primary, map);
+        ctx.primary.assignments.push(assign_new);
     }
 
     let range: IndexRange<AssignmentIdx> =
-        IndexRange::new(base, interp_ctx.assignments.peek_next_idx());
+        IndexRange::new(base, ctx.primary.assignments.peek_next_idx());
 
     Group::new(
         id,
@@ -83,20 +77,19 @@ fn translate_group(
 #[must_use]
 fn translate_comb_group(
     comb_group: &cir::CombGroup,
-    interp_ctx: &mut InterpretationContext,
-    secondary_ctx: &mut SecondaryContext,
+    ctx: &mut Context,
     map: &PortMapper,
 ) -> CombGroup {
-    let identifier = secondary_ctx.string_table.insert(comb_group.name());
-    let base = interp_ctx.assignments.peek_next_idx();
+    let identifier = ctx.secondary.string_table.insert(comb_group.name());
+    let base = ctx.primary.assignments.peek_next_idx();
 
     for assign in comb_group.assignments.iter() {
-        let assign_new = translate_assignment(assign, interp_ctx, map);
-        interp_ctx.assignments.push(assign_new);
+        let assign_new = translate_assignment(assign, &mut ctx.primary, map);
+        ctx.primary.assignments.push(assign_new);
     }
 
     let range: IndexRange<AssignmentIdx> =
-        IndexRange::new(base, interp_ctx.assignments.peek_next_idx());
+        IndexRange::new(base, ctx.primary.assignments.peek_next_idx());
 
     CombGroup::new(identifier, range)
 }
@@ -125,18 +118,16 @@ fn translate_guard(
 #[must_use]
 fn translate_component(
     comp: &cir::Component,
-    interp_ctx: &mut InterpretationContext,
-    secondary_ctx: &mut SecondaryContext,
+    ctx: &mut Context,
     component_id_map: &mut ComponentMapper,
 ) -> ComponentIdx {
     let mut auxillary_component_info = AuxillaryComponentInfo::new_with_name(
-        secondary_ctx.string_table.insert(comp.name),
+        ctx.secondary.string_table.insert(comp.name),
     );
 
-    let port_map = compute_local_layout(
+    let layout = compute_local_layout(
         comp,
-        interp_ctx,
-        secondary_ctx,
+        ctx,
         &mut auxillary_component_info,
         component_id_map,
     );
@@ -144,36 +135,31 @@ fn translate_component(
     // Translate the groups
     let mut group_map = HashMap::with_capacity(comp.groups.len());
 
-    let group_base = interp_ctx.groups.peek_next_idx();
+    let group_base = ctx.primary.groups.peek_next_idx();
 
     for group in comp.groups.iter() {
         let group_brw = group.borrow();
-        let group_idx =
-            translate_group(&group_brw, interp_ctx, secondary_ctx, &port_map);
-        let k = interp_ctx.groups.push(group_idx);
+        let group_idx = translate_group(&group_brw, ctx, &layout.port_map);
+        let k = ctx.primary.groups.push(group_idx);
         group_map.insert(group.as_raw(), k);
     }
     auxillary_component_info
-        .set_group_range(group_base, interp_ctx.groups.peek_next_idx());
+        .set_group_range(group_base, ctx.primary.groups.peek_next_idx());
 
-    let comb_group_base = interp_ctx.comb_groups.peek_next_idx();
+    let comb_group_base = ctx.primary.comb_groups.peek_next_idx();
     // Translate comb groups
     let mut comb_group_map = HashMap::with_capacity(comp.comb_groups.len());
 
     for comb_grp in comp.comb_groups.iter() {
         let comb_grp_brw = comb_grp.borrow();
-        let comb_grp_idx = translate_comb_group(
-            &comb_grp_brw,
-            interp_ctx,
-            secondary_ctx,
-            &port_map,
-        );
-        let k = interp_ctx.comb_groups.push(comb_grp_idx);
+        let comb_grp_idx =
+            translate_comb_group(&comb_grp_brw, ctx, &layout.port_map);
+        let k = ctx.primary.comb_groups.push(comb_grp_idx);
         comb_group_map.insert(comb_grp.as_raw(), k);
     }
     auxillary_component_info.set_comb_group_range(
         comb_group_base,
-        interp_ctx.comb_groups.peek_next_idx(),
+        ctx.primary.comb_groups.peek_next_idx(),
     );
 
     let group_mapper = GroupMapper {
@@ -182,18 +168,29 @@ fn translate_component(
     };
 
     // Continuous Assignments
-    let cont_assignment_base = interp_ctx.assignments.peek_next_idx();
+    let cont_assignment_base = ctx.primary.assignments.peek_next_idx();
     for assign in &comp.continuous_assignments {
-        let assign_new = translate_assignment(assign, interp_ctx, &port_map);
-        interp_ctx.assignments.push(assign_new);
+        let assign_new =
+            translate_assignment(assign, &mut ctx.primary, &layout.port_map);
+        ctx.primary.assignments.push(assign_new);
     }
 
     let continuous_assignments = IndexRange::new(
         cont_assignment_base,
-        interp_ctx.assignments.peek_next_idx(),
+        ctx.primary.assignments.peek_next_idx(),
     );
 
     let ctrl_ref = comp.control.borrow();
+
+    // do some memory slight of hand to pass the owned version rather than a ref
+    // to the tuple
+    let mut taken_ctx = std::mem::take(ctx);
+    // control also must be taken since the flatten needs mutable access to it
+    // and this is not possible when it is inside the context
+    let mut taken_control = std::mem::take(&mut taken_ctx.primary.control);
+
+    let argument_tuple =
+        (group_mapper, layout, taken_ctx, auxillary_component_info);
 
     let control: Option<ControlIdx> =
         if matches!(*ctrl_ref, cir::Control::Empty(_)) {
@@ -202,11 +199,18 @@ fn translate_component(
             let ctrl_node = flatten_tree(
                 &*ctrl_ref,
                 None,
-                &mut interp_ctx.control,
-                &(group_mapper, port_map),
+                &mut taken_control,
+                &argument_tuple,
             );
             Some(ctrl_node)
         };
+
+    // unwrap all the stuff packed into the argument tuple
+    let (_, _layout, mut taken_ctx, auxillary_component_info) = argument_tuple;
+
+    // put stuff back
+    taken_ctx.primary.control = taken_control;
+    *ctx = taken_ctx;
 
     let comp_core = ComponentCore {
         control,
@@ -214,8 +218,8 @@ fn translate_component(
         is_comb: comp.is_comb,
     };
 
-    let ctrl_ref = interp_ctx.components.push(comp_core);
-    secondary_ctx
+    let ctrl_ref = ctx.primary.components.push(comp_core);
+    ctx.secondary
         .comp_aux_info
         .insert(ctrl_ref, auxillary_component_info);
 
@@ -248,7 +252,7 @@ fn insert_cell(
     secondary_ctx: &mut SecondaryContext,
     aux: &mut AuxillaryComponentInfo,
     cell: &RRC<cir::Cell>,
-    port_map: &mut PortMapper,
+    layout: &mut Layout,
     comp_id: ComponentIdx,
 ) {
     let cell_ref = cell.borrow();
@@ -257,7 +261,7 @@ fn insert_cell(
     if !cell_ref.is_reference() {
         let base = aux.port_offset_map.peek_next_index();
         for port in cell_ref.ports() {
-            port_map.insert(
+            layout.port_map.insert(
                 port.as_raw(),
                 insert_port(secondary_ctx, aux, port, ContainmentType::Local),
             );
@@ -265,39 +269,47 @@ fn insert_cell(
         let range =
             IndexRange::new(base, aux.port_offset_map.peek_next_index());
         let cell_def = secondary_ctx.push_local_cell(id, range, comp_id);
-        aux.cell_offset_map.insert(cell_def);
+        let cell_offset = aux.cell_offset_map.insert(cell_def);
+        layout.cell_map.insert(cell.as_raw(), cell_offset.into());
     }
     // CASE 2 - Reference Cell
     else {
         let base = aux.ref_port_offset_map.peek_next_index();
         for port in cell_ref.ports() {
-            port_map.insert(
+            layout.port_map.insert(
                 port.as_raw(),
                 insert_port(secondary_ctx, aux, port, ContainmentType::Ref),
             );
         }
+
         let range =
             IndexRange::new(base, aux.ref_port_offset_map.peek_next_index());
         let ref_cell_def = secondary_ctx.push_ref_cell(id, range, comp_id);
-        aux.ref_cell_offset_map.insert(ref_cell_def);
+        let cell_offset = aux.ref_cell_offset_map.insert(ref_cell_def);
+        layout.cell_map.insert(cell.as_raw(), cell_offset.into());
     }
+}
+
+#[derive(Debug, Default)]
+pub struct Layout {
+    port_map: PortMapper,
+    cell_map: CellMapper,
 }
 
 fn compute_local_layout(
     comp: &cir::Component,
-    ctx: &mut InterpretationContext,
-    secondary_ctx: &mut SecondaryContext,
+    ctx: &mut Context,
     aux: &mut AuxillaryComponentInfo,
     component_id_map: &ComponentMapper,
-) -> PortMapper {
-    let comp_id = ctx.components.peek_next_idx();
+) -> Layout {
+    let comp_id = ctx.primary.components.peek_next_idx();
 
-    let port_def_base = secondary_ctx.local_port_defs.peek_next_idx();
-    let ref_port_def_base = secondary_ctx.ref_port_defs.peek_next_idx();
-    let cell_def_base = secondary_ctx.local_cell_defs.peek_next_idx();
-    let ref_cell_def_base = secondary_ctx.ref_cell_defs.peek_next_idx();
+    let port_def_base = ctx.secondary.local_port_defs.peek_next_idx();
+    let ref_port_def_base = ctx.secondary.ref_port_defs.peek_next_idx();
+    let cell_def_base = ctx.secondary.local_cell_defs.peek_next_idx();
+    let ref_cell_def_base = ctx.secondary.ref_cell_defs.peek_next_idx();
 
-    let mut port_map = PortMapper::new();
+    let mut layout = Layout::default();
 
     // need this to set the appropriate signature range on the component
     let sig_base = aux.port_offset_map.peek_next_index();
@@ -305,8 +317,8 @@ fn compute_local_layout(
     // first, handle the signature ports
     for port in comp.signature.borrow().ports() {
         let local_offset =
-            insert_port(secondary_ctx, aux, port, ContainmentType::Local);
-        port_map.insert(port.as_raw(), local_offset);
+            insert_port(&mut ctx.secondary, aux, port, ContainmentType::Local);
+        layout.port_map.insert(port.as_raw(), local_offset);
     }
 
     // update the aux info with the signature layout
@@ -317,9 +329,13 @@ fn compute_local_layout(
     for group in &comp.groups {
         let group = group.borrow();
         for port in &group.holes {
-            let local_offset =
-                insert_port(secondary_ctx, aux, port, ContainmentType::Local);
-            port_map.insert(port.as_raw(), local_offset);
+            let local_offset = insert_port(
+                &mut ctx.secondary,
+                aux,
+                port,
+                ContainmentType::Local,
+            );
+            layout.port_map.insert(port.as_raw(), local_offset);
         }
     }
 
@@ -330,7 +346,7 @@ fn compute_local_layout(
         // this is silly
         // CASE 1 & 2 - local/ref cells
         if is_primitive(&cell.borrow()) {
-            insert_cell(secondary_ctx, aux, cell, &mut port_map, comp_id)
+            insert_cell(&mut ctx.secondary, aux, cell, &mut layout, comp_id)
         }
         // CASE 3 - Subcomponent
         else {
@@ -342,12 +358,12 @@ fn compute_local_layout(
     // fourth, the sub-components
     for cell in sub_component_queue {
         // insert the cells and ports
-        insert_cell(secondary_ctx, aux, cell, &mut port_map, comp_id);
+        insert_cell(&mut ctx.secondary, aux, cell, &mut layout, comp_id);
 
         // Advance the offsets to appropriately layout the next comp-cell
         let cell_ref = cell.borrow();
         if let cir::CellType::Component { name } = &cell_ref.prototype {
-            let aux_info = &secondary_ctx.comp_aux_info[component_id_map[name]];
+            let aux_info = &ctx.secondary.comp_aux_info[component_id_map[name]];
             let skips = if cell_ref.is_reference() {
                 aux_info.skip_sizes_for_ref()
             } else {
@@ -361,22 +377,22 @@ fn compute_local_layout(
 
     aux.set_port_range(
         port_def_base,
-        secondary_ctx.local_port_defs.peek_next_idx(),
+        ctx.secondary.local_port_defs.peek_next_idx(),
     );
     aux.set_ref_port_range(
         ref_port_def_base,
-        secondary_ctx.ref_port_defs.peek_next_idx(),
+        ctx.secondary.ref_port_defs.peek_next_idx(),
     );
     aux.set_cell_range(
         cell_def_base,
-        secondary_ctx.local_cell_defs.peek_next_idx(),
+        ctx.secondary.local_cell_defs.peek_next_idx(),
     );
     aux.set_ref_cell_range(
         ref_cell_def_base,
-        secondary_ctx.ref_cell_defs.peek_next_idx(),
+        ctx.secondary.ref_cell_defs.peek_next_idx(),
     );
 
-    port_map
+    layout
 }
 
 fn is_primitive(cell_ref: &std::cell::Ref<cir::Cell>) -> bool {
@@ -419,14 +435,14 @@ impl FlattenTree for cir::Control {
 
     type IdxType = ControlIdx;
 
-    type AuxillaryData = (GroupMapper, PortMapper);
+    type AuxillaryData = (GroupMapper, Layout, Context, AuxillaryComponentInfo);
 
     fn process_element<'data>(
         &'data self,
         mut handle: SingleHandle<'_, 'data, Self, Self::IdxType, Self::Output>,
         aux: &Self::AuxillaryData,
     ) -> Self::Output {
-        let (group_map, port_map) = aux;
+        let (group_map, layout, ctx, comp_info) = aux;
         match self {
             cir::Control::Seq(s) => ControlNode::Seq(Seq::new(
                 s.stmts.iter().map(|s| handle.enqueue(s)),
@@ -435,17 +451,94 @@ impl FlattenTree for cir::Control {
                 p.stmts.iter().map(|s| handle.enqueue(s)),
             )),
             cir::Control::If(i) => ControlNode::If(If::new(
-                port_map[&i.port.as_raw()],
+                layout.port_map[&i.port.as_raw()],
                 i.cond.as_ref().map(|c| group_map.comb_groups[&c.as_raw()]),
                 handle.enqueue(&i.tbranch),
                 handle.enqueue(&i.fbranch),
             )),
             cir::Control::While(w) => ControlNode::While(While::new(
-                port_map[&w.port.as_raw()],
+                layout.port_map[&w.port.as_raw()],
                 w.cond.as_ref().map(|c| group_map.comb_groups[&c.as_raw()]),
                 handle.enqueue(&w.body),
             )),
-            cir::Control::Invoke(_inv) => ControlNode::Invoke(Invoke {}),
+            cir::Control::Invoke(inv) => {
+                let invoked_cell = layout.cell_map[&inv.comp.as_raw()];
+
+                let resolve_id = |id: &cir::Id| {
+                    *ctx.secondary.string_table.lookup_id(id).unwrap()
+                };
+
+                let resolve_invoked_cell_port = |id: &cir::Id| -> PortRef {
+                    let id = resolve_id(id);
+
+                    match invoked_cell {
+                        CellRef::Local(l) => {
+                            let def_idx = comp_info.cell_offset_map[l];
+                            let cell_def = &ctx.secondary[def_idx];
+
+                            cell_def
+                                .ports()
+                                .into_iter()
+                                .find(|&candidate_offset| {
+                                    let candidate_def = comp_info
+                                        .port_offset_map[candidate_offset];
+                                    ctx.secondary[candidate_def] == id
+                                })
+                                .unwrap()
+                                .into()
+                        }
+                        CellRef::Ref(r) => {
+                            let def_idx = comp_info.ref_cell_offset_map[r];
+                            let cell_def = &ctx.secondary[def_idx];
+
+                            cell_def
+                                .ports()
+                                .into_iter()
+                                .find(|&candidate_offset| {
+                                    let candidate_def = comp_info
+                                        .ref_port_offset_map[candidate_offset];
+                                    ctx.secondary[candidate_def] == id
+                                })
+                                .unwrap()
+                                .into()
+                        }
+                    }
+                };
+
+                ControlNode::Invoke(Invoke::new(
+                    *invoked_cell
+                        .as_local()
+                        .expect("Invoke cell must be local at this moment"),
+                    inv.comb_group
+                        .as_ref()
+                        .map(|x| group_map.comb_groups[&x.as_raw()]),
+                    inv.ref_cells.iter().map(|(id, cell)| {
+                        let cell_name = resolve_id(id);
+                        let ref_cell_actual = layout.cell_map[&cell.as_raw()];
+
+
+                        todo!()
+
+                    }),
+                    inv.inputs.iter().map(|(id, port)| {
+                        // rust fmt doesn't like this for some reason. I don't
+                        // blame it
+                        (
+                         *resolve_invoked_cell_port(id).as_local().expect(
+                                "Invoke input port must be local at this moment",
+                            ),
+                        layout.port_map[&port.as_raw()],
+                        )
+                    }),
+                    inv.outputs.iter().map(|(id, port)| {
+                        (
+                         *resolve_invoked_cell_port(id).as_local().expect(
+                                "Invoke input port must be local at this moment",
+                            ),
+                        layout.port_map[&port.as_raw()],
+                        )}),
+                ))
+            }
             cir::Control::Enable(e) => ControlNode::Enable(Enable::new(
                 group_map.groups[&e.group.as_raw()],
             )),

--- a/interp/src/flatten/flat_ir/control/translator.rs
+++ b/interp/src/flatten/flat_ir/control/translator.rs
@@ -8,7 +8,7 @@ use crate::{
             flatten_trait::{flatten_tree, FlattenTree, SingleHandle},
             prelude::{
                 Assignment, AssignmentIdx, CombGroup, CombGroupIdx,
-                ComponentRef, GroupIdx, GuardIdx, PortRef,
+                ComponentIdx, GroupIdx, GuardIdx, PortRef,
             },
             wires::{core::Group, guards::Guard},
         },
@@ -23,7 +23,7 @@ use crate::{
 use super::{structures::*, utils::CompTraversal};
 
 type PortMapper = HashMap<*const cir::Port, PortRef>;
-type ComponentMapper = HashMap<cir::Id, ComponentRef>;
+type ComponentMapper = HashMap<cir::Id, ComponentIdx>;
 
 /// An ephemeral structure used during the translation of a component.
 pub struct GroupMapper {
@@ -128,7 +128,7 @@ fn translate_component(
     interp_ctx: &mut InterpretationContext,
     secondary_ctx: &mut SecondaryContext,
     component_id_map: &mut ComponentMapper,
-) -> ComponentRef {
+) -> ComponentIdx {
     let mut auxillary_component_info = AuxillaryComponentInfo::new_with_name(
         secondary_ctx.string_table.insert(comp.name),
     );
@@ -249,7 +249,7 @@ fn insert_cell(
     aux: &mut AuxillaryComponentInfo,
     cell: &RRC<cir::Cell>,
     port_map: &mut PortMapper,
-    comp_id: ComponentRef,
+    comp_id: ComponentIdx,
 ) {
     let cell_ref = cell.borrow();
     let id = secondary_ctx.string_table.insert(cell_ref.name());

--- a/interp/src/flatten/flat_ir/control/translator.rs
+++ b/interp/src/flatten/flat_ir/control/translator.rs
@@ -521,15 +521,11 @@ impl FlattenTree for cir::Control {
                         let def_idx = comp_info.cell_offset_map[local_off];
                         let cell_def = &ctx.secondary[def_idx].prototype;
                         cell_def
-                            .as_component()
-                            .expect("invoking a non-component with ref cells")
                     }
                     CellRef::Ref(ref_off) => {
                         let def_idx = comp_info.ref_cell_offset_map[ref_off];
                         let cell_def = &ctx.secondary[def_idx].prototype;
                         cell_def
-                            .as_component()
-                            .expect("invoking a non-component with ref cells")
                     }
                 };
 
@@ -575,6 +571,7 @@ impl FlattenTree for cir::Control {
                 };
 
                 let ref_cells = inv.ref_cells.iter().map(|(ref_cell_id, realizing_cell)| {
+                        let invoked_comp = invoked_comp.as_component().expect("cannot invoke a non-component with ref cells");
                         let target = &ctx.secondary[*invoked_comp].ref_cell_offset_map.iter().find(|(&_idx, &def_idx)| {
                             let def = &ctx.secondary[def_idx];
                             def.name == resolve_id(ref_cell_id)
@@ -597,9 +594,7 @@ impl FlattenTree for cir::Control {
                 });
 
                 ControlNode::Invoke(Invoke::new(
-                    *invoked_cell
-                        .as_local()
-                        .expect("Invoke cell must be local at this moment"),
+                    invoked_cell,
                     inv.comb_group
                         .as_ref()
                         .map(|x| group_map.comb_groups[&x.as_raw()]),

--- a/interp/src/flatten/flat_ir/control/translator.rs
+++ b/interp/src/flatten/flat_ir/control/translator.rs
@@ -9,7 +9,7 @@ use crate::{
             flatten_trait::{flatten_tree, FlattenTree, SingleHandle},
             prelude::{
                 Assignment, AssignmentIdx, CellRef, CombGroup, CombGroupIdx,
-                ComponentIdx, GroupIdx, GuardIdx, Identifier, PortRef,
+                ComponentIdx, GroupIdx, GuardIdx, PortRef,
             },
             wires::{core::Group, guards::Guard},
         },
@@ -519,13 +519,13 @@ impl FlattenTree for cir::Control {
                 let invoked_comp = match invoked_cell {
                     CellRef::Local(local_off) => {
                         let def_idx = comp_info.cell_offset_map[local_off];
-                        let cell_def = &ctx.secondary[def_idx].prototype;
-                        cell_def
+
+                        &ctx.secondary[def_idx].prototype
                     }
                     CellRef::Ref(ref_off) => {
                         let def_idx = comp_info.ref_cell_offset_map[ref_off];
-                        let cell_def = &ctx.secondary[def_idx].prototype;
-                        cell_def
+
+                        &ctx.secondary[def_idx].prototype
                     }
                 };
 

--- a/interp/src/flatten/flat_ir/identifier.rs
+++ b/interp/src/flatten/flat_ir/identifier.rs
@@ -92,12 +92,10 @@ impl CanonicalIdentifier {
         }
     }
 
-    pub fn name(&self) -> Identifier {
+    pub fn name(&self) -> Option<&Identifier> {
         match self {
-            CanonicalIdentifier::Standard { name, .. } => *name,
-            CanonicalIdentifier::Literal { .. } => {
-                panic!("Cannot get name of literal")
-            }
+            CanonicalIdentifier::Standard { name, .. } => name.into(),
+            CanonicalIdentifier::Literal { .. } => None,
         }
     }
 }

--- a/interp/src/flatten/flat_ir/identifier.rs
+++ b/interp/src/flatten/flat_ir/identifier.rs
@@ -94,12 +94,8 @@ impl CanonicalIdentifier {
 
     pub fn name(&self) -> Identifier {
         match self {
-            CanonicalIdentifier::Standard {
-                parent,
-                name,
-                name_type,
-            } => *name,
-            CanonicalIdentifier::Literal { width, val } => {
+            CanonicalIdentifier::Standard { name, .. } => *name,
+            CanonicalIdentifier::Literal { .. } => {
                 panic!("Cannot get name of literal")
             }
         }

--- a/interp/src/flatten/flat_ir/identifier.rs
+++ b/interp/src/flatten/flat_ir/identifier.rs
@@ -72,6 +72,10 @@ impl CanonicalIdentifier {
             NameType::Cell => format!("{}.{}", parent, port),
         }
     }
+
+    pub fn name(&self) -> Identifier {
+        self.name
+    }
 }
 
 /// A map used to store strings and assign them unique identifiers. This is

--- a/interp/src/flatten/flat_ir/identifier.rs
+++ b/interp/src/flatten/flat_ir/identifier.rs
@@ -3,7 +3,10 @@ use std::hash::Hash;
 
 use crate::flatten::structures::index_trait::{impl_index, IndexRef};
 
-impl_index!(pub Identifier);
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct Identifier(u32);
+
+impl_index!(Identifier);
 
 impl Identifier {
     #[inline]
@@ -11,11 +14,21 @@ impl Identifier {
         // manually construct
         Identifier(0)
     }
+
+    /// Utility method to resolve the string associated with an identifier
+    pub fn resolve<'a>(&self, resolver: &'a IdMap) -> &'a String {
+        resolver.lookup_string(self).unwrap()
+    }
 }
 
+/// Internal enum to distinguish between the different parents for a port. Used
+/// to format names appropriately
 enum NameType {
+    /// This is one of the component ports
     Interface,
+    /// This port belongs to a group (go/done)
     Group,
+    /// The standard port on a cell
     Cell,
 }
 
@@ -73,8 +86,10 @@ impl CanonicalIdentifier {
 /// issue
 #[derive(Debug)]
 pub struct IdMap {
+    /// The forward map hashes strings to identifiers
     forward: HashMap<String, Identifier>,
-    // Identifiers are handed out linearly so this is a simple vector
+    /// Since identifiers are handed out linearly the backwards map is a vector
+    /// of strings
     backward: Vec<String>,
 }
 

--- a/interp/src/flatten/flat_ir/mod.rs
+++ b/interp/src/flatten/flat_ir/mod.rs
@@ -1,5 +1,6 @@
 pub mod attributes;
 pub mod base;
+pub mod cell_prototype;
 pub mod component;
 pub mod control;
 pub mod flatten_trait;

--- a/interp/src/flatten/structures/context.rs
+++ b/interp/src/flatten/structures/context.rs
@@ -5,7 +5,7 @@ use crate::flatten::flat_ir::{
     identifier::IdMap,
     prelude::{
         Assignment, AssignmentIdx, CellDefinitionIdx, CellInfo, CombGroup,
-        CombGroupIdx, CombGroupMap, ComponentRef, ControlIdx, ControlMap,
+        CombGroupIdx, CombGroupMap, ComponentIdx, ControlIdx, ControlMap,
         ControlNode, Group, GroupIdx, GuardIdx, Identifier, LocalPortOffset,
         LocalRefPortOffset, ParentIdx, PortDefinitionIdx, PortDefinitionRef,
         PortRef, RefCellDefinitionIdx, RefCellInfo, RefPortDefinitionIdx,
@@ -57,10 +57,10 @@ pub struct InterpretationContext {
     pub control: ControlMap,
 }
 
-impl Index<ComponentRef> for InterpretationContext {
+impl Index<ComponentIdx> for InterpretationContext {
     type Output = ComponentCore;
 
-    fn index(&self, index: ComponentRef) -> &Self::Output {
+    fn index(&self, index: ComponentIdx) -> &Self::Output {
         &self.components[index]
     }
 }
@@ -126,7 +126,7 @@ pub struct SecondaryContext {
     /// ref-cell definitions
     pub ref_cell_defs: IndexedMap<RefCellDefinitionIdx, RefCellInfo>,
     /// auxillary information for components
-    pub comp_aux_info: AuxillaryMap<ComponentRef, AuxillaryComponentInfo>,
+    pub comp_aux_info: AuxillaryMap<ComponentIdx, AuxillaryComponentInfo>,
 }
 
 impl Index<Identifier> for SecondaryContext {
@@ -169,10 +169,10 @@ impl Index<RefCellDefinitionIdx> for SecondaryContext {
     }
 }
 
-impl Index<ComponentRef> for SecondaryContext {
+impl Index<ComponentIdx> for SecondaryContext {
     type Output = AuxillaryComponentInfo;
 
-    fn index(&self, index: ComponentRef) -> &Self::Output {
+    fn index(&self, index: ComponentIdx) -> &Self::Output {
         &self.comp_aux_info[index]
     }
 }
@@ -194,7 +194,7 @@ impl SecondaryContext {
         &mut self,
         name: Identifier,
         ports: IndexRange<LocalPortOffset>,
-        parent: ComponentRef,
+        parent: ComponentIdx,
     ) -> CellDefinitionIdx {
         self.local_cell_defs
             .push(CellInfo::new(name, ports, parent))
@@ -204,7 +204,7 @@ impl SecondaryContext {
         &mut self,
         name: Identifier,
         ports: IndexRange<LocalRefPortOffset>,
-        parent: ComponentRef,
+        parent: ComponentIdx,
     ) -> RefCellDefinitionIdx {
         self.ref_cell_defs
             .push(RefCellInfo::new(name, ports, parent))
@@ -240,7 +240,7 @@ impl Context {
     #[inline]
     pub(crate) fn lookup_port_definition(
         &self,
-        comp: ComponentRef,
+        comp: ComponentIdx,
         target: PortRef,
     ) -> PortDefinitionRef {
         match target {
@@ -257,7 +257,7 @@ impl Context {
     /// TODO Griffin: if relevant, replace with something more efficient.
     pub(crate) fn find_parent_cell(
         &self,
-        comp: ComponentRef,
+        comp: ComponentIdx,
         target: PortRef,
     ) -> ParentIdx {
         match target {

--- a/interp/src/flatten/structures/context.rs
+++ b/interp/src/flatten/structures/context.rs
@@ -23,7 +23,7 @@ use super::{
 };
 
 /// The full immutable program context for the interpreter.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Context {
     /// Simulation relevant context
     pub primary: InterpretationContext,
@@ -225,6 +225,10 @@ impl Default for SecondaryContext {
 }
 
 impl Context {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
     #[inline]
     pub fn resolve_id(&self, id: Identifier) -> &String {
         self.secondary.string_table.lookup_string(&id).unwrap()

--- a/interp/src/flatten/structures/context.rs
+++ b/interp/src/flatten/structures/context.rs
@@ -1,6 +1,7 @@
 use std::ops::Index;
 
 use crate::flatten::flat_ir::{
+    cell_prototype::CellPrototype,
     component::{AuxillaryComponentInfo, ComponentCore, ComponentMap},
     identifier::IdMap,
     prelude::{
@@ -195,9 +196,10 @@ impl SecondaryContext {
         name: Identifier,
         ports: IndexRange<LocalPortOffset>,
         parent: ComponentIdx,
+        prototype: CellPrototype,
     ) -> CellDefinitionIdx {
         self.local_cell_defs
-            .push(CellInfo::new(name, ports, parent))
+            .push(CellInfo::new(name, ports, parent, prototype))
     }
 
     pub fn push_ref_cell(
@@ -205,9 +207,10 @@ impl SecondaryContext {
         name: Identifier,
         ports: IndexRange<LocalRefPortOffset>,
         parent: ComponentIdx,
+        prototype: CellPrototype,
     ) -> RefCellDefinitionIdx {
         self.ref_cell_defs
-            .push(RefCellInfo::new(name, ports, parent))
+            .push(RefCellInfo::new(name, ports, parent, prototype))
     }
 }
 
@@ -275,7 +278,7 @@ impl Context {
                     .cells()
                     .iter()
                     .find(|c| self.secondary[*c]
-                        .ports().contains(l));
+                        .ports.contains(l));
 
                     if let Some(p) = port {
                         p.into()
@@ -294,7 +297,7 @@ impl Context {
                 .definitions
                 .ref_cells()
                 .iter()
-                .find(|c| self.secondary[*c].ports().contains(r))
+                .find(|c| self.secondary[*c].ports.contains(r))
                 .expect("Port does not belong to any ref cell in the given component").into()
             },
         }

--- a/interp/src/flatten/structures/environment.rs
+++ b/interp/src/flatten/structures/environment.rs
@@ -2,7 +2,7 @@ use super::indexed_map::IndexedMap;
 use crate::{
     flatten::{
         flat_ir::{
-            base::{ComponentRef, GlobalCellId, GlobalPortId, GlobalRefCellId},
+            base::{ComponentIdx, GlobalCellId, GlobalPortId, GlobalRefCellId},
             prelude::Identifier,
         },
         primitives::Primitive,
@@ -23,7 +23,7 @@ pub(crate) enum CellLedger {
     Component {
         name: Identifier,
         port_base_offset: GlobalPortId,
-        comp_id: ComponentRef,
+        comp_id: ComponentIdx,
     },
 }
 

--- a/interp/src/flatten/structures/index_trait.rs
+++ b/interp/src/flatten/structures/index_trait.rs
@@ -9,15 +9,14 @@ pub trait IndexRef: Copy + Eq {
 /// a [`u32`](std::u32) as the backing type. However, if a different backing type
 /// is desired, it can be specified as the second argument.
 macro_rules! impl_index {
-    ($v: vis $struct_name: ident) => {
-        impl_index!($v $struct_name, u32);
+    ($struct_name: ident) => {
+        impl_index!($struct_name, u32);
     };
 
-    ( $v:vis $struct_name: ident, $backing_ty: ty) => {
-        #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
-        $v struct $struct_name($backing_ty);
-
-        impl $crate::flatten::structures::index_trait::IndexRef for $struct_name {
+    ($struct_name: ident, $backing_ty: ty) => {
+        impl $crate::flatten::structures::index_trait::IndexRef
+            for $struct_name
+        {
             fn index(&self) -> usize {
                 self.0 as usize
             }
@@ -46,36 +45,35 @@ macro_rules! impl_index {
 /// different backing type is desired, it can be specified as the second
 /// argument to the macro.
 macro_rules! impl_index_nonzero {
-
     // Cool and normal stuff here
-
-    ($v: vis $struct_name: ident) => {
-        impl_index_nonzero!($v $struct_name, std::num::NonZeroU32, u32);
+    ($struct_name: ident) => {
+        impl_index_nonzero!($struct_name, std::num::NonZeroU32, u32);
     };
 
-    ($v: vis $struct_name: ident, NonZeroU8) => {
-        impl_index_nonzero!($v $struct_name, std::num::NonZeroU8, u8);
+    ($struct_name: ident, NonZeroU8) => {
+        impl_index_nonzero!($struct_name, std::num::NonZeroU8, u8);
     };
 
-    ($v: vis $struct_name: ident, NonZeroU16) => {
-        impl_index_nonzero!($v $struct_name, std::num::NonZeroU16, u16);
+    ($struct_name: ident, NonZeroU16) => {
+        impl_index_nonzero!($struct_name, std::num::NonZeroU16, u16);
     };
 
-    ($v: vis $struct_name: ident, NonZeroU32) => {
-        impl_index_nonzero!($v $struct_name, std::num::NonZeroU32, u32);
+    ($struct_name: ident, NonZeroU32) => {
+        impl_index_nonzero!($struct_name, std::num::NonZeroU32, u32);
     };
 
-    ( $v:vis $struct_name: ident, $non_zero_type:ty, $normal_type:ty) => {
-        #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
-        $v struct $struct_name($non_zero_type);
-
-        impl $crate::flatten::structures::index_trait::IndexRef for $struct_name {
+    ($struct_name: ident, $non_zero_type:ty, $normal_type:ty) => {
+        impl $crate::flatten::structures::index_trait::IndexRef
+            for $struct_name
+        {
             fn index(&self) -> usize {
                 self.0.get() as usize - 1
             }
 
             fn new(input: usize) -> Self {
-                Self(<$non_zero_type>::new((input + 1) as $normal_type).unwrap())
+                Self(
+                    <$non_zero_type>::new((input + 1) as $normal_type).unwrap(),
+                )
             }
         }
 

--- a/interp/src/flatten/structures/printer.rs
+++ b/interp/src/flatten/structures/printer.rs
@@ -107,9 +107,9 @@ impl<'a> Printer<'a> {
 
         match (port, parent) {
             (PortDefinitionRef::Local(l), ParentIdx::Component(c)) => CanonicalIdentifier::interface_port( self.ctx.secondary[c].name, self.ctx.secondary[l]),
-            (PortDefinitionRef::Local(l), ParentIdx::Cell(c)) => CanonicalIdentifier::cell_port( self.ctx.secondary[c].name(), self.ctx.secondary[l]),
+            (PortDefinitionRef::Local(l), ParentIdx::Cell(c)) => CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l]),
             (PortDefinitionRef::Local(l), ParentIdx::Group(g)) => CanonicalIdentifier::group_port( self.ctx.primary[g].name(), self.ctx.secondary[l]),
-            (PortDefinitionRef::Ref(rp), ParentIdx::RefCell(rc)) => CanonicalIdentifier::cell_port( self.ctx.secondary[rc].name(), self.ctx.secondary[rp]),
+            (PortDefinitionRef::Ref(rp), ParentIdx::RefCell(rc)) => CanonicalIdentifier::cell_port( self.ctx.secondary[rc].name, self.ctx.secondary[rp]),
             _ => unreachable!("Inconsistent port definition and parent. This should never happen"),
         }
     }

--- a/interp/src/flatten/structures/printer.rs
+++ b/interp/src/flatten/structures/printer.rs
@@ -149,16 +149,12 @@ impl<'a> Printer<'a> {
         match (port, parent) {
             (PortDefinitionRef::Local(l), ParentIdx::Component(c)) => CanonicalIdentifier::interface_port( self.ctx.secondary[c].name, self.ctx.secondary[l]),
             (PortDefinitionRef::Local(l), ParentIdx::Cell(c)) => {
-
-
                 if let CellPrototype::ConstantLiteral { value, width }= &self.ctx.secondary[c].prototype {
                     CanonicalIdentifier::literal(*width, *value)
                 } else {
-CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l])
+                    CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l])
                 }
-
-
-                },
+            },
             (PortDefinitionRef::Local(l), ParentIdx::Group(g)) => CanonicalIdentifier::group_port( self.ctx.primary[g].name(), self.ctx.secondary[l]),
             (PortDefinitionRef::Ref(rp), ParentIdx::RefCell(rc)) => CanonicalIdentifier::cell_port( self.ctx.secondary[rc].name, self.ctx.secondary[rp]),
             _ => unreachable!("Inconsistent port definition and parent. This should never happen"),

--- a/interp/src/flatten/structures/printer.rs
+++ b/interp/src/flatten/structures/printer.rs
@@ -1,6 +1,7 @@
 use calyx_ir::PortComp;
 
 use crate::flatten::flat_ir::{
+    cell_prototype::CellPrototype,
     identifier::{CanonicalIdentifier, IdMap},
     wires::guards::Guard,
 };
@@ -8,6 +9,8 @@ use crate::flatten::flat_ir::{
 use super::super::flat_ir::prelude::*;
 use super::super::text_utils;
 use super::context::Context;
+
+use std::fmt::Write;
 
 pub struct Printer<'a> {
     ctx: &'a Context,
@@ -93,6 +96,44 @@ impl<'a> Printer<'a> {
         for idx in self.ctx.primary.components.keys() {
             self.print_component(idx);
             println!()
+        }
+    }
+
+    fn lookup_cell_prototype(
+        &self,
+        parent: ComponentIdx,
+        cell: CellRef,
+    ) -> &CellPrototype {
+        match cell {
+            CellRef::Local(l) => {
+                &self.ctx.secondary
+                    [self.ctx.secondary[parent].cell_offset_map[l]]
+                    .prototype
+            }
+            CellRef::Ref(r) => {
+                &self.ctx.secondary
+                    [self.ctx.secondary[parent].ref_cell_offset_map[r]]
+                    .prototype
+            }
+        }
+    }
+
+    fn lookup_cell_id(
+        &self,
+        parent: ComponentIdx,
+        cell: CellRef,
+    ) -> Identifier {
+        match cell {
+            CellRef::Local(l) => {
+                self.ctx.secondary
+                    [self.ctx.secondary[parent].cell_offset_map[l]]
+                    .name
+            }
+            CellRef::Ref(r) => {
+                self.ctx.secondary
+                    [self.ctx.secondary[parent].ref_cell_offset_map[r]]
+                    .name
+            }
         }
     }
 
@@ -199,10 +240,93 @@ impl<'a> Printer<'a> {
 
                 out
             }
-            ControlNode::Invoke(_) => {
-                text_utils::indent("<<<<INVOKE PLACEHOLDER>>>>", indent)
+            ControlNode::Invoke(i) => {
+                let invoked_name =
+                    &self.ctx.secondary[self.lookup_cell_id(parent, i.cell)];
+
+                let mut out = format!("invoke {invoked_name}");
+
+                if !i.ref_cells.is_empty() {
+                    let ref_cells = self.format_invoke_ref_cell_list(i, parent);
+                    out += &format!("[{}]", ref_cells);
+                }
+                let inputs = self.format_invoke_port_lists(&i.inputs, parent);
+                let outputs = self.format_invoke_port_lists(&i.outputs, parent);
+
+                out += &format!("({inputs})({outputs})");
+
+                if let Some(grp) = i.comb_group {
+                    out += &format!(
+                        " with {}",
+                        self.ctx.secondary[self.ctx.primary[grp].name()]
+                    );
+                }
+
+                out += ";";
+
+                text_utils::indent(out, indent)
             }
         }
+    }
+
+    fn format_invoke_port_lists(
+        &self,
+        ports: &[(PortRef, PortRef)],
+        parent: ComponentIdx,
+    ) -> String {
+        let mut out = String::new();
+        for (dst, src) in ports {
+            let dst = self.lookup_id_from_port(parent, *dst).name();
+            let src = self.lookup_id_from_port(parent, *src);
+            write!(
+                out,
+                "{} = {}, ",
+                self.ctx.secondary[dst],
+                src.format_name(self.string_table())
+            )
+            .unwrap();
+        }
+        // remove trailing ", "
+        if out.ends_with(", ") {
+            out.pop();
+            out.pop();
+        }
+
+        out
+    }
+
+    fn format_invoke_ref_cell_list(
+        &self,
+        invoke: &Invoke,
+        parent: ComponentIdx,
+    ) -> String {
+        let mut out = String::new();
+        let invoked_cell = self
+            .lookup_cell_prototype(parent, invoke.cell)
+            .as_component()
+            .expect("invoked a non-component with ref cells");
+
+        let invoked_comp_info = &self.ctx.secondary[*invoked_cell];
+
+        for (dst, src) in &invoke.ref_cells {
+            let src = self.lookup_cell_id(parent, *src);
+
+            let dst = invoked_comp_info.ref_cell_offset_map[*dst];
+            let dst = self.ctx.secondary[dst].name;
+
+            let src = &self.ctx.secondary[src];
+            let dst = &self.ctx.secondary[dst];
+
+            write!(out, "{dst} = {src}").unwrap();
+        }
+
+        // remove trailing ", "
+        if out.ends_with(", ") {
+            out.pop();
+            out.pop();
+        }
+
+        out
     }
 
     pub fn format_guard(

--- a/interp/src/flatten/structures/printer.rs
+++ b/interp/src/flatten/structures/printer.rs
@@ -286,7 +286,7 @@ CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l
     ) -> String {
         let mut out = String::new();
         for (dst, src) in ports {
-            let dst = self.lookup_id_from_port(parent, *dst).name();
+            let dst = *self.lookup_id_from_port(parent, *dst).name().expect("destination for a ref cell is a literal. This should never happen");
             let src = self.lookup_id_from_port(parent, *src);
             write!(
                 out,

--- a/interp/src/flatten/structures/printer.rs
+++ b/interp/src/flatten/structures/printer.rs
@@ -327,7 +327,7 @@ CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l
             let src = &self.ctx.secondary[src];
             let dst = &self.ctx.secondary[dst];
 
-            write!(out, "{dst}={src}").unwrap();
+            write!(out, "{dst}={src}, ").unwrap();
         }
 
         // remove trailing ", "

--- a/interp/src/flatten/structures/printer.rs
+++ b/interp/src/flatten/structures/printer.rs
@@ -23,7 +23,7 @@ impl<'a> Printer<'a> {
         &self.ctx.secondary.string_table
     }
 
-    pub fn print_group(&self, group: GroupIdx, parent: ComponentRef) {
+    pub fn print_group(&self, group: GroupIdx, parent: ComponentIdx) {
         println!(
             "{}",
             text_utils::indent(
@@ -42,7 +42,7 @@ impl<'a> Printer<'a> {
         }
     }
 
-    pub fn print_comb_group(&self, group: CombGroupIdx, parent: ComponentRef) {
+    pub fn print_comb_group(&self, group: CombGroupIdx, parent: ComponentIdx) {
         println!(
             "{}",
             text_utils::indent(
@@ -61,7 +61,7 @@ impl<'a> Printer<'a> {
         }
     }
 
-    pub fn print_component(&self, idx: ComponentRef) {
+    pub fn print_component(&self, idx: ComponentIdx) {
         println!(
             "Component: {}",
             self.ctx.resolve_id(self.ctx.secondary[idx].name)
@@ -99,7 +99,7 @@ impl<'a> Printer<'a> {
     #[inline]
     pub fn lookup_id_from_port(
         &self,
-        comp: ComponentRef,
+        comp: ComponentIdx,
         target: PortRef,
     ) -> CanonicalIdentifier {
         let port = self.ctx.lookup_port_definition(comp, target);
@@ -116,7 +116,7 @@ impl<'a> Printer<'a> {
 
     pub fn format_control(
         &self,
-        parent: ComponentRef,
+        parent: ComponentIdx,
         control: ControlIdx,
         indent: usize,
     ) -> String {
@@ -207,7 +207,7 @@ impl<'a> Printer<'a> {
 
     pub fn format_guard(
         &self,
-        parent: ComponentRef,
+        parent: ComponentIdx,
         guard: GuardIdx,
     ) -> String {
         fn op_to_str(op: &PortComp) -> String {
@@ -256,7 +256,7 @@ impl<'a> Printer<'a> {
 
     pub fn print_assignment(
         &self,
-        parent_comp: ComponentRef,
+        parent_comp: ComponentIdx,
         target: AssignmentIdx,
     ) -> String {
         let assign = &self.ctx.primary.assignments[target];

--- a/interp/src/flatten/structures/printer.rs
+++ b/interp/src/flatten/structures/printer.rs
@@ -148,7 +148,17 @@ impl<'a> Printer<'a> {
 
         match (port, parent) {
             (PortDefinitionRef::Local(l), ParentIdx::Component(c)) => CanonicalIdentifier::interface_port( self.ctx.secondary[c].name, self.ctx.secondary[l]),
-            (PortDefinitionRef::Local(l), ParentIdx::Cell(c)) => CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l]),
+            (PortDefinitionRef::Local(l), ParentIdx::Cell(c)) => {
+
+
+                if let CellPrototype::ConstantLiteral { value, width }= &self.ctx.secondary[c].prototype {
+                    CanonicalIdentifier::literal(*width, *value)
+                } else {
+CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l])
+                }
+
+
+                },
             (PortDefinitionRef::Local(l), ParentIdx::Group(g)) => CanonicalIdentifier::group_port( self.ctx.primary[g].name(), self.ctx.secondary[l]),
             (PortDefinitionRef::Ref(rp), ParentIdx::RefCell(rc)) => CanonicalIdentifier::cell_port( self.ctx.secondary[rc].name, self.ctx.secondary[rp]),
             _ => unreachable!("Inconsistent port definition and parent. This should never happen"),
@@ -280,7 +290,7 @@ impl<'a> Printer<'a> {
             let src = self.lookup_id_from_port(parent, *src);
             write!(
                 out,
-                "{} = {}, ",
+                "{}={}, ",
                 self.ctx.secondary[dst],
                 src.format_name(self.string_table())
             )
@@ -317,7 +327,7 @@ impl<'a> Printer<'a> {
             let src = &self.ctx.secondary[src];
             let dst = &self.ctx.secondary[dst];
 
-            write!(out, "{dst} = {src}").unwrap();
+            write!(out, "{dst}={src}").unwrap();
         }
 
         // remove trailing ", "
@@ -394,7 +404,7 @@ impl<'a> Printer<'a> {
         };
 
         format!(
-            "{} = {}{}",
+            "{} = {}{};",
             dst.format_name(self.string_table()),
             guard,
             src.format_name(self.string_table())

--- a/interp/src/flatten/structures/sparse_map.rs
+++ b/interp/src/flatten/structures/sparse_map.rs
@@ -82,4 +82,16 @@ where
     pub fn count(&self) -> usize {
         self.count
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &D)> {
+        self.data.iter()
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.data.keys()
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &D> {
+        self.data.values()
+    }
 }


### PR DESCRIPTION
This was supposed to be a nice little change to add some documentation and invoke to the flat ir. That latter point proved more complicated than I would've liked.

The flat ir now flattens `invoke`s alongside everything else and can pretty print them (including ref cells). Also took the time to make the pretty printer process constant literals properly, rather than printing the `out` port of the generated constant cell.

The `impl_index` macro works a bit differently now to make it easier to add docstrings