### PR TITLE
Better when comma is missing in signature

### DIFF
--- a/calyx-frontend/src/parser.rs
+++ b/calyx-frontend/src/parser.rs
@@ -455,7 +455,7 @@ impl CalyxParser {
             input.into_children();
             [io_port((name, width, attributes))] => {
                 let pd = PortDef {
-                    name, width, direction: Direction::Output, attributes
+                    name, width, direction: Direction::Input, attributes
                 };
                 vec![pd]
             },

--- a/calyx-frontend/src/syntax.pest
+++ b/calyx-frontend/src/syntax.pest
@@ -85,6 +85,10 @@ imports = { import* }
 
 // ====== Component signature ======
 
+// This rule is optional but the parser errors in the case when a comma is required but not present.
+comma_req = { "," }
+comma = { comma_req? }
+
 signature = {
       "(" ~ inputs? ~ ")" ~ "->" ~ "(" ~ outputs? ~ ")"
 }
@@ -93,12 +97,15 @@ io_port = {
      at_attributes? ~ identifier ~ ":" ~ (bitwidth | identifier)
 }
 
+// Defined separately because we need to provide different `ir::Direction` for inputs and outputs.
 inputs = {
-      io_port ~ ("," ~ io_port)*
+      io_port ~ comma ~ inputs
+      | io_port ~ ","?
 }
 
 outputs = {
-      io_port ~ ("," ~ io_port)*
+      io_port ~ comma ~ outputs
+      | io_port ~ ","?
 }
 
 // ========= Exernal primitive definitions ===============

--- a/tests/errors/parser/sig-missing-comma.expect
+++ b/tests/errors/parser/sig-missing-comma.expect
@@ -1,0 +1,9 @@
+---CODE---
+1
+---STDERR---
+Error: Failed to parse `tests/errors/parser/sig-missing-comma.futil`:  --> 3:5
+  |
+3 |     b: 2
+  |     ^
+  |
+  = expected comma

--- a/tests/errors/parser/sig-missing-comma.futil
+++ b/tests/errors/parser/sig-missing-comma.futil
@@ -1,0 +1,8 @@
+component main(
+    a: 1 // missing comma
+    b: 2
+) -> () {
+    cells {}
+    wires {}
+    control {}
+}


### PR DESCRIPTION
@andrewb1999 ran into this in #1610. Some parsing magic to make the compiler at least a reasonable error message.