### PR TITLE
Builder: allow registers to be passed by reference

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -214,9 +214,9 @@ class ComponentBuilder:
 
         return self.cell(cell_name, ast.CompInst(comp_name, []))
 
-    def reg(self, name: str, size: int) -> CellBuilder:
+    def reg(self, name: str, size: int, is_ref=False) -> CellBuilder:
         """Generate a StdReg cell."""
-        return self.cell(name, ast.Stdlib.register(size))
+        return self.cell(name, ast.Stdlib.register(size), is_ref)
 
     def const(self, name: str, width: int, value: int) -> CellBuilder:
         """Generate a StdConstant cell."""

--- a/docs/lang/memories-by-reference.md
+++ b/docs/lang/memories-by-reference.md
@@ -1,7 +1,7 @@
 # Passing Cells by Reference
 
 One question that may arise when using Calyx as a backend is how to
-pass a memory "by reference" between components. In C++, this might look like:
+pass a cell "by reference" between components. In C++, this might look like:
 ```C++
 #include <array>
 #include <cstdint>
@@ -17,9 +17,11 @@ int main() {
 }
 ```
 
-There are two steps to passing a memory by reference in Calyx:
-1. Define the component in a manner such that it can accept a memory by reference.
-2. Pass the desired memory by reference.
+In Calyx, there are two steps to passing a cell by reference:
+1. Define the component in a manner such that it can accept a cell by reference.
+2. Pass the desired cell by reference.
+
+When we say cell, we mean any cell, including memories of various dimensions and registers.
 
 The language provides two ways of doing this.
 


### PR DESCRIPTION
The builder library did not allow registers to be passed by reference, and the docs were a little unclear as to whether registers could be passed by reference. This PR fixes those two things, and thereby closes #1616 