### PR TITLE
`wrap-main` runs at the start of lowering

### DIFF
--- a/calyx-opt/src/default_passes.rs
+++ b/calyx-opt/src/default_passes.rs
@@ -123,12 +123,12 @@ impl PassManager {
             pm,
             "lower",
             [
+                WrapMain,
                 GoInsertion,
                 WireInliner,
                 ClkInsertion,
                 ResetInsertion,
                 MergeAssign,
-                WrapMain
             ]
         );
 


### PR DESCRIPTION
Maybe we should just `wrap-main` at the very start of the compilation pipeline. Anyways, this should fix the problem that @andrewb1999 was running into.