### PR TITLE
`comb-prop`: Disable rewrites when wire output is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 - Don't require `@clk` and `@reset` ports in `comb` components
 - `inline` pass supports inlining `ref` cells
+- `comb-prop`: disable rewrite from `wire.in = port` when the output of a wire is read.
 
 
 ## 0.4.0

--- a/calyx-ir/src/structure.rs
+++ b/calyx-ir/src/structure.rs
@@ -469,6 +469,26 @@ pub struct Assignment<T> {
 }
 
 impl<T> Assignment<T> {
+    /// Build a new unguarded assignment
+    pub fn new(dst: RRC<Port>, src: RRC<Port>) -> Self {
+        assert!(
+            dst.borrow().direction == Direction::Input,
+            "{} is not in input port",
+            dst.borrow().canonical()
+        );
+        assert!(
+            src.borrow().direction == Direction::Output,
+            "{} is not in output port",
+            src.borrow().canonical()
+        );
+        Self {
+            dst,
+            src,
+            guard: Box::new(Guard::True),
+            attributes: Attributes::default(),
+        }
+    }
+
     /// Apply function `f` to each port contained within the assignment and
     /// replace the port with the generated value if not None.
     pub fn for_each_port<F>(&mut self, mut f: F)

--- a/tests/passes/comb-prop/wire-dst-read.expect
+++ b/tests/passes/comb-prop/wire-dst-read.expect
@@ -1,0 +1,18 @@
+import "primitives/compile.futil";
+component main<"toplevel"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 32, @done done: 1) {
+  cells {
+    opt = std_wire(32);
+    r = std_reg(32);
+    r0 = std_reg(1);
+    r1 = std_reg(1);
+    r2 = std_reg(1);
+  }
+  wires {
+    r.in = opt.out;
+    r.write_en = 1'd1;
+    opt.in = r0.out ? 32'd10;
+    opt.in = r1.out ? 32'd20;
+    out = r2.out ? opt.out;
+  }
+  control {}
+}

--- a/tests/passes/comb-prop/wire-dst-read.futil
+++ b/tests/passes/comb-prop/wire-dst-read.futil
@@ -1,0 +1,22 @@
+// -p well-formed -p comb-prop
+import "primitives/compile.futil";
+component main<"toplevel"=1>() -> (out: 32) {
+  cells {
+    opt = std_wire(32);
+    r = std_reg(32);
+    // Stable conditions
+    r0 = std_reg(1);
+    r1 = std_reg(1);
+    r2 = std_reg(1);
+  }
+  wires {
+    r.in = opt.out;
+    r.write_en = 1'd1;
+
+    opt.in = r0.out ? 32'd10;
+    opt.in = r1.out ? 32'd20;
+
+    out = r2.out ? opt.out;
+  }
+  control {}
+}


### PR DESCRIPTION
Fixes #1646.