### PR TITLE
Builder: allow user to generate `seq_mem_d1`

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -236,6 +236,20 @@ class ComponentBuilder:
             name, ast.Stdlib.mem_d1(bitwidth, len, idx_size), is_external, is_ref
         )
 
+    def seq_mem_d1(
+        self,
+        name: str,
+        bitwidth: int,
+        len: int,
+        idx_size: int,
+        is_external=False,
+        is_ref=False,
+    ) -> CellBuilder:
+        """Generate a SeqMemD1 cell."""
+        return self.cell(
+            name, ast.Stdlib.seq_mem_d1(bitwidth, len, idx_size), is_external, is_ref
+        )
+
     def add(self, name: str, size: int, signed=False) -> CellBuilder:
         """Generate a StdAdd cell."""
         self.prog.import_("primitives/binary_operators.futil")


### PR DESCRIPTION
As far as I can tell, the builder library does not yet expose a way for the user to create `seq_mem`s. This is a quick PR to allow that.