### PR TITLE
[cider/flat] Instantiate the beginning flat environment

### DIFF
--- a/interp/src/flatten/flat_ir/base.rs
+++ b/interp/src/flatten/flat_ir/base.rs
@@ -10,7 +10,7 @@ use super::{cell_prototype::CellPrototype, prelude::Identifier};
 // second arg to contract or expand as needed
 
 /// The identifier for a component definition
-#[derive(Debug, Eq, Copy, Clone, PartialEq)]
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash)]
 pub struct ComponentIdx(u32);
 impl_index!(ComponentIdx);
 

--- a/interp/src/flatten/flat_ir/base.rs
+++ b/interp/src/flatten/flat_ir/base.rs
@@ -292,12 +292,12 @@ mod sealed {
     impl PortType for LocalRefPortOffset {}
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BaseIndices {
-    port_base: GlobalPortId,
-    cell_base: GlobalCellId,
-    ref_cell_base: GlobalRefCellId,
-    ref_port_base: GlobalRefPortId,
+    pub port_base: GlobalPortId,
+    pub cell_base: GlobalCellId,
+    pub ref_cell_base: GlobalRefCellId,
+    pub ref_port_base: GlobalRefPortId,
 }
 
 impl BaseIndices {

--- a/interp/src/flatten/flat_ir/base.rs
+++ b/interp/src/flatten/flat_ir/base.rs
@@ -1,7 +1,7 @@
-use std::num::NonZeroU32;
+use std::{num::NonZeroU32, ops::Add};
 
 use crate::flatten::structures::index_trait::{
-    impl_index, impl_index_nonzero, IndexRange,
+    impl_index, impl_index_nonzero, IndexRange, IndexRef,
 };
 
 use super::{cell_prototype::CellPrototype, prelude::Identifier};
@@ -50,6 +50,11 @@ impl_index!(GlobalCellId);
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
 pub struct GlobalRefCellId(u32);
 impl_index!(GlobalRefCellId);
+
+/// The index of a ref port instance in the global value map
+#[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
+pub struct GlobalRefPortId(u32);
+impl_index!(GlobalRefPortId);
 
 // Offset indices
 
@@ -285,4 +290,92 @@ mod sealed {
 
     impl PortType for LocalPortOffset {}
     impl PortType for LocalRefPortOffset {}
+}
+
+#[derive(Debug)]
+pub struct BaseIndices {
+    port_base: GlobalPortId,
+    cell_base: GlobalCellId,
+    ref_cell_base: GlobalRefCellId,
+    ref_port_base: GlobalRefPortId,
+}
+
+impl BaseIndices {
+    pub fn new(
+        port_base: GlobalPortId,
+        cell_base: GlobalCellId,
+        ref_cell_base: GlobalRefCellId,
+        ref_port_base: GlobalRefPortId,
+    ) -> Self {
+        Self {
+            port_base,
+            cell_base,
+            ref_cell_base,
+            ref_port_base,
+        }
+    }
+}
+
+impl Add<LocalPortOffset> for &BaseIndices {
+    type Output = GlobalPortId;
+
+    fn add(self, rhs: LocalPortOffset) -> Self::Output {
+        GlobalPortId::new(self.port_base.index() + rhs.index())
+    }
+}
+
+impl Add<LocalRefPortOffset> for &BaseIndices {
+    type Output = GlobalRefPortId;
+
+    fn add(self, rhs: LocalRefPortOffset) -> Self::Output {
+        GlobalRefPortId::new(self.ref_port_base.index() + rhs.index())
+    }
+}
+
+impl Add<LocalCellOffset> for &BaseIndices {
+    type Output = GlobalCellId;
+
+    fn add(self, rhs: LocalCellOffset) -> Self::Output {
+        GlobalCellId::new(self.cell_base.index() + rhs.index())
+    }
+}
+
+impl Add<LocalRefCellOffset> for &BaseIndices {
+    type Output = GlobalRefCellId;
+
+    fn add(self, rhs: LocalRefCellOffset) -> Self::Output {
+        GlobalRefCellId::new(self.ref_cell_base.index() + rhs.index())
+    }
+}
+
+impl Add<&LocalPortOffset> for &BaseIndices {
+    type Output = GlobalPortId;
+
+    fn add(self, rhs: &LocalPortOffset) -> Self::Output {
+        GlobalPortId::new(self.port_base.index() + rhs.index())
+    }
+}
+
+impl Add<&LocalRefPortOffset> for &BaseIndices {
+    type Output = GlobalRefPortId;
+
+    fn add(self, rhs: &LocalRefPortOffset) -> Self::Output {
+        GlobalRefPortId::new(self.ref_port_base.index() + rhs.index())
+    }
+}
+
+impl Add<&LocalCellOffset> for &BaseIndices {
+    type Output = GlobalCellId;
+
+    fn add(self, rhs: &LocalCellOffset) -> Self::Output {
+        GlobalCellId::new(self.cell_base.index() + rhs.index())
+    }
+}
+
+impl Add<&LocalRefCellOffset> for &BaseIndices {
+    type Output = GlobalRefCellId;
+
+    fn add(self, rhs: &LocalRefCellOffset) -> Self::Output {
+        GlobalRefCellId::new(self.ref_cell_base.index() + rhs.index())
+    }
 }

--- a/interp/src/flatten/flat_ir/base.rs
+++ b/interp/src/flatten/flat_ir/base.rs
@@ -38,13 +38,13 @@ impl_index!(RefPortDefinitionIdx);
 
 /// The index of a port instance in the global value map
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
-pub struct GlobalPortId(u32);
-impl_index!(GlobalPortId);
+pub struct GlobalPortId(NonZeroU32);
+impl_index_nonzero!(GlobalPortId);
 
 /// The index of a cell instance in the global value map
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]
-pub struct GlobalCellId(u32);
-impl_index!(GlobalCellId);
+pub struct GlobalCellId(NonZeroU32);
+impl_index_nonzero!(GlobalCellId);
 
 /// The index of a ref cell instance in the global value map
 #[derive(Debug, Eq, Copy, Clone, PartialEq, Hash, PartialOrd, Ord)]

--- a/interp/src/flatten/flat_ir/cell_prototype.rs
+++ b/interp/src/flatten/flat_ir/cell_prototype.rs
@@ -6,11 +6,22 @@ use crate::primitives::prim_utils::get_params;
 use super::prelude::ComponentIdx;
 
 #[derive(Debug, Clone)]
+pub enum LiteralOrPrimitive {
+    Literal,
+    Primitive,
+}
+
+#[derive(Debug, Clone)]
 pub enum CellPrototype {
     Component(ComponentIdx),
-    ConstantLiteral { value: u64, width: u64 },
-    Register { width: u64 },
-    ConstantPrimitive { value: u64, width: u64 },
+    Constant {
+        value: u64,
+        width: u64,
+        c_type: LiteralOrPrimitive,
+    },
+    Register {
+        width: u64,
+    },
     // TODO Griffin: lots more
     Unknown(String, Box<cir::Binding>),
 }
@@ -57,7 +68,11 @@ impl CellPrototype {
                         width: "WIDTH"
                     ];
 
-                    Self::ConstantPrimitive { value, width }
+                    Self::Constant {
+                        value,
+                        width,
+                        c_type: LiteralOrPrimitive::Primitive,
+                    }
                 }
 
                 _ => CellPrototype::Unknown(
@@ -66,7 +81,15 @@ impl CellPrototype {
                 ),
             }
         } else {
-            panic!("construct_primitive called on non-primitive cell");
+            unreachable!("construct_primitive called on non-primitive cell");
         }
+    }
+
+    /// Returns `true` if the cell prototype is [`Component`].
+    ///
+    /// [`Component`]: CellPrototype::Component
+    #[must_use]
+    pub fn is_component(&self) -> bool {
+        matches!(self, Self::Component(..))
     }
 }

--- a/interp/src/flatten/flat_ir/control/translator.rs
+++ b/interp/src/flatten/flat_ir/control/translator.rs
@@ -4,7 +4,7 @@ use calyx_ir::{self as cir, RRC};
 use crate::{
     flatten::{
         flat_ir::{
-            cell_prototype::CellPrototype,
+            cell_prototype::{CellPrototype, LiteralOrPrimitive},
             component::{AuxillaryComponentInfo, ComponentCore},
             flatten_trait::{flatten_tree, FlattenTree, SingleHandle},
             prelude::{
@@ -437,12 +437,11 @@ fn create_cell_prototype(
             CellPrototype::Component(comp_id_map[name])
         }
 
-        cir::CellType::Constant { val, width } => {
-            CellPrototype::ConstantLiteral {
-                value: *val,
-                width: *width,
-            }
-        }
+        cir::CellType::Constant { val, width } => CellPrototype::Constant {
+            value: *val,
+            width: *width,
+            c_type: LiteralOrPrimitive::Literal,
+        },
         cir::CellType::ThisComponent => unreachable!(
             "the flattening should not have this cell type, this is an error"
         ),

--- a/interp/src/flatten/flat_ir/control/translator.rs
+++ b/interp/src/flatten/flat_ir/control/translator.rs
@@ -244,7 +244,8 @@ fn insert_port(
             local_offset.into()
         }
         ContainmentType::Local => {
-            let idx_definition = secondary_ctx.push_local_port(id);
+            let idx_definition =
+                secondary_ctx.push_local_port(id, port.borrow().width as usize);
             let local_offset = aux.port_offset_map.insert(idx_definition);
             local_offset.into()
         }
@@ -548,7 +549,7 @@ impl FlattenTree for cir::Control {
                                 .find(|&candidate_offset| {
                                     let candidate_def = comp_info
                                         .port_offset_map[candidate_offset];
-                                    ctx.secondary[candidate_def] == id
+                                    ctx.secondary[candidate_def].name == id
                                 })
                                 .unwrap()
                                 .into()
@@ -573,10 +574,10 @@ impl FlattenTree for cir::Control {
 
                 let ref_cells = inv.ref_cells.iter().map(|(ref_cell_id, realizing_cell)| {
                         let invoked_comp = invoked_comp.as_component().expect("cannot invoke a non-component with ref cells");
-                        let target = &ctx.secondary[*invoked_comp].ref_cell_offset_map.iter().find(|(&_idx, &def_idx)| {
+                        let target = &ctx.secondary[*invoked_comp].ref_cell_offset_map.iter().find(|(_idx, &def_idx)| {
                             let def = &ctx.secondary[def_idx];
                             def.name == resolve_id(ref_cell_id)
-                        }).map(|(&t, _)| t).expect("Unable to find the given ref cell in the invoked component");
+                        }).map(|(t, _)| t).expect("Unable to find the given ref cell in the invoked component");
                         (*target, layout.cell_map[&realizing_cell.as_raw()])
                     });
 

--- a/interp/src/flatten/flat_ir/control/translator.rs
+++ b/interp/src/flatten/flat_ir/control/translator.rs
@@ -43,10 +43,13 @@ pub fn translate(orig_ctx: &cir::Context) -> Context {
     // iteration over the components in a post-order so this is a hack instead
 
     for comp in CompTraversal::new(&orig_ctx.components).iter() {
-        // TODO Griffin: capture the entry-point component and store that
-        // somewhere in the context
-        let _ = translate_component(comp, &mut ctx, &mut component_id_map);
+        translate_component(comp, &mut ctx, &mut component_id_map);
     }
+
+    ctx.entry_point = *component_id_map
+        .get(&orig_ctx.entrypoint().name)
+        .expect("Unable to find entrypoint");
+
     ctx
 }
 
@@ -116,7 +119,6 @@ fn translate_guard(
     flatten_tree(guard, None, &mut interp_ctx.guards, map)
 }
 
-#[must_use]
 fn translate_component(
     comp: &cir::Component,
     ctx: &mut Context,

--- a/interp/src/flatten/mod.rs
+++ b/interp/src/flatten/mod.rs
@@ -11,4 +11,5 @@ pub fn flat_main(ctx: &calyx_ir::Context) {
     i_ctx.printer().print_program();
 
     let env = Environment::new(&i_ctx);
+    dbg!(env);
 }

--- a/interp/src/flatten/mod.rs
+++ b/interp/src/flatten/mod.rs
@@ -3,8 +3,12 @@ pub mod primitives;
 mod structures;
 pub(crate) mod text_utils;
 
+use structures::environment::Environment;
+
 pub fn flat_main(ctx: &calyx_ir::Context) {
     let i_ctx = flat_ir::control::translator::translate(ctx);
 
     i_ctx.printer().print_program();
+
+    let env = Environment::new(&i_ctx);
 }

--- a/interp/src/flatten/mod.rs
+++ b/interp/src/flatten/mod.rs
@@ -11,5 +11,5 @@ pub fn flat_main(ctx: &calyx_ir::Context) {
     i_ctx.printer().print_program();
 
     let env = Environment::new(&i_ctx);
-    dbg!(env);
+    env.print_env_stats();
 }

--- a/interp/src/flatten/primitives/builder.rs
+++ b/interp/src/flatten/primitives/builder.rs
@@ -1,0 +1,33 @@
+use crate::flatten::{
+    flat_ir::prelude::CellInfo, structures::environment::Environment,
+};
+
+use super::{prim_trait::DummyPrimitive, Primitive};
+
+pub fn build_primitive(
+    _prim: &CellInfo,
+    _env: &Environment,
+) -> Box<dyn Primitive> {
+    return DummyPrimitive::new_dyn();
+
+    #[allow(unreachable_code)]
+    match &_prim.prototype {
+        crate::flatten::flat_ir::cell_prototype::CellPrototype::Constant {
+            value: _,
+            width: _,
+            c_type: _,
+        } => todo!(),
+        crate::flatten::flat_ir::cell_prototype::CellPrototype::Register {
+            width: _,
+        } => todo!(),
+        crate::flatten::flat_ir::cell_prototype::CellPrototype::Unknown(
+            _,
+            _,
+        ) => todo!(),
+        crate::flatten::flat_ir::cell_prototype::CellPrototype::Component(
+            _,
+        ) => unreachable!(
+            "Build primitive erroneously called on a calyx component"
+        ),
+    }
+}

--- a/interp/src/flatten/primitives/mod.rs
+++ b/interp/src/flatten/primitives/mod.rs
@@ -1,3 +1,5 @@
+mod builder;
 pub mod prim_trait;
 
+pub(crate) use builder::build_primitive;
 pub use prim_trait::Primitive;

--- a/interp/src/flatten/primitives/prim_trait.rs
+++ b/interp/src/flatten/primitives/prim_trait.rs
@@ -10,3 +10,21 @@ pub trait Primitive {
     fn exec_comb_paths(&self, portmap: &PortMap) -> PortResults;
     fn exec_stateful_paths(&mut self, portmap: &PortMap) -> PortResults;
 }
+
+pub struct DummyPrimitive;
+
+impl DummyPrimitive {
+    pub fn new_dyn() -> Box<dyn Primitive> {
+        Box::new(Self)
+    }
+}
+
+impl Primitive for DummyPrimitive {
+    fn exec_comb_paths(&self, portmap: &PortMap) -> PortResults {
+        todo!()
+    }
+
+    fn exec_stateful_paths(&mut self, portmap: &PortMap) -> PortResults {
+        todo!()
+    }
+}

--- a/interp/src/flatten/primitives/prim_trait.rs
+++ b/interp/src/flatten/primitives/prim_trait.rs
@@ -20,11 +20,11 @@ impl DummyPrimitive {
 }
 
 impl Primitive for DummyPrimitive {
-    fn exec_comb_paths(&self, portmap: &PortMap) -> PortResults {
+    fn exec_comb_paths(&self, _portmap: &PortMap) -> PortResults {
         todo!()
     }
 
-    fn exec_stateful_paths(&mut self, portmap: &PortMap) -> PortResults {
+    fn exec_stateful_paths(&mut self, _portmap: &PortMap) -> PortResults {
         todo!()
     }
 }

--- a/interp/src/flatten/structures/context.rs
+++ b/interp/src/flatten/structures/context.rs
@@ -18,27 +18,10 @@ use crate::flatten::flat_ir::{
 };
 
 use super::{
-    index_trait::IndexRange,
+    index_trait::{IndexRange, IndexRef},
     indexed_map::{AuxillaryMap, IndexedMap},
     printer::Printer,
 };
-
-/// The full immutable program context for the interpreter.
-#[derive(Debug, Default)]
-pub struct Context {
-    /// Simulation relevant context
-    pub primary: InterpretationContext,
-    /// Setup/debugging relevant context
-    pub secondary: SecondaryContext,
-}
-
-impl From<(InterpretationContext, SecondaryContext)> for Context {
-    fn from(
-        (primary, secondary): (InterpretationContext, SecondaryContext),
-    ) -> Self {
-        Self { primary, secondary }
-    }
-}
 
 /// The immutable program context for the interpreter. Relevant at simulation
 /// time
@@ -223,6 +206,41 @@ impl Default for SecondaryContext {
             local_cell_defs: Default::default(),
             ref_cell_defs: Default::default(),
             comp_aux_info: Default::default(),
+        }
+    }
+}
+
+/// The full immutable program context for the interpreter.
+#[derive(Debug)]
+pub struct Context {
+    /// Simulation relevant context
+    pub primary: InterpretationContext,
+    /// Setup/debugging relevant context
+    pub secondary: SecondaryContext,
+    /// The ID of the entry component for the program (usually called "main")
+    /// In general this will be the last component in the program to be
+    /// processed and should have the highest index.
+    pub entry_point: ComponentIdx,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self {
+            primary: Default::default(),
+            secondary: Default::default(),
+            entry_point: ComponentIdx::new(0),
+        }
+    }
+}
+
+impl From<(InterpretationContext, SecondaryContext)> for Context {
+    fn from(
+        (primary, secondary): (InterpretationContext, SecondaryContext),
+    ) -> Self {
+        Self {
+            primary,
+            secondary,
+            entry_point: ComponentIdx::new(0),
         }
     }
 }

--- a/interp/src/flatten/structures/context.rs
+++ b/interp/src/flatten/structures/context.rs
@@ -1,6 +1,5 @@
-use std::ops::Index;
-
 use std::collections::HashMap;
+use std::ops::{AddAssign, Index};
 
 use crate::flatten::flat_ir::{
     cell_prototype::CellPrototype,
@@ -24,8 +23,6 @@ use super::{
     indexed_map::{AuxillaryMap, IndexedMap},
     printer::Printer,
 };
-
-use std::ops::AddAssign;
 
 /// The immutable program context for the interpreter. Relevant at simulation
 /// time

--- a/interp/src/flatten/structures/context.rs
+++ b/interp/src/flatten/structures/context.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-use std::ops::{AddAssign, Index};
+use std::ops::Index;
 
 use crate::flatten::flat_ir::{
     cell_prototype::CellPrototype,

--- a/interp/src/flatten/structures/environment.rs
+++ b/interp/src/flatten/structures/environment.rs
@@ -35,4 +35,5 @@ pub struct Environment {
     ports: PortMap,
     cells: CellMap,
     ref_cells: RefCellMap,
+    ref_ports: RefPortMap,
 }

--- a/interp/src/flatten/structures/environment.rs
+++ b/interp/src/flatten/structures/environment.rs
@@ -31,9 +31,15 @@ pub(crate) struct ProgramCounter {
 }
 
 pub struct Environment {
-    pcs: ProgramCounter,
+    /// A map from global port IDs to their current values.
     ports: PortMap,
+    /// A map from global cell IDs to their current state and execution info.
     cells: CellMap,
+    /// A map from global ref cell IDs to the cell they reference, if any.
     ref_cells: RefCellMap,
+    /// A map from global ref port IDs to the port they reference, if any.
     ref_ports: RefPortMap,
+
+    /// The program counter for the whole program execution.
+    pcs: ProgramCounter,
 }

--- a/interp/src/flatten/structures/environment.rs
+++ b/interp/src/flatten/structures/environment.rs
@@ -1,3 +1,5 @@
+use bitvec::index;
+
 use super::{context::Context, indexed_map::IndexedMap};
 use crate::{
     flatten::{
@@ -5,31 +7,74 @@ use crate::{
             BaseIndices, ComponentIdx, GlobalCellId, GlobalPortId,
             GlobalRefCellId, GlobalRefPortId,
         },
-        primitives::Primitive,
+        primitives::{self, prim_trait::DummyPrimitive, Primitive},
+        structures::index_trait::IndexRef,
     },
     values::Value,
 };
+use std::fmt::Debug;
 
 pub(crate) type PortMap = IndexedMap<GlobalPortId, Value>;
 pub(crate) type CellMap = IndexedMap<GlobalCellId, CellLedger>;
 pub(crate) type RefCellMap = IndexedMap<GlobalRefCellId, Option<GlobalCellId>>;
 pub(crate) type RefPortMap = IndexedMap<GlobalRefPortId, Option<GlobalPortId>>;
 
+pub(crate) struct ComponentLedger {
+    pub(crate) index_bases: BaseIndices,
+    pub(crate) comp_id: ComponentIdx,
+}
+
 pub(crate) enum CellLedger {
     Primitive {
         // wish there was a better option with this one
         cell_dyn: Box<dyn Primitive>,
     },
-    Component {
-        index_bases: BaseIndices,
-        comp_id: ComponentIdx,
-    },
+    Component(ComponentLedger),
 }
 
+impl CellLedger {
+    fn comp(idx: ComponentIdx, env: &Environment) -> Self {
+        Self::Component(ComponentLedger {
+            index_bases: BaseIndices::new(
+                env.ports.peek_next_idx(),
+                (env.cells.peek_next_idx().index() + 1).into(),
+                env.ref_cells.peek_next_idx(),
+                env.ref_ports.peek_next_idx(),
+            ),
+            comp_id: idx,
+        })
+    }
+
+    pub fn as_comp(&self) -> Option<&ComponentLedger> {
+        match self {
+            Self::Component(comp) => Some(comp),
+            _ => None,
+        }
+    }
+}
+
+impl Debug for CellLedger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Primitive { .. } => f.debug_struct("Primitive").finish(),
+            Self::Component(ComponentLedger {
+                index_bases,
+                comp_id,
+            }) => f
+                .debug_struct("Component")
+                .field("index_bases", index_bases)
+                .field("comp_id", comp_id)
+                .finish(),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub(crate) struct ProgramCounter {
     // TODO
 }
 
+#[derive(Debug)]
 pub struct Environment {
     /// A map from global port IDs to their current values.
     ports: PortMap,
@@ -47,13 +92,102 @@ pub struct Environment {
 impl Environment {
     pub fn new(ctx: &Context) -> Self {
         let root = ctx.entry_point;
-        let sizes = ctx.get_component_size_definitions(root);
+        let aux = &ctx.secondary[root];
 
-        let mut ports = PortMap::with_capacity(sizes.ports);
-        let mut cells = CellMap::with_capacity(sizes.cells);
-        let mut ref_cells = RefCellMap::with_capacity(sizes.ref_cells);
-        let mut ref_ports = RefPortMap::with_capacity(sizes.ref_ports);
+        let mut env = Self {
+            ports: PortMap::with_capacity(aux.port_offset_map.count()),
+            cells: CellMap::with_capacity(aux.cell_offset_map.count()),
+            ref_cells: RefCellMap::with_capacity(
+                aux.ref_cell_offset_map.count(),
+            ),
+            ref_ports: RefPortMap::with_capacity(
+                aux.ref_port_offset_map.count(),
+            ),
+            pcs: ProgramCounter {},
+        };
 
-        todo!()
+        let root_node = CellLedger::comp(root, &env);
+        let root = env.cells.push(root_node);
+        env.layout_component(root, ctx);
+
+        env
+    }
+
+    fn layout_component(&mut self, comp: GlobalCellId, ctx: &Context) {
+        let ComponentLedger {
+            index_bases,
+            comp_id,
+        } = self.cells[comp]
+            .as_comp()
+            .expect("Called layout component with a non-component cell.");
+        let comp_aux = &ctx.secondary[*comp_id];
+
+        let comp_id = *comp_id;
+
+        // first layout the signature
+        for sig_port in comp_aux.signature.iter() {
+            let width = ctx.lookup_port_def(&comp_id, sig_port).width;
+            let idx = self.ports.push(Value::zeroes(width));
+            debug_assert_eq!(index_bases + sig_port, idx);
+        }
+        // second group ports
+        for group_idx in comp_aux.definitions.groups() {
+            //go
+            let go = self.ports.push(Value::bit_low());
+            debug_assert_eq!(go, index_bases + ctx.primary[group_idx].go);
+
+            //done
+            let done = self.ports.push(Value::bit_low());
+            debug_assert_eq!(done, index_bases + ctx.primary[group_idx].done);
+        }
+
+        for (cell_off, def_idx) in comp_aux.cell_offset_map.iter() {
+            let info = &ctx.secondary[*def_idx];
+            if !info.prototype.is_component() {
+                for port in info.ports.iter() {
+                    let width = ctx.lookup_port_def(&comp_id, port).width;
+                    let idx = self.ports.push(Value::zeroes(width));
+                    debug_assert_eq!(
+                        &self.cells[comp].as_comp().unwrap().index_bases + port,
+                        idx
+                    );
+                }
+                let cell_dyn = primitives::build_primitive(info, self);
+                let cell = self.cells.push(CellLedger::Primitive { cell_dyn });
+
+                debug_assert_eq!(
+                    &self.cells[comp].as_comp().unwrap().index_bases + cell_off,
+                    cell
+                );
+            } else {
+                let child_comp = info.prototype.as_component().unwrap();
+                let child_comp = CellLedger::comp(*child_comp, self);
+
+                let cell = self.cells.push(child_comp);
+                debug_assert_eq!(
+                    &self.cells[comp].as_comp().unwrap().index_bases + cell_off,
+                    cell
+                );
+
+                self.layout_component(cell, ctx);
+            }
+        }
+
+        // ref cells and ports are initialized to None
+        for (ref_cell, def_idx) in comp_aux.ref_cell_offset_map.iter() {
+            let info = &ctx.secondary[*def_idx];
+            for port_idx in info.ports.iter() {
+                let port_actual = self.ref_ports.push(None);
+                debug_assert_eq!(
+                    &self.cells[comp].as_comp().unwrap().index_bases + port_idx,
+                    port_actual
+                )
+            }
+            let cell_actual = self.ref_cells.push(None);
+            debug_assert_eq!(
+                &self.cells[comp].as_comp().unwrap().index_bases + ref_cell,
+                cell_actual
+            )
+        }
     }
 }

--- a/interp/src/flatten/structures/environment.rs
+++ b/interp/src/flatten/structures/environment.rs
@@ -1,9 +1,9 @@
 use super::indexed_map::IndexedMap;
 use crate::{
     flatten::{
-        flat_ir::{
-            base::{ComponentIdx, GlobalCellId, GlobalPortId, GlobalRefCellId},
-            prelude::Identifier,
+        flat_ir::prelude::{
+            BaseIndices, ComponentIdx, GlobalCellId, GlobalPortId,
+            GlobalRefCellId, GlobalRefPortId,
         },
         primitives::Primitive,
     },
@@ -13,16 +13,15 @@ use crate::{
 pub(crate) type PortMap = IndexedMap<GlobalPortId, Value>;
 pub(crate) type CellMap = IndexedMap<GlobalCellId, CellLedger>;
 pub(crate) type RefCellMap = IndexedMap<GlobalRefCellId, Option<GlobalCellId>>;
+pub(crate) type RefPortMap = IndexedMap<GlobalRefPortId, Option<GlobalPortId>>;
 
 pub(crate) enum CellLedger {
     Primitive {
-        name: Identifier,
         // wish there was a better option with this one
         cell_dyn: Box<dyn Primitive>,
     },
     Component {
-        name: Identifier,
-        port_base_offset: GlobalPortId,
+        index_bases: BaseIndices,
         comp_id: ComponentIdx,
     },
 }

--- a/interp/src/flatten/structures/environment.rs
+++ b/interp/src/flatten/structures/environment.rs
@@ -192,4 +192,12 @@ impl Environment {
             )
         }
     }
+
+    pub fn print_env_stats(&self) {
+        println!("Environment Stats:");
+        println!("  Ports: {}", self.ports.len());
+        println!("  Cells: {}", self.cells.len());
+        println!("  Ref Cells: {}", self.ref_cells.len());
+        println!("  Ref Ports: {}", self.ref_ports.len());
+    }
 }

--- a/interp/src/flatten/structures/environment.rs
+++ b/interp/src/flatten/structures/environment.rs
@@ -130,6 +130,10 @@ impl Environment {
         }
         // second group ports
         for group_idx in comp_aux.definitions.groups() {
+            // TODO Griffin: The sanity checks here are assuming that go & done
+            // are defined in that order. This could break if the IR changes the
+            // order on hole ports in groups.
+
             //go
             let go = self.ports.push(Value::bit_low());
             debug_assert_eq!(go, index_bases + ctx.primary[group_idx].go);

--- a/interp/src/flatten/structures/environment.rs
+++ b/interp/src/flatten/structures/environment.rs
@@ -1,4 +1,4 @@
-use super::indexed_map::IndexedMap;
+use super::{context::Context, indexed_map::IndexedMap};
 use crate::{
     flatten::{
         flat_ir::prelude::{
@@ -42,4 +42,18 @@ pub struct Environment {
 
     /// The program counter for the whole program execution.
     pcs: ProgramCounter,
+}
+
+impl Environment {
+    pub fn new(ctx: &Context) -> Self {
+        let root = ctx.entry_point;
+        let sizes = ctx.get_component_size_definitions(root);
+
+        let mut ports = PortMap::with_capacity(sizes.ports);
+        let mut cells = CellMap::with_capacity(sizes.cells);
+        let mut ref_cells = RefCellMap::with_capacity(sizes.ref_cells);
+        let mut ref_ports = RefPortMap::with_capacity(sizes.ref_ports);
+
+        todo!()
+    }
 }

--- a/interp/src/flatten/structures/environment.rs
+++ b/interp/src/flatten/structures/environment.rs
@@ -7,7 +7,7 @@ use crate::{
             BaseIndices, ComponentIdx, GlobalCellId, GlobalPortId,
             GlobalRefCellId, GlobalRefPortId,
         },
-        primitives::{self, prim_trait::DummyPrimitive, Primitive},
+        primitives::{self, Primitive},
         structures::index_trait::IndexRef,
     },
     values::Value,

--- a/interp/src/flatten/structures/environment.rs
+++ b/interp/src/flatten/structures/environment.rs
@@ -1,5 +1,3 @@
-use bitvec::index;
-
 use super::{context::Context, indexed_map::IndexedMap};
 use crate::{
     flatten::{

--- a/interp/src/flatten/structures/index_trait.rs
+++ b/interp/src/flatten/structures/index_trait.rs
@@ -146,6 +146,10 @@ where
     pub fn contains(&self, candidate: I) -> bool {
         self.start <= candidate && self.end > candidate
     }
+
+    pub fn set_end(&mut self, end: I) {
+        self.end = end;
+    }
 }
 
 impl<'a, I> IntoIterator for &'a IndexRange<I>

--- a/interp/src/flatten/structures/indexed_map.rs
+++ b/interp/src/flatten/structures/indexed_map.rs
@@ -102,6 +102,10 @@ where
         // TODO (griffin): Make this an actual struct instead
         self.data.iter().enumerate().map(|(i, _)| K::new(i))
     }
+
+    pub fn capacity(&self) -> usize {
+        self.data.capacity()
+    }
 }
 
 impl<T, K> Default for IndexedMap<K, T>

--- a/interp/src/flatten/structures/printer.rs
+++ b/interp/src/flatten/structures/printer.rs
@@ -147,18 +147,18 @@ impl<'a> Printer<'a> {
         let parent = self.ctx.find_parent_cell(comp, target);
 
         match (port, parent) {
-            (PortDefinitionRef::Local(l), ParentIdx::Component(c)) => CanonicalIdentifier::interface_port( self.ctx.secondary[c].name, self.ctx.secondary[l]),
+            (PortDefinitionRef::Local(l), ParentIdx::Component(c)) => CanonicalIdentifier::interface_port( self.ctx.secondary[c].name, self.ctx.secondary[l].name),
             (PortDefinitionRef::Local(l), ParentIdx::Cell(c)) => {
                 if let CellPrototype::Constant { value, width, c_type }= &self.ctx.secondary[c].prototype {
                     match c_type {
                         LiteralOrPrimitive::Literal => CanonicalIdentifier::literal(*width, *value),
-                        LiteralOrPrimitive::Primitive => CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l]),
+                        LiteralOrPrimitive::Primitive => CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l].name),
                     }
                 } else {
-                    CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l])
+                    CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l].name)
                 }
             },
-            (PortDefinitionRef::Local(l), ParentIdx::Group(g)) => CanonicalIdentifier::group_port( self.ctx.primary[g].name(), self.ctx.secondary[l]),
+            (PortDefinitionRef::Local(l), ParentIdx::Group(g)) => CanonicalIdentifier::group_port( self.ctx.primary[g].name(), self.ctx.secondary[l].name),
             (PortDefinitionRef::Ref(rp), ParentIdx::RefCell(rc)) => CanonicalIdentifier::cell_port( self.ctx.secondary[rc].name, self.ctx.secondary[rp]),
             _ => unreachable!("Inconsistent port definition and parent. This should never happen"),
         }

--- a/interp/src/flatten/structures/printer.rs
+++ b/interp/src/flatten/structures/printer.rs
@@ -1,7 +1,7 @@
 use calyx_ir::PortComp;
 
 use crate::flatten::flat_ir::{
-    cell_prototype::CellPrototype,
+    cell_prototype::{CellPrototype, LiteralOrPrimitive},
     identifier::{CanonicalIdentifier, IdMap},
     wires::guards::Guard,
 };
@@ -149,8 +149,11 @@ impl<'a> Printer<'a> {
         match (port, parent) {
             (PortDefinitionRef::Local(l), ParentIdx::Component(c)) => CanonicalIdentifier::interface_port( self.ctx.secondary[c].name, self.ctx.secondary[l]),
             (PortDefinitionRef::Local(l), ParentIdx::Cell(c)) => {
-                if let CellPrototype::ConstantLiteral { value, width }= &self.ctx.secondary[c].prototype {
-                    CanonicalIdentifier::literal(*width, *value)
+                if let CellPrototype::Constant { value, width, c_type }= &self.ctx.secondary[c].prototype {
+                    match c_type {
+                        LiteralOrPrimitive::Literal => CanonicalIdentifier::literal(*width, *value),
+                        LiteralOrPrimitive::Primitive => CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l]),
+                    }
                 } else {
                     CanonicalIdentifier::cell_port( self.ctx.secondary[c].name, self.ctx.secondary[l])
                 }

--- a/interp/src/flatten/structures/sparse_map.rs
+++ b/interp/src/flatten/structures/sparse_map.rs
@@ -1,25 +1,30 @@
 use std::{hash::Hash, ops::Index};
 
-use super::index_trait::IndexRef;
+use super::index_trait::{IndexRange, IndexRef};
 use ahash::{HashMap, HashMapExt};
 
 #[derive(Debug, Clone)]
 pub struct SparseMap<K, D>
 where
-    K: IndexRef + Hash,
+    K: IndexRef + Hash + PartialOrd,
 {
     data: HashMap<K, D>,
+    /// An internal list of ranges that are used to iterate over the map in
+    /// insertion order. A bit of cleverness which allows us to avoid storing
+    /// every index
+    iteration_order: Vec<IndexRange<K>>,
     count: usize,
 }
 
 // This is not quite the same as the derived version, sorry!
 impl<K, D> Default for SparseMap<K, D>
 where
-    K: IndexRef + Hash,
+    K: IndexRef + Hash + PartialOrd,
 {
     fn default() -> Self {
         Self {
             data: HashMap::new(),
+            iteration_order: vec![IndexRange::empty_interval()],
             count: 0,
         }
     }
@@ -27,7 +32,7 @@ where
 
 impl<K, D> Index<K> for SparseMap<K, D>
 where
-    K: IndexRef + Hash,
+    K: IndexRef + Hash + PartialOrd,
 {
     type Output = D;
 
@@ -38,11 +43,12 @@ where
 
 impl<K, D> SparseMap<K, D>
 where
-    K: IndexRef + Hash,
+    K: IndexRef + Hash + PartialOrd,
 {
     pub fn new() -> Self {
         Self {
             data: Default::default(),
+            iteration_order: vec![IndexRange::empty_interval()],
             count: 0,
         }
     }
@@ -50,6 +56,7 @@ where
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             data: HashMap::with_capacity(capacity),
+            iteration_order: vec![IndexRange::empty_interval()],
             count: 0,
         }
     }
@@ -58,6 +65,11 @@ where
         let index = K::new(self.count);
         self.data.insert(index, value);
         self.count += 1;
+
+        self.iteration_order
+            .last_mut()
+            .unwrap()
+            .set_end(K::new(self.count));
         index
     }
 
@@ -72,6 +84,8 @@ where
     /// Skips the next `skip_count` indices. Used to advance the index counter.
     pub fn skip(&mut self, skip_count: usize) {
         self.count += skip_count;
+        self.iteration_order
+            .push(IndexRange::new(K::new(self.count), K::new(self.count)));
     }
 
     pub fn peek_next_index(&self) -> K {
@@ -83,12 +97,16 @@ where
         self.count
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&K, &D)> {
-        self.data.iter()
+    /// Iterates over all the keys and values in the map in insertion order.
+    pub fn iter(&self) -> impl Iterator<Item = (K, &D)> {
+        self.keys().map(|x| (x, self.get(x).unwrap()))
     }
 
-    pub fn keys(&self) -> impl Iterator<Item = &K> {
-        self.data.keys()
+    /// Iterates over all the keys in the map in insertion order.
+    /// This returns `K` rather than `&K` because it internally uses
+    /// [IndexRange]s
+    pub fn keys(&self) -> impl Iterator<Item = K> + '_ {
+        self.iteration_order.iter().flat_map(|x| x.iter())
     }
 
     pub fn values(&self) -> impl Iterator<Item = &D> {


### PR DESCRIPTION
Some stuff from the last week which creates the basic environment (all ports are zero and all ref cells/ports are None). Includes sanity checks that the local offset based definitions match the instantiated global offset from the appropriate offset base.

Reworked the `SparseMap` to iterate in insertion order and got a little clever with index ranges to avoid keeping a list of every key in order.