### PR TITLE
Builder: `seq_mem` requires an additional import

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -246,6 +246,7 @@ class ComponentBuilder:
         is_ref=False,
     ) -> CellBuilder:
         """Generate a SeqMemD1 cell."""
+        self.prog.import_("primitives/memories.futil")
         return self.cell(
             name, ast.Stdlib.seq_mem_d1(bitwidth, len, idx_size), is_external, is_ref
         )


### PR DESCRIPTION
It turns out that using `seq_mem` requires that the Calyx file import import `primitives/memories.futil`. The builder library now does this.

Thanks @andrewb1999!