### PR TITLE
Tiny docs fix (fixes #1611)

### DIFF
--- a/docs/lang/ref.md
+++ b/docs/lang/ref.md
@@ -53,7 +53,7 @@ with some additional pieces:
 For example, the following is the signature of the `std_reg` primitive from the
 Calyx standard library:
 ```
-{{#include ../../primitives/core.futil:std_reg_def}}
+{{#include ../../primitives/compile.futil:std_reg_def}}
 ```
 
 The primitive defines one parameter called `WIDTH`, which describes the sizes for

--- a/primitives/compile.futil
+++ b/primitives/compile.futil
@@ -19,6 +19,7 @@ comb primitive std_add<"share"=1>[WIDTH](@data left: WIDTH, @data right: WIDTH) 
 }
 
 /// Standard register with a one-cycle latency.
+// ANCHOR: std_reg_def
 primitive std_reg<"state_share"=1>[WIDTH](
   @write_together(1) @data in: WIDTH,
   @write_together(1) @static(1) @go write_en: 1,
@@ -28,6 +29,7 @@ primitive std_reg<"state_share"=1>[WIDTH](
   @stable out: WIDTH,
   @done done: 1
 ) {
+// ANCHOR_END: std_reg_def
   always_ff @(posedge clk) begin
     if (reset) begin
        out <= 0;

--- a/primitives/compile.futil
+++ b/primitives/compile.futil
@@ -28,8 +28,9 @@ primitive std_reg<"state_share"=1>[WIDTH](
 ) -> (
   @stable out: WIDTH,
   @done done: 1
-) {
+)
 // ANCHOR_END: std_reg_def
+{
   always_ff @(posedge clk) begin
     if (reset) begin
        out <= 0;


### PR DESCRIPTION
Just a tiny docs fix for #1611; some anchors didn't survive the transition to `compile.futil` from `core.futil`.
