### PR TITLE
Adding an S-expression backend!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom",
  "once_cell",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -22,7 +22,22 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
- "version_check",
+ "version_check 0.9.4",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -81,6 +96,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bit-set"
@@ -163,6 +184,8 @@ dependencies = [
  "log",
  "quick-xml",
  "serde",
+ "serde_sexpr",
+ "serde_with 3.0.0",
  "vast",
 ]
 
@@ -179,6 +202,8 @@ dependencies = [
  "pest",
  "pest_consume",
  "pest_derive",
+ "serde",
+ "serde_with 3.0.0",
  "smallvec",
  "strum",
  "strum_macros",
@@ -194,6 +219,8 @@ dependencies = [
  "linked-hash-map",
  "log",
  "petgraph",
+ "serde",
+ "serde_with 3.0.0",
  "smallvec",
  "string-interner",
 ]
@@ -261,9 +288,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "cider-dap"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "dap",
  "owo-colors",
  "serde",
@@ -302,6 +343,12 @@ dependencies = [
  "cfg-if",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
@@ -425,8 +472,7 @@ dependencies = [
 [[package]]
 name = "dap"
 version = "0.2.0-alpha1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b03f0c23c75d79d10ae9e6ea850f795db0b11bb9610d55f7751d8a92272db2"
+source = "git+https://github.com/sztomi/dap-rs?rev=7be5376#7be5376b84fbf1a3fbbc1953153e0130cbc7bfb6"
 dependencies = [
  "serde",
  "serde_json",
@@ -439,8 +485,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -458,14 +514,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.16",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -625,7 +706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
- "version_check",
+ "version_check 0.9.4",
 ]
 
 [[package]]
@@ -694,6 +775,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ibig"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +830,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -737,7 +848,7 @@ version = "0.1.1"
 dependencies = [
  "ahash 0.8.3",
  "argh",
- "base64",
+ "base64 0.13.1",
  "bitvec",
  "calyx-frontend",
  "calyx-ir",
@@ -757,7 +868,7 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 1.14.0",
  "slog",
  "slog-async",
  "slog-term",
@@ -881,6 +992,16 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+dependencies = [
+ "memchr",
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -1428,13 +1549,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_sexpr"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5318bfeed779c64075ce317c81462ed54dc00021be1c6b34957d798e11a68bdb"
+dependencies = [
+ "nom",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
+dependencies = [
+ "base64 0.21.2",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros 3.0.0",
+ "time",
 ]
 
 [[package]]
@@ -1443,10 +1590,22 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1496,6 +1655,9 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "static_assertions"
@@ -1761,6 +1923,12 @@ dependencies = [
 
 [[package]]
 name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
@@ -1886,6 +2054,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ lazy_static = "1"
 linked-hash-map = "0.5"
 smallvec = "1"
 serde = { version = "1.0", features = ["derive"] }
+serde_sexpr = "0.1.0"
+serde_with = "3.0.0"
 pest = "2.0"
 pest_derive = "2"
 pest_consume = "1"
@@ -74,11 +76,17 @@ path = "src/main.rs"
 name = "futil"
 path = "src/futil.rs"
 
+[features]
+default = []
+serialize = ["dep:serde_with", "calyx-ir/serialize", "dep:serde_sexpr", "serde/rc"]
+
 [dependencies]
 atty.workspace = true
 itertools.workspace = true
 log.workspace = true
 serde.workspace = true
+serde_with = { workspace = true, optional = true }
+serde_sexpr = { workspace = true, optional = true }
 argh.workspace = true
 csv = "1.1"
 vast = "0.3.1"

--- a/calyx-frontend/Cargo.toml
+++ b/calyx-frontend/Cargo.toml
@@ -13,11 +13,17 @@ readme.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+serialize = ["dep:serde/derive", "dep:serde_with"]
+
 [dependencies]
 atty.workspace = true
 lazy_static.workspace = true
 linked-hash-map.workspace = true
 log.workspace = true
+serde = { workspace = true, optional = true }
+serde_with = { workspace = true, optional = true }
 smallvec.workspace = true
 pest.workspace = true
 pest_derive.workspace = true

--- a/calyx-frontend/Cargo.toml
+++ b/calyx-frontend/Cargo.toml
@@ -15,7 +15,7 @@ readme.workspace = true
 
 [features]
 default = []
-serialize = ["dep:serde/derive", "dep:serde_with"]
+serialize = ["serde/derive", "dep:serde_with"]
 
 [dependencies]
 atty.workspace = true

--- a/calyx-frontend/src/attribute.rs
+++ b/calyx-frontend/src/attribute.rs
@@ -18,6 +18,7 @@ pub const DEPRECATED_ATTRIBUTES: &[&str] = &[];
     Eq,
     Debug,
 )]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[repr(u8)]
 /// Attributes that are only allowed to take boolean values.
 pub enum BoolAttr {
@@ -73,6 +74,7 @@ impl std::fmt::Display for BoolAttr {
 }
 
 #[derive(AsRefStr, EnumString, Clone, Copy, Hash, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 /// Attributes that can take numeric values
 pub enum NumAttr {
     // ============ numeric attributes ============
@@ -114,6 +116,7 @@ impl std::fmt::Display for NumAttr {
 }
 
 #[derive(AsRefStr, Clone, Copy, Hash, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[allow(non_camel_case_types)]
 /// Internal attributes that cannot be parsed back from the IL.
 pub enum InternalAttr {
@@ -133,6 +136,7 @@ impl From<InternalAttr> for Attribute {
 }
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 /// Defines the known attributes that can be attached to IR nodes.
 /// All caps names represent attributes that are internal to the compiler and
 /// cannot be parsed back.

--- a/calyx-frontend/src/attribute.rs
+++ b/calyx-frontend/src/attribute.rs
@@ -215,3 +215,13 @@ impl InlineAttributes {
         })
     }
 }
+
+#[cfg(feature = "serialize")]
+impl serde::Serialize for InlineAttributes {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_owned().attrs.serialize(ser)
+    }
+}

--- a/calyx-frontend/src/attributes.rs
+++ b/calyx-frontend/src/attributes.rs
@@ -16,7 +16,6 @@ struct HeapAttrInfo {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Attributes {
     /// Inlined attributes
-    #[cfg_attr(feature = "serialize", serde(skip))]
     inl: InlineAttributes,
     /// Attributes stored on the heap
     hinfo: Box<HeapAttrInfo>,

--- a/calyx-frontend/src/attributes.rs
+++ b/calyx-frontend/src/attributes.rs
@@ -13,8 +13,10 @@ struct HeapAttrInfo {
 
 /// Attributes associated with a specific IR structure.
 #[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Attributes {
     /// Inlined attributes
+    #[cfg_attr(feature = "serialize", serde(skip))]
     inl: InlineAttributes,
     /// Attributes stored on the heap
     hinfo: Box<HeapAttrInfo>,
@@ -143,5 +145,15 @@ impl Attributes {
             .chain(self.inl.iter().map(|k| fmt(k.as_ref().to_string(), 1)))
             .collect::<Vec<_>>()
             .join(sep)
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl serde::Serialize for HeapAttrInfo {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        ser.collect_map(self.to_owned().attrs.iter())
     }
 }

--- a/calyx-frontend/src/common.rs
+++ b/calyx-frontend/src/common.rs
@@ -185,6 +185,7 @@ impl PortDef<Width> {
 
 /// Direction of a port on a cell.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum Direction {
     /// Input port.
     Input,

--- a/calyx-ir/Cargo.toml
+++ b/calyx-ir/Cargo.toml
@@ -11,12 +11,18 @@ homepage.workspace = true
 categories.workspace = true
 readme.workspace = true
 
+[features]
+default = []
+serialize = ["dep:serde/derive", "dep:serde_with", "calyx-utils/serialize", "calyx-frontend/serialize", "smallvec/serde"]
+
 [dependencies]
 log.workspace = true
 petgraph.workspace = true
 string-interner.workspace = true
 itertools.workspace = true
 linked-hash-map.workspace = true
+serde = { workspace = true, optional = true }
+serde_with = { workspace = true, optional = true }
 smallvec.workspace = true
 
 calyx-utils.workspace = true

--- a/calyx-ir/Cargo.toml
+++ b/calyx-ir/Cargo.toml
@@ -13,7 +13,7 @@ readme.workspace = true
 
 [features]
 default = []
-serialize = ["dep:serde/derive", "dep:serde_with", "calyx-utils/serialize", "calyx-frontend/serialize", "smallvec/serde"]
+serialize = ["serde/derive", "dep:serde_with", "calyx-utils/serialize", "calyx-frontend/serialize", "smallvec/serde"]
 
 [dependencies]
 log.workspace = true

--- a/calyx-ir/src/component.rs
+++ b/calyx-ir/src/component.rs
@@ -28,6 +28,7 @@ const INTERFACE_PORTS: [(Attribute, u64, Direction); 4] = [
 
 /// In memory representation of a Component.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Component {
     /// Name of the component.
     pub name: Id,
@@ -56,6 +57,7 @@ pub struct Component {
     ///// Internal structures
     /// Namegenerator that contains the names currently defined in this
     /// component (cell and group names).
+    #[cfg_attr(feature = "serialize", serde(skip))]
     namegen: NameGenerator,
 }
 

--- a/calyx-ir/src/control.rs
+++ b/calyx-ir/src/control.rs
@@ -9,6 +9,7 @@ type StaticLatency = u64;
 
 /// Data for the `seq` control statement.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Seq {
     /// List of `Control` statements to run in sequence.
     pub stmts: Vec<Control>,
@@ -26,6 +27,7 @@ impl GetAttributes for Seq {
 
 /// Data for the `static seq` control statement.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct StaticSeq {
     /// List of `StaticControl` statements to run in sequence.
     pub stmts: Vec<StaticControl>,
@@ -45,6 +47,7 @@ impl GetAttributes for StaticSeq {
 
 /// Data for the `par` control statement.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Par {
     /// List of `Control` statements to run in parallel.
     pub stmts: Vec<Control>,
@@ -62,6 +65,7 @@ impl GetAttributes for Par {
 
 // Data for the `static par` control statement.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct StaticPar {
     /// List of `StaticControl` statements to run in parallel.
     pub stmts: Vec<StaticControl>,
@@ -81,6 +85,7 @@ impl GetAttributes for StaticPar {
 
 /// Data for the `if` control statement.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct If {
     /// Port that connects the conditional check.
     pub port: RRC<Port>,
@@ -109,6 +114,7 @@ impl GetAttributes for If {
 
 /// Data for the `static if` control statement.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct StaticIf {
     /// Port that connects the conditional check.
     pub port: RRC<Port>,
@@ -139,6 +145,7 @@ impl GetAttributes for StaticIf {
 
 /// Data for the `while` control statement.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct While {
     /// Port that connects the conditional check.
     pub port: RRC<Port>,
@@ -162,6 +169,7 @@ impl GetAttributes for While {
 /// Data for the Dynamic `Repeat` control statement. Repeats the body of the loop
 /// a given number times.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Repeat {
     /// Attributes
     pub attributes: Attributes,
@@ -182,6 +190,7 @@ impl GetAttributes for Repeat {
 
 /// Data for the `StaticRepeat` control statement. Essentially a static while loop.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct StaticRepeat {
     /// Attributes
     pub attributes: Attributes,
@@ -204,6 +213,7 @@ impl GetAttributes for StaticRepeat {
 
 /// Data for the `enable` control statement.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Enable {
     /// List of components to run.
     pub group: RRC<Group>,
@@ -222,6 +232,7 @@ impl GetAttributes for Enable {
 
 /// Data for the `enable` control for a static group.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct StaticEnable {
     /// List of components to run.
     pub group: RRC<StaticGroup>,
@@ -250,6 +261,7 @@ type CellMap = Vec<(Id, RRC<Cell>)>;
 
 /// Data for an `invoke` control statement.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Invoke {
     /// Cell that is being invoked.
     pub comp: RRC<Cell>,
@@ -276,6 +288,7 @@ impl GetAttributes for Invoke {
 
 /// Data for a `StaticInvoke` control statement
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct StaticInvoke {
     /// Cell that is being invoked.
     pub comp: RRC<Cell>,
@@ -302,12 +315,14 @@ impl GetAttributes for StaticInvoke {
 
 /// Data for the `empty` control statement.
 #[derive(Debug, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Empty {
     pub attributes: Attributes,
 }
 
 /// Control AST nodes.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum Control {
     /// Represents sequential composition of control statements.
     Seq(Seq),
@@ -331,6 +346,7 @@ pub enum Control {
 
 /// Control AST nodes.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum StaticControl {
     /// Essentially a Static While Loop
     Repeat(StaticRepeat),

--- a/calyx-ir/src/guard.rs
+++ b/calyx-ir/src/guard.rs
@@ -6,6 +6,7 @@ use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
 use std::{cmp::Ordering, hash::Hash, rc::Rc};
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Nothing;
 
 impl ToString for Nothing {
@@ -16,6 +17,7 @@ impl ToString for Nothing {
 
 /// Comparison operations that can be performed between ports by [Guard::CompOp].
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum PortComp {
     /// p1 == p2
     Eq,
@@ -33,6 +35,7 @@ pub enum PortComp {
 
 /// An assignment guard which has pointers to the various ports from which it reads.
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum Guard<T> {
     /// Represents `c1 || c2`.
     Or(Box<Guard<T>>, Box<Guard<T>>),
@@ -52,6 +55,7 @@ pub enum Guard<T> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct StaticTiming {
     interval: (u64, u64),
 }

--- a/calyx-ir/src/lib.rs
+++ b/calyx-ir/src/lib.rs
@@ -54,3 +54,6 @@ pub mod from_ast;
 
 /// Convinience macros for constructing IR nodes.
 mod macros;
+
+/// Serializer methods for IR nodes.
+pub mod serializers;

--- a/calyx-ir/src/serializers.rs
+++ b/calyx-ir/src/serializers.rs
@@ -1,0 +1,86 @@
+#[cfg(feature = "serialize")]
+use crate::{Cell, Context, Control, IdList, PortParent, RRC};
+#[cfg(feature = "serialize")]
+use calyx_utils::GetName;
+#[cfg(feature = "serialize")]
+use serde::{
+    ser::{SerializeSeq, SerializeStruct},
+    Serialize, Serializer,
+};
+#[cfg(feature = "serialize")]
+use serde_with::SerializeAs;
+
+#[cfg(feature = "serialize")]
+impl Serialize for Context {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut ctx = ser.serialize_struct("Context", 2)?;
+        ctx.serialize_field("components", &self.components)?;
+        ctx.serialize_field("entrypoint", &self.entrypoint)?;
+        ctx.end()
+    }
+}
+
+#[cfg(feature = "serialize")]
+pub struct SerCellRef;
+#[cfg(feature = "serialize")]
+impl SerializeAs<RRC<Cell>> for SerCellRef {
+    fn serialize_as<S>(
+        value: &RRC<Cell>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        value.borrow().name().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl SerializeAs<RRC<Control>> for Control {
+    fn serialize_as<S>(
+        value: &RRC<Control>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        value.borrow().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl<T: GetName + Serialize> Serialize for IdList<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for obj in self.iter() {
+            seq.serialize_element(obj)?;
+        }
+        seq.end()
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl Serialize for PortParent {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match &self {
+            PortParent::Cell(weak_cell_ref) => {
+                weak_cell_ref.upgrade().borrow().name().serialize(ser)
+            }
+            PortParent::Group(weak_group_ref) => {
+                weak_group_ref.upgrade().borrow().name().serialize(ser)
+            }
+            PortParent::StaticGroup(weak_sgroup_ref) => {
+                weak_sgroup_ref.upgrade().borrow().name().serialize(ser)
+            }
+        }
+    }
+}

--- a/calyx-ir/src/structure.rs
+++ b/calyx-ir/src/structure.rs
@@ -23,6 +23,7 @@ pub enum PortParent {
 
 /// Represents a port on a cell.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Port {
     /// Name of the port
     pub name: Id,
@@ -172,6 +173,7 @@ pub type Binding = SmallVec<[(Id, u64); 5]>;
 
 /// The type for a Cell
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum CellType {
     /// Cell constructed using a primitive definition
     Primitive {
@@ -231,6 +233,7 @@ impl CellType {
 
 /// Represents an instantiated cell.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Cell {
     /// Name of this cell.
     name: Id,
@@ -448,6 +451,7 @@ impl Cell {
 
 /// Represents a guarded assignment in the program
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Assignment<T> {
     /// The destination for the assignment.
     pub dst: RRC<Port>,
@@ -504,6 +508,7 @@ impl<StaticTiming> Assignment<StaticTiming> {
 
 /// A Group of assignments that perform a logical action.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Group {
     /// Name of this group
     name: Id,
@@ -595,6 +600,7 @@ impl Group {
 
 /// A Group of assignments that perform a logical action.
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct StaticGroup {
     /// Name of this group
     name: Id,
@@ -672,6 +678,7 @@ impl StaticGroup {
 /// A combinational group does not have any holes and should only contain assignments that should
 /// will be combinationally active
 #[derive(Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct CombGroup {
     /// Name of this group
     pub(super) name: Id,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,6 +1,7 @@
 //! Backends for the Calyx compiler.
 pub mod mlir;
 pub mod resources;
+pub mod sexp;
 pub mod traits;
 pub mod verilog;
 pub mod xilinx;

--- a/src/backend/sexp.rs
+++ b/src/backend/sexp.rs
@@ -1,0 +1,43 @@
+//! Pretty-printer for Calyx syntax.
+//! Outputs s-expressions.
+
+use crate::backend::traits::Backend;
+use calyx_ir as ir;
+use calyx_utils::{CalyxResult, OutputFile};
+
+#[derive(Default)]
+pub struct SexpBackend;
+
+impl Backend for SexpBackend {
+    fn name(&self) -> &'static str {
+        "sexp"
+    }
+
+    /// OK to run this analysis on any Calyx program
+    fn validate(_ctx: &ir::Context) -> CalyxResult<()> {
+        Ok(())
+    }
+
+    /// Don't need to take care of this for this pass
+    fn link_externs(
+        _ctx: &ir::Context,
+        _file: &mut OutputFile,
+    ) -> CalyxResult<()> {
+        Ok(())
+    }
+
+    #[cfg(feature = "serialize")]
+    fn emit(ctx: &ir::Context, file: &mut OutputFile) -> CalyxResult<()> {
+        let out = &mut file.get_write();
+        writeln!(out, "{}", serde_sexpr::to_string(ctx).unwrap())?;
+
+        Ok(())
+    }
+
+    #[cfg(not(feature = "serialize"))]
+    fn emit(_ctx: &ir::Context, file: &mut OutputFile) -> CalyxResult<()> {
+        let out = &mut file.get_write();
+        writeln!(out, "The serialize feature is not enabled. To compile Calyx with the serialize feature, run `cargo build --features serialize`")?;
+        Ok(())
+    }
+}

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,8 +1,9 @@
 //! Command line parsing for the Calyx compiler.
 use crate::backend::traits::Backend;
 use crate::backend::{
-    mlir::MlirBackend, resources::ResourcesBackend, verilog::VerilogBackend,
-    xilinx::XilinxInterfaceBackend, xilinx::XilinxXmlBackend,
+    mlir::MlirBackend, resources::ResourcesBackend, sexp::SexpBackend,
+    verilog::VerilogBackend, xilinx::XilinxInterfaceBackend,
+    xilinx::XilinxXmlBackend,
 };
 use argh::FromArgs;
 use calyx_ir as ir;
@@ -110,6 +111,7 @@ pub enum BackendOpt {
     XilinxXml,
     Mlir,
     Resources,
+    Sexp,
     None,
 }
 
@@ -123,6 +125,7 @@ fn backends() -> Vec<(&'static str, BackendOpt)> {
         ("calyx", BackendOpt::Calyx),
         ("mlir", BackendOpt::Mlir),
         ("resources", BackendOpt::Resources),
+        ("sexp", BackendOpt::Sexp),
         ("none", BackendOpt::None),
     ]
 }
@@ -160,6 +163,7 @@ impl ToString for BackendOpt {
         match self {
             Self::Mlir => "mlir",
             Self::Resources => "resources",
+            Self::Sexp => "sexp",
             Self::Verilog => "verilog",
             Self::Xilinx => "xilinx",
             Self::XilinxXml => "xilinx-xml",
@@ -180,6 +184,10 @@ impl Opts {
             }
             BackendOpt::Resources => {
                 let backend = ResourcesBackend::default();
+                backend.run(context, self.output)
+            }
+            BackendOpt::Sexp => {
+                let backend = SexpBackend::default();
                 backend.run(context, self.output)
             }
             BackendOpt::Verilog => {


### PR DESCRIPTION
We are parsing Calyx programs in S-expression form for VCalyx. This PR adds support for serialization using `serde` for all current Calyx features. To compile Calyx with serialization support, run `cargo build --features serialize`. To use the serialization backend, you can use `-b sexp`, i.e., `/target/debug/calyx -b sexp prog.futil`.

Would love to hear thoughts on the following: 
- Right now, the responsibility for adding serialization support for new language features falls on whoever adds them to the repository. Does this seem reasonable, and if not, what are some good alternatives?
- This is my first time working with Rust features and I'm not 100% sure I got the TOML files right. Please let me know if anything needs to be changed! 
- I added the file `calyx-ir/serializers.rs` to consolidate custom serialization for certain structures, but there's only a few methods that needed to be hand-written. Would it be better to put these serialization methods in the same files as the definitions of those structures (i.e., put the serialization method for `Control` in `control.rs`)?
- Relatedly, I put the serialization of `HeapAttrInfo` in `calyx-frontend/attributes.rs` due to it not being a `pub struct`. This seemed to be the least obtrusive change to me, but if we don't want it in that file I can move it out. 

Thanks in advance for the review!