### PR TITLE
[cider/flat] Print the flat env port states

### DIFF
--- a/interp/src/flatten/flat_ir/base.rs
+++ b/interp/src/flatten/flat_ir/base.rs
@@ -414,3 +414,35 @@ impl Sub<&BaseIndices> for GlobalRefCellId {
         LocalRefCellOffset::new(self.index() - rhs.ref_cell_base.index())
     }
 }
+
+impl Sub<&BaseIndices> for &GlobalPortId {
+    type Output = LocalPortOffset;
+
+    fn sub(self, rhs: &BaseIndices) -> Self::Output {
+        LocalPortOffset::new(self.index() - rhs.port_base.index())
+    }
+}
+
+impl Sub<&BaseIndices> for &GlobalRefPortId {
+    type Output = LocalRefPortOffset;
+
+    fn sub(self, rhs: &BaseIndices) -> Self::Output {
+        LocalRefPortOffset::new(self.index() - rhs.ref_port_base.index())
+    }
+}
+
+impl Sub<&BaseIndices> for &GlobalCellId {
+    type Output = LocalCellOffset;
+
+    fn sub(self, rhs: &BaseIndices) -> Self::Output {
+        LocalCellOffset::new(self.index() - rhs.cell_base.index())
+    }
+}
+
+impl Sub<&BaseIndices> for &GlobalRefCellId {
+    type Output = LocalRefCellOffset;
+
+    fn sub(self, rhs: &BaseIndices) -> Self::Output {
+        LocalRefCellOffset::new(self.index() - rhs.ref_cell_base.index())
+    }
+}

--- a/interp/src/flatten/flat_ir/base.rs
+++ b/interp/src/flatten/flat_ir/base.rs
@@ -1,4 +1,7 @@
-use std::{num::NonZeroU32, ops::Add};
+use std::{
+    num::NonZeroU32,
+    ops::{Add, Sub},
+};
 
 use crate::flatten::structures::index_trait::{
     impl_index, impl_index_nonzero, IndexRange, IndexRef,
@@ -377,5 +380,37 @@ impl Add<&LocalRefCellOffset> for &BaseIndices {
 
     fn add(self, rhs: &LocalRefCellOffset) -> Self::Output {
         GlobalRefCellId::new(self.ref_cell_base.index() + rhs.index())
+    }
+}
+
+impl Sub<&BaseIndices> for GlobalPortId {
+    type Output = LocalPortOffset;
+
+    fn sub(self, rhs: &BaseIndices) -> Self::Output {
+        LocalPortOffset::new(self.index() - rhs.port_base.index())
+    }
+}
+
+impl Sub<&BaseIndices> for GlobalRefPortId {
+    type Output = LocalRefPortOffset;
+
+    fn sub(self, rhs: &BaseIndices) -> Self::Output {
+        LocalRefPortOffset::new(self.index() - rhs.ref_port_base.index())
+    }
+}
+
+impl Sub<&BaseIndices> for GlobalCellId {
+    type Output = LocalCellOffset;
+
+    fn sub(self, rhs: &BaseIndices) -> Self::Output {
+        LocalCellOffset::new(self.index() - rhs.cell_base.index())
+    }
+}
+
+impl Sub<&BaseIndices> for GlobalRefCellId {
+    type Output = LocalRefCellOffset;
+
+    fn sub(self, rhs: &BaseIndices) -> Self::Output {
+        LocalRefCellOffset::new(self.index() - rhs.ref_cell_base.index())
     }
 }

--- a/interp/src/flatten/mod.rs
+++ b/interp/src/flatten/mod.rs
@@ -12,4 +12,5 @@ pub fn flat_main(ctx: &calyx_ir::Context) {
 
     let env = Environment::new(&i_ctx);
     env.print_env_stats();
+    env.print_env();
 }

--- a/interp/src/flatten/structures/environment.rs
+++ b/interp/src/flatten/structures/environment.rs
@@ -217,6 +217,12 @@ impl<'a> Environment<'a> {
         let comp = &self.ctx.secondary[info.comp_id];
         hierarchy.push(target);
 
+        // This funky iterator chain first pulls the first element (the
+        // entrypoint) and extracts its name. Subsequent element are pairs of
+        // global offsets produced by a staggered iteration, yielding `(root,
+        // child)` then `(child, grandchild)` and so on. All the strings are
+        // finally collected and concatenated with a `.` separator to produce
+        // the fully qualified name prefix for the given component instance.
         let name_prefix = hierarchy
             .first()
             .iter()

--- a/interp/src/flatten/structures/indexed_map.rs
+++ b/interp/src/flatten/structures/indexed_map.rs
@@ -106,6 +106,10 @@ where
     pub fn capacity(&self) -> usize {
         self.data.capacity()
     }
+
+    pub fn first(&self) -> Option<&D> {
+        self.data.first()
+    }
 }
 
 impl<T, K> Default for IndexedMap<K, T>


### PR DESCRIPTION
A tiny PR with a simple pretty print for all the cells in the program environment. Currently only prints the ports on actual cells but descends the whole tree. For programs with heavy use of ref-cells this is not yet super useful, but a good start.

Nothing super exciting in this one, though there is a kinda overkill iterator chain at one point which was fun for me to write and probably not at all fun to read.