### PR TITLE
Builder: registers by reference: patch

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -216,7 +216,7 @@ class ComponentBuilder:
 
     def reg(self, name: str, size: int, is_ref=False) -> CellBuilder:
         """Generate a StdReg cell."""
-        return self.cell(name, ast.Stdlib.register(size), is_ref)
+        return self.cell(name, ast.Stdlib.register(size), False, is_ref)
 
     def const(self, name: str, width: int, value: int) -> CellBuilder:
         """Generate a StdConstant cell."""


### PR DESCRIPTION
Turns out that, in #1622, I was inadvertently toggling with the `is_external` status, not the `is_ref` status. Now I pass False for `is_external` and actually obey the user's wish accurately.