### PR TITLE
Support inlining `ref` cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Don't require `@clk` and `@reset` ports in `comb` components
+- `inline` pass supports inlining `ref` cells
 
 
 ## 0.4.0

--- a/calyx-opt/src/analysis/control_ports.rs
+++ b/calyx-opt/src/analysis/control_ports.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 type PortMap = HashMap<ir::Id, Vec<RRC<ir::Port>>>;
-type Binding = Vec<(ir::Id, RRC<ir::Port>)>;
+type Binding = (Vec<(ir::Id, RRC<ir::Cell>)>, Vec<(ir::Id, RRC<ir::Port>)>);
 type InvokeMap = HashMap<ir::Id, Vec<Binding>>;
 
 /// Contains a mapping from name of [ir::CombGroup] to the ports read by the control program
@@ -15,7 +15,7 @@ type InvokeMap = HashMap<ir::Id, Vec<Binding>>;
 pub struct ControlPorts<const INVOKE_MAP: bool> {
     // Map name of combinational group to the ports read by the control program.
     cg_to_port: PortMap,
-    // Mapping from name of invoke instance to the port bindings.
+    // Mapping from name of invoke instance to the ref cells and port bindings.
     invoke_map: InvokeMap,
 }
 
@@ -61,6 +61,7 @@ impl<const INVOKE_MAP: bool> ControlPorts<INVOKE_MAP> {
         &mut self,
         inputs: &[(ir::Id, ir::RRC<ir::Port>)],
         outputs: &[(ir::Id, ir::RRC<ir::Port>)],
+        ref_cells: &[(ir::Id, ir::RRC<ir::Cell>)],
         comp: &ir::RRC<ir::Cell>,
         comb_group: &Option<ir::RRC<ir::CombGroup>>,
     ) {
@@ -86,7 +87,10 @@ impl<const INVOKE_MAP: bool> ControlPorts<INVOKE_MAP> {
             let name = comp.borrow().name();
             let bindings =
                 inputs.iter().chain(outputs.iter()).cloned().collect_vec();
-            self.invoke_map.entry(name).or_default().push(bindings);
+            self.invoke_map
+                .entry(name)
+                .or_default()
+                .push((ref_cells.to_vec(), bindings));
         }
     }
 
@@ -113,9 +117,10 @@ impl<const INVOKE_MAP: bool> ControlPorts<INVOKE_MAP> {
                 comp,
                 inputs,
                 outputs,
+                ref_cells,
                 ..
             }) => {
-                self.handle_invoke(inputs, outputs, comp, &None);
+                self.handle_invoke(inputs, outputs, ref_cells, comp, &None);
             }
         }
     }
@@ -128,9 +133,12 @@ impl<const INVOKE_MAP: bool> ControlPorts<INVOKE_MAP> {
                 comb_group,
                 inputs,
                 outputs,
+                ref_cells,
                 ..
             }) => {
-                self.handle_invoke(inputs, outputs, comp, comb_group);
+                self.handle_invoke(
+                    inputs, outputs, ref_cells, comp, comb_group,
+                );
             }
             ir::Control::If(ir::If {
                 cond,
@@ -193,12 +201,19 @@ impl<const INVOKE_MAP: bool> From<&ir::Control> for ControlPorts<INVOKE_MAP> {
             cp.invoke_map.values_mut().for_each(|v| {
                 *v = v
                     .drain(..)
-                    .unique_by(|binding| {
-                        binding
-                            .clone()
-                            .into_iter()
-                            .map(|(p, v)| (p, v.borrow().canonical()))
-                            .collect_vec()
+                    .unique_by(|(cells, ports)| {
+                        (
+                            cells
+                                .clone()
+                                .into_iter()
+                                .map(|(c, cell)| (c, cell.borrow().name()))
+                                .collect_vec(),
+                            ports
+                                .clone()
+                                .into_iter()
+                                .map(|(p, v)| (p, v.borrow().canonical()))
+                                .collect_vec(),
+                        )
                     })
                     .collect()
             });

--- a/calyx-opt/src/default_passes.rs
+++ b/calyx-opt/src/default_passes.rs
@@ -87,8 +87,6 @@ impl PassManager {
                 DeadAssignmentRemoval,
                 GroupToInvoke, // Creates Dead Groups potentially
                 InferShare,
-                DeadGroupRemoval, // Reduces the work of inliner
-                DeadCellRemoval,  // Required by inliner
                 ComponentInliner,
                 CombProp,
                 CompileRef, //Must run before cell-share, and before component-inliner

--- a/calyx-opt/src/default_passes.rs
+++ b/calyx-opt/src/default_passes.rs
@@ -87,6 +87,8 @@ impl PassManager {
                 DeadAssignmentRemoval,
                 GroupToInvoke, // Creates Dead Groups potentially
                 InferShare,
+                DeadGroupRemoval, // Reduces the work of inliner
+                DeadCellRemoval,  // Required by inliner
                 ComponentInliner,
                 CombProp,
                 CompileRef, //Must run before cell-share, and before component-inliner

--- a/calyx-opt/src/default_passes.rs
+++ b/calyx-opt/src/default_passes.rs
@@ -87,10 +87,10 @@ impl PassManager {
                 DeadAssignmentRemoval,
                 GroupToInvoke, // Creates Dead Groups potentially
                 InferShare,
-                CompileRef, //Must run before cell-share, and before component-inliner
                 ComponentInliner,
                 CombProp,
-                CellShare, // LiveRangeAnalaysis should handle comb groups
+                CompileRef, //Must run before cell-share, and before component-inliner
+                CellShare,  // LiveRangeAnalaysis should handle comb groups
                 SimplifyWithControl, // Must run before infer-static-timing
                 CompileInvoke, // creates dead comb groups
                 AttributePromotion,

--- a/calyx-opt/src/passes/component_iniliner.rs
+++ b/calyx-opt/src/passes/component_iniliner.rs
@@ -427,9 +427,17 @@ impl Visitor for ComponentInliner {
             }
 
             let comp_name = cell.type_name().unwrap();
-            let (cell_binds, _) = &invoke_bindings[&cell.name()][0];
             let cell_map =
-                cell_binds.iter().map(|(k, v)| (*k, v.clone())).collect();
+                if let Some(binding) = &invoke_bindings.get(&cell.name()) {
+                    let (cell_binds, _) = &binding[0];
+                    cell_binds.iter().map(|(k, v)| (*k, v.clone())).collect()
+                } else {
+                    log::info!(
+                        "no binding for `{}` which means instance is unused",
+                        cell.name()
+                    );
+                    HashMap::new()
+                };
             let (control, rewrites) = Self::inline_component(
                 &mut builder,
                 cell_map,

--- a/calyx-opt/src/passes/data_path_infer.rs
+++ b/calyx-opt/src/passes/data_path_infer.rs
@@ -37,10 +37,10 @@ impl DataPathInfer {
     /// Mark the cell associated with the port as a part of the control path.
     fn mark_port_control(&mut self, port: &ir::Port) {
         if Self::always_safe_src(port) || port.is_hole() {
-            log::info!("`{}': safe port", port.canonical());
+            log::debug!("`{}': safe port", port.canonical());
             return;
         }
-        log::info!("`{}': control port", port.canonical());
+        log::debug!("`{}': control port", port.canonical());
         self.control_cells.insert(port.get_parent_name());
     }
 

--- a/tests/passes/inliner/inline-ref.expect
+++ b/tests/passes/inliner/inline-ref.expect
@@ -1,0 +1,41 @@
+import "primitives/compile.futil";
+component foo(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    ref r = std_reg(32);
+    add = std_add(32);
+  }
+  wires {
+    group incr {
+      add.right = 32'd1;
+      add.left = r.out;
+      r.write_en = 1'd1;
+      r.in = add.out;
+      incr[done] = r.done;
+    }
+  }
+  control {
+    incr;
+  }
+}
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    r0 = std_reg(32);
+    @generated add = std_add(32);
+    @generated f_go = std_wire(1);
+    @generated f_clk = std_wire(1);
+    @generated f_reset = std_wire(1);
+    @generated f_done = std_wire(1);
+  }
+  wires {
+    group incr {
+      add.right = 32'd1;
+      add.left = r0.out;
+      r0.write_en = 1'd1;
+      r0.in = add.out;
+      incr[done] = r0.done;
+    }
+  }
+  control {
+    incr;
+  }
+}

--- a/tests/passes/inliner/inline-ref.futil
+++ b/tests/passes/inliner/inline-ref.futil
@@ -1,0 +1,32 @@
+// -p validate -p inline
+import "primitives/compile.futil";
+
+component foo() -> () {
+    cells {
+        ref r = std_reg(32);
+        add = std_add(32);
+    }
+    wires {
+        group incr {
+            r.in = add.out;
+            r.write_en = 1'd1;
+            add.left = r.out;
+            add.right = 32'd1;
+            incr[done] = r.done;
+        }
+    }
+    control {
+        incr;
+    }
+}
+
+component main () -> () {
+    cells {
+        @inline f = foo();
+        r0 = std_reg(32);
+    }
+    wires {}
+    control {
+        invoke f[r=r0]()();
+    }
+}


### PR DESCRIPTION
Enables `inliner` to inline programs instances with `ref` cells. The changes are straightforward since we can just add the `ref` cell bindings in the `CellRewriteMap` and have the rewriter handle rest of the complexity.

This also helps move the needle on #1649.