### PR TITLE
Updates to emacs syntax highlighting instructions

### DIFF
--- a/docs/tools/editor-highlighting.md
+++ b/docs/tools/editor-highlighting.md
@@ -28,14 +28,15 @@ M-x package-install RET highlight-numbers RET
 ```
 
 Clone the repository, add the above path to your [load path][], and require
-`futil-mode`.
-If you use [Spacemacs][], this looks like adding the following lines to
-`dotspacemacs/user-config` in your `.spacemacs` file:
+`futil-mode` in your `.emacs` file:
 ```elisp
 (push "~/.emacs.d/private/local/futil-mode" load-path)
 (require 'futil-mode)
 ```
-I imagine it looks very similar for pure emacs, but haven't actually tried it myself.
+
+If you use [Spacemacs][], you would add this to `dotspacemacs/user-config`
+in your `.spacemacs`.
+
 
 ## Visual Studio Code
 

--- a/docs/tools/editor-highlighting.md
+++ b/docs/tools/editor-highlighting.md
@@ -32,8 +32,8 @@ Clone the repository, add the above path to your [load path][], and require
 If you use [Spacemacs][], this looks like adding the following lines to
 `dotspacemacs/user-config` in your `.spacemacs` file:
 ```elisp
-(push "~/.emacs.d/private/local/fuse-mode" load-path)
-(require 'fuse-mode)
+(push "~/.emacs.d/private/local/futil-mode" load-path)
+(require 'futil-mode)
 ```
 I imagine it looks very similar for pure emacs, but haven't actually tried it myself.
 

--- a/docs/tools/editor-highlighting.md
+++ b/docs/tools/editor-highlighting.md
@@ -22,6 +22,11 @@ And run:
 `futil-mode` is implements highlighting for `.futil` files in emacs.
 It is located in `<repo>/tools/emacs/futil-mode`.
 
+The `highlight-numbers` package is required as part of `futil-mode`, install it:
+```
+M-x package-install RET highlight-numbers RET
+```
+
 Clone the repository, add the above path to your [load path][], and require
 `futil-mode`.
 If you use [Spacemacs][], this looks like adding the following lines to


### PR DESCRIPTION
- `fuse-mode` is no longer the name for `futil-mode`
- Pure emacs doesn't have `highlight-mode`, list as prerequisite
- Clarification between pure & space emacs