### PR TITLE
Builder: massage away magic width 32

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -462,7 +462,7 @@ class ComponentBuilder:
         add_cell = self.add(width, cellname)
         with self.group(f"{cellname}_group") as incr_group:
             add_cell.left = reg.out
-            add_cell.right = const(32, val)
+            add_cell.right = const(width, val)
             reg.write_en = 1
             reg.in_ = add_cell.out
             incr_group.done = reg.done
@@ -480,7 +480,7 @@ class ComponentBuilder:
         sub_cell = self.sub(width, cellname)
         with self.group(f"{cellname}_group") as decr_group:
             sub_cell.left = reg.out
-            sub_cell.right = const(32, val)
+            sub_cell.right = const(width, val)
             reg.write_en = 1
             reg.in_ = sub_cell.out
             decr_group.done = reg.done
@@ -599,7 +599,7 @@ class ComponentBuilder:
             load_grp.done = ans.done
         return load_grp
 
-    def add_store_in_reg(self, cellname, left, right, ans_reg=None):
+    def add_store_in_reg(self, left, right, cellname, width, ans_reg=None):
         """Inserts wiring into component `self` to compute `left` + `right` and
         store it in `ans_reg`.
         1. Within component `self`, creates a group called `cellname`_group.
@@ -608,8 +608,8 @@ class ComponentBuilder:
         4. Then puts the answer of the computation into `ans_reg`.
         4. Returns the summing group and the register.
         """
-        add_cell = self.add(32, cellname)
-        ans_reg = ans_reg or self.reg(f"reg_{cellname}", 32)
+        add_cell = self.add(width, cellname)
+        ans_reg = ans_reg or self.reg(f"reg_{cellname}", width)
         with self.group(f"{cellname}_group") as adder_group:
             add_cell.left = left
             add_cell.right = right

--- a/calyx-py/test/correctness/reduction_tree.py
+++ b/calyx-py/test/correctness/reduction_tree.py
@@ -23,9 +23,9 @@ def add_tree(prog):
     # Into the component `tree`, add the wiring for three adder groups that will
     # use the tree to perform their additions.
     # These need to be orchestrated in the control below.
-    add_l0_l1, left = tree.add_store_in_reg("add_l0_l1", leaf0, leaf1)
-    add_l2_l3, right = tree.add_store_in_reg("add_l2_l3", leaf2, leaf3)
-    add_l_r_nodes, root = tree.add_store_in_reg("add_l_r", left.out, right.out)
+    add_l0_l1, left = tree.add_store_in_reg(leaf0, leaf1, "add_l0_l1", 32)
+    add_l2_l3, right = tree.add_store_in_reg(leaf2, leaf3, "add_l2_l3", 32)
+    add_l_r_nodes, root = tree.add_store_in_reg(left.out, right.out, "add_l_r", 32)
 
     # Continuously output the value of the root register.
     # It is the invoker's responsibility to ensure that the tree is done


### PR DESCRIPTION
In a few places, I was accidentally assuming a width of 32 instead of getting the width as an argument. This is a quick fix for that.