### PR TITLE
Builder: catch up `gen_exp` to new features of eDSL

### DIFF
--- a/calyx-py/calyx/builder.py
+++ b/calyx-py/calyx/builder.py
@@ -459,12 +459,12 @@ class ComponentBuilder:
         """Inserts wiring into `self` to compute `left` - `right`."""
         return self.binary_use(left, right, self.sub(width, cellname, signed))
 
-    def bitwise_flip_reg(self, reg, width, signed=False, cellname=None):
+    def bitwise_flip_reg(self, reg, width, cellname=None):
         """Inserts wiring into `self` to bitwise-flip the contents of `reg`
         and put the result back into `reg`.
         """
         cellname = cellname or f"{reg.name}_not"
-        not_cell = self.not_(width, cellname, signed)
+        not_cell = self.not_(width, cellname)
         with self.group(f"{cellname}_group") as not_group:
             not_cell.in_ = reg.out
             reg.write_en = 1

--- a/calyx-py/calyx/gen_exp.py
+++ b/calyx-py/calyx/gen_exp.py
@@ -68,7 +68,7 @@ def generate_fp_pow_component(
         pow.in_ = mul.out
         execute_mul.done = pow.done
 
-    incr_count = comp.incr(count, width)
+    incr_count = comp.incr(count, width, 1, is_signed)
 
     cond = comp.lt_use(count.out, comp.this().integer_exp, width, is_signed)
 

--- a/calyx-py/calyx/gen_exp.py
+++ b/calyx-py/calyx/gen_exp.py
@@ -49,7 +49,6 @@ def generate_fp_pow_component(
             "mult_pipe", width, int_width, frac_width, signed=is_signed
         ),
     )
-    incr = comp.cell("incr", Stdlib.op("add", width, signed=is_signed))
 
     # groups
     with comp.group("init") as init:

--- a/calyx-py/calyx/gen_exp.py
+++ b/calyx-py/calyx/gen_exp.py
@@ -49,7 +49,6 @@ def generate_fp_pow_component(
             "mult_pipe", width, int_width, frac_width, signed=is_signed
         ),
     )
-    lt = comp.cell("lt", Stdlib.op("lt", width, signed=is_signed))
     incr = comp.cell("incr", Stdlib.op("add", width, signed=is_signed))
 
     # groups
@@ -70,27 +69,14 @@ def generate_fp_pow_component(
         pow.in_ = mul.out
         execute_mul.done = pow.done
 
-    with comp.group("incr_count") as incr_count:
-        incr.left = const(width, 1)
-        incr.right = count.out
-        count.in_ = incr.out
-        count.write_en = 1
-        incr_count.done = count.done
+    incr_count = comp.incr(count, width)
 
-    with comp.comb_group("cond") as cond:
-        lt.left = count.out
-        lt.right = comp.this().integer_exp
+    cond = comp.lt_use(count.out, comp.this().integer_exp, width, is_signed)
 
     with comp.continuous:
         comp.this().out = pow.out
 
-    comp.control += [
-        init,
-        while_with(
-            CellAndGroup(lt, cond),
-            par(execute_mul, incr_count),
-        ),
-    ]
+    comp.control += [init, while_with(cond, par(execute_mul, incr_count))]
 
     return comp.component
 
@@ -105,11 +91,12 @@ def generate_cells(
     comp.reg("int_x", width)
     comp.reg("frac_x", width)
     comp.reg("m", width)
-    comp.cell("and0", Stdlib.op("and", width, signed=False))
-    comp.cell("and1", Stdlib.op("and", width, signed=False))
-    comp.cell("rsh", Stdlib.op("rsh", width, signed=False))
+
+    comp.and_(width, "and0")
+    comp.and_(width, "and1")
+    comp.rsh(width, "rsh")
     if is_signed:
-        comp.cell("lt", Stdlib.op("lt", width, signed=is_signed))
+        comp.lt(width, "lt", is_signed)
 
     # constants
     for i in range(2, degree + 1):
@@ -541,21 +528,6 @@ def gen_reverse_sign(
         group.done = base_cell.done
 
 
-def gen_comb_lt(
-    comp: ComponentBuilder,
-    name: str,
-    lhs: ExprBuilder,
-    lt: CellBuilder,
-    const_cell: CellBuilder,
-):
-    """
-    Generates lhs < const_cell
-    """
-    with comp.comb_group(name):
-        lt.left = lhs
-        lt.right = const_cell.out
-
-
 # This appears to be unused. Brilliant.
 # TODO (griffin): Double check that this is unused and, if so, remove it.
 def gen_constant_cell(
@@ -590,7 +562,8 @@ def generate_fp_pow_full(
     comp.input("base", width)
     comp.input("exp_value", width)
     comp.output("out", width)
-    lt = comp.cell("lt", Stdlib.op("lt", width, is_signed))
+    lt = comp.lt(width, "lt", is_signed)
+
     div = comp.cell(
         "div",
         Stdlib.fixed_point_op(
@@ -632,7 +605,13 @@ def generate_fp_pow_full(
         )
         gen_reverse_sign(comp, "rev_base_sign", new_base_reg, mult, const_neg_one),
         gen_reverse_sign(comp, "rev_res_sign", res, mult, const_neg_one),
-        gen_comb_lt(comp, "base_lt_zero", comp.this().base, lt, const_zero),
+
+        base_lt_zero = comp.lt_use(
+            comp.this().base,
+            const_zero.out,
+            width,
+            is_signed,
+        )
 
     new_exp_val = comp.reg("new_exp_val", width)
     e = comp.comp_instance("e", "exp", check_undeclared=False)
@@ -649,48 +628,29 @@ def generate_fp_pow_full(
     with comp.continuous:
         comp.this().out = res.out
 
-    with comp.group("write_to_base_reg") as write_to_base_reg:
-        new_base_reg.write_en = 1
-        new_base_reg.in_ = comp.this().base
-        write_to_base_reg.done = new_base_reg.done
-
-    with comp.group("store_old_reg_val") as store_old_reg_val:
-        stored_base_reg.write_en = 1
-        stored_base_reg.in_ = new_base_reg.out
-        store_old_reg_val.done = stored_base_reg.done
-
-    with comp.group("write_e_to_res") as write_e_to_res:
-        res.write_en = 1
-        res.in_ = e.out
-        write_e_to_res.done = res.done
+    write_to_base_reg = comp.reg_store(
+        new_base_reg, comp.this().base, "write_to_base_reg"
+    )
+    store_old_reg_val = comp.reg_store(
+        stored_base_reg, new_base_reg.out, "store_old_reg_val"
+    )
+    write_e_to_res = comp.reg_store(res, e.out, "write_e_to_res")
 
     gen_reciprocal(comp, "set_base_reciprocal", new_base_reg, div, const_one)
     gen_reciprocal(comp, "set_res_reciprocal", res, div, const_one),
-    gen_comb_lt(
-        comp,
-        "base_lt_one",
-        stored_base_reg.out,
-        lt,
-        const_one,
-    )
+    base_lt_one = comp.lt_use(stored_base_reg.out, const_one.out, width, is_signed)
 
-    base_reciprocal = if_with(
-        CellAndGroup(lt, comp.get_group("base_lt_one")),
-        comp.get_group("set_base_reciprocal"),
-    )
+    base_reciprocal = if_with(base_lt_one, comp.get_group("set_base_reciprocal"))
 
-    res_reciprocal = if_with(
-        CellAndGroup(lt, comp.get_group("base_lt_one")),
-        comp.get_group("set_res_reciprocal"),
-    )
+    res_reciprocal = if_with(base_lt_one, comp.get_group("set_res_reciprocal"))
 
     if is_signed:
         base_rev = if_with(
-            CellAndGroup(lt, comp.get_group("base_lt_zero")),
+            base_lt_zero,
             comp.get_group("rev_base_sign"),
         )
         res_rev = if_with(
-            CellAndGroup(lt, comp.get_group("base_lt_zero")),
+            base_lt_zero,
             comp.get_group("rev_res_sign"),
         )
         pre_process = [base_rev, store_old_reg_val, base_reciprocal]
@@ -741,23 +701,9 @@ def build_base_not_e(degree, width, int_width, is_signed) -> Program:
     ret = main.mem_d1("ret", width, 1, 1, is_external=True)
     f = main.comp_instance("f", "fp_pow_full")
 
-    with main.group("read_base") as read_base:
-        b.addr0 = 0
-        base_reg.in_ = b.read_data
-        base_reg.write_en = 1
-        read_base.done = base_reg.done
-
-    with main.group("read_exp") as read_exp:
-        x.addr0 = 0
-        exp_reg.in_ = x.read_data
-        exp_reg.write_en = 1
-        read_exp.done = exp_reg.done
-
-    with main.group("write_to_memory") as write_to_memory:
-        ret.addr0 = 0
-        ret.write_en = 1
-        ret.write_data = f.out
-        write_to_memory.done = ret.done
+    read_base = main.mem_load_std_d1(b, 0, base_reg, "read_base")
+    read_exp = main.mem_load_std_d1(x, 0, exp_reg, "read_exp")
+    write_to_memory = main.mem_store_std_d1(ret, 0, f.out, "write_to_memory")
 
     main.control += [
         read_base,
@@ -796,11 +742,7 @@ def build_base_is_e(degree, width, int_width, is_signed) -> Program:
         t.write_en = 1
         init.done = t.done
 
-    with main.group("write_to_memory") as write_to_memory:
-        ret.addr0 = 0
-        ret.write_en = 1
-        ret.write_data = e.out
-        write_to_memory.done = ret.done
+    write_to_memory = main.mem_store_std_d1(ret, 0, e.out, "write_to_memory")
 
     main.control += [
         init,

--- a/tests/frontend/exp/degree-2-unsigned.expect
+++ b/tests/frontend/exp/degree-2-unsigned.expect
@@ -105,8 +105,8 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
     pow = std_reg(32);
     count = std_reg(32);
     mul = std_fp_mult_pipe(32, 16, 16);
-    lt = std_lt(32);
-    incr = std_add(32);
+    count_incr = std_add(32);
+    lt_1 = std_lt(32);
   }
   wires {
     group init {
@@ -124,26 +124,26 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group incr_count {
-      incr.left = 32'd1;
-      incr.right = count.out;
-      count.in = incr.out;
+    group count_incr_group {
+      count_incr.left = count.out;
+      count_incr.right = 32'd1;
       count.write_en = 1'd1;
-      incr_count[done] = count.done;
+      count.in = count_incr.out;
+      count_incr_group[done] = count.done;
     }
-    comb group cond {
-      lt.left = count.out;
-      lt.right = integer_exp;
+    comb group lt_1_group {
+      lt_1.left = count.out;
+      lt_1.right = integer_exp;
     }
     out = pow.out;
   }
   control {
     seq {
       init;
-      while lt.out with cond {
+      while lt_1.out with lt_1_group {
         par {
           execute_mul;
-          incr_count;
+          count_incr_group;
         }
       }
     }

--- a/tests/frontend/exp/degree-4-signed.expect
+++ b/tests/frontend/exp/degree-4-signed.expect
@@ -198,8 +198,8 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
     pow = std_reg(16);
     count = std_reg(16);
     mul = std_fp_smult_pipe(16, 8, 8);
-    lt = std_slt(16);
-    incr = std_sadd(16);
+    count_incr = std_add(16);
+    lt_1 = std_slt(16);
   }
   wires {
     group init {
@@ -217,26 +217,26 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group incr_count {
-      incr.left = 16'd1;
-      incr.right = count.out;
-      count.in = incr.out;
+    group count_incr_group {
+      count_incr.left = count.out;
+      count_incr.right = 16'd1;
       count.write_en = 1'd1;
-      incr_count[done] = count.done;
+      count.in = count_incr.out;
+      count_incr_group[done] = count.done;
     }
-    comb group cond {
-      lt.left = count.out;
-      lt.right = integer_exp;
+    comb group lt_1_group {
+      lt_1.left = count.out;
+      lt_1.right = integer_exp;
     }
     out = pow.out;
   }
   control {
     seq {
       init;
-      while lt.out with cond {
+      while lt_1.out with lt_1_group {
         par {
           execute_mul;
-          incr_count;
+          count_incr_group;
         }
       }
     }

--- a/tests/frontend/exp/degree-4-signed.expect
+++ b/tests/frontend/exp/degree-4-signed.expect
@@ -198,7 +198,7 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
     pow = std_reg(16);
     count = std_reg(16);
     mul = std_fp_smult_pipe(16, 8, 8);
-    count_incr = std_add(16);
+    count_incr = std_sadd(16);
     lt_1 = std_slt(16);
   }
   wires {

--- a/tests/frontend/exp/degree-4-unsigned.expect
+++ b/tests/frontend/exp/degree-4-unsigned.expect
@@ -169,8 +169,8 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
     pow = std_reg(16);
     count = std_reg(16);
     mul = std_fp_mult_pipe(16, 8, 8);
-    lt = std_lt(16);
-    incr = std_add(16);
+    count_incr = std_add(16);
+    lt_1 = std_lt(16);
   }
   wires {
     group init {
@@ -188,26 +188,26 @@ component fp_pow(base: 16, integer_exp: 16) -> (out: 16) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group incr_count {
-      incr.left = 16'd1;
-      incr.right = count.out;
-      count.in = incr.out;
+    group count_incr_group {
+      count_incr.left = count.out;
+      count_incr.right = 16'd1;
       count.write_en = 1'd1;
-      incr_count[done] = count.done;
+      count.in = count_incr.out;
+      count_incr_group[done] = count.done;
     }
-    comb group cond {
-      lt.left = count.out;
-      lt.right = integer_exp;
+    comb group lt_1_group {
+      lt_1.left = count.out;
+      lt_1.right = integer_exp;
     }
     out = pow.out;
   }
   control {
     seq {
       init;
-      while lt.out with cond {
+      while lt_1.out with lt_1_group {
         par {
           execute_mul;
-          incr_count;
+          count_incr_group;
         }
       }
     }

--- a/tests/frontend/relay/softmax.expect
+++ b/tests/frontend/relay/softmax.expect
@@ -619,7 +619,7 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
     pow = std_reg(32);
     count = std_reg(32);
     mul = std_fp_smult_pipe(32, 16, 16);
-    count_incr = std_sadd(32);
+    count_incr = std_add(32);
     lt_1 = std_slt(32);
   }
   wires {

--- a/tests/frontend/relay/softmax.expect
+++ b/tests/frontend/relay/softmax.expect
@@ -619,7 +619,7 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
     pow = std_reg(32);
     count = std_reg(32);
     mul = std_fp_smult_pipe(32, 16, 16);
-    count_incr = std_add(32);
+    count_incr = std_sadd(32);
     lt_1 = std_slt(32);
   }
   wires {

--- a/tests/frontend/relay/softmax.expect
+++ b/tests/frontend/relay/softmax.expect
@@ -619,8 +619,8 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
     pow = std_reg(32);
     count = std_reg(32);
     mul = std_fp_smult_pipe(32, 16, 16);
-    lt = std_slt(32);
-    incr = std_sadd(32);
+    count_incr = std_sadd(32);
+    lt_1 = std_slt(32);
   }
   wires {
     group init {
@@ -638,26 +638,26 @@ component fp_pow(base: 32, integer_exp: 32) -> (out: 32) {
       pow.in = mul.out;
       execute_mul[done] = pow.done;
     }
-    group incr_count {
-      incr.left = 32'd1;
-      incr.right = count.out;
-      count.in = incr.out;
+    group count_incr_group {
+      count_incr.left = count.out;
+      count_incr.right = 32'd1;
       count.write_en = 1'd1;
-      incr_count[done] = count.done;
+      count.in = count_incr.out;
+      count_incr_group[done] = count.done;
     }
-    comb group cond {
-      lt.left = count.out;
-      lt.right = integer_exp;
+    comb group lt_1_group {
+      lt_1.left = count.out;
+      lt_1.right = integer_exp;
     }
     out = pow.out;
   }
   control {
     seq {
       init;
-      while lt.out with cond {
+      while lt_1.out with lt_1_group {
         par {
           execute_mul;
-          incr_count;
+          count_incr_group;
         }
       }
     }


### PR DESCRIPTION
Just starting off the process of catching the clients of the eDSL up to the nice new features.

So far I've just caught one file up to speed, and I wanted to surface is so that we can see how the expect tests are breaking and what we want to do about it. In particular, I think the breaks at present are all "just" up to renaming of cells and groups. More broadly, we may want to talk about whether it even makes sense to expect-test the futil files, when in other examples we pipe the futil code directly to veri{something} without saving it in a txt file, and expect-test the output of veri{something}.

Once we agree on a plan, we can do more of this in other files, and/or see if there are other opportunities for cleanup.

One known oddity in the present eDSL examples is that groups are often inserted in one Python method and then retrieved, using their string names, in another. While this is okay, the latest eDSL examples (queues, arbiter, reduction tree) have adopted the style of defining a group and immediately saving its handle, and then using that handle for future orchestration. My personal preference is to do the latter, since I've been trained to fear stringly-typed things. Not a hill to die on, though!
