### PR TITLE
Queues: more magic numbers

### DIFF
--- a/calyx-py/calyx/queue_call.py
+++ b/calyx-py/calyx/queue_call.py
@@ -3,6 +3,7 @@ import calyx.builder as cb
 import calyx.builder_util as util
 
 MAX_CMDS = 15
+ANS_MEM_LEN = 10
 
 
 def insert_raise_err_if_i_eq_max_cmds(prog):
@@ -58,7 +59,7 @@ def insert_main(prog, queue):
     # - one ref register, `err`, which is raised if an error occurs.
 
     commands = main.seq_mem_d1("commands", 32, MAX_CMDS, 32, is_external=True)
-    ans_mem = main.seq_mem_d1("ans_mem", 32, 10, 32, is_external=True)
+    ans_mem = main.seq_mem_d1("ans_mem", 32, ANS_MEM_LEN, 32, is_external=True)
 
     # The two components we'll use:
     queue = main.cell("myqueue", queue)


### PR DESCRIPTION
The eDSL code for the three kinds of queues had a magic number: the capacity of the queues, set to 10 in the examples. This quick PR declares the value as a constant.

There was another magic constant, technically unrelated but coincidentally also set to 10: the number of spots in the user-facing answer memory. This is controlled not by the flavor of queue (`fifo.py`, `pifo.py`, or `pifo_tree.py`) but rather by the top-level runner generated using `queue_call.py`. This too has been clarified in this PR.