### PR TITLE
Remove the `futil` binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `inline` pass supports inlining `ref` cells
 - `comb-prop`: disable rewrite from `wire.in = port` when the output of a wire is read.
 - BREAKING: Remove `PortDef::into()` because it makes it easy to miss copying attributes.
+- Remove the `futil` binary.
 
 
 ## 0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,13 +72,14 @@ rust-version.workspace = true
 name = "calyx"
 path = "src/main.rs"
 
-[[bin]]
-name = "futil"
-path = "src/futil.rs"
-
 [features]
 default = []
-serialize = ["dep:serde_with", "calyx-ir/serialize", "dep:serde_sexpr", "serde/rc"]
+serialize = [
+    "dep:serde_with",
+    "calyx-ir/serialize",
+    "dep:serde_sexpr",
+    "serde/rc",
+]
 
 [dependencies]
 atty.workspace = true

--- a/src/futil.rs
+++ b/src/futil.rs
@@ -1,8 +1,0 @@
-use calyx::driver;
-use calyx_utils::CalyxResult;
-
-fn main() -> CalyxResult<()> {
-    driver::run_compiler()?;
-    log::warn!("The `futil` binary is deprecated. Please use `calyx` instead.");
-    Ok(())
-}


### PR DESCRIPTION
We've waited a couple of version to do this so hopefully people have transitioned to the `calyx` binary. The next major version of the compiler will not install the `futil` binary.