### PR TITLE
Install primitives in global folder

### DIFF
--- a/docs/compiler-as-library.md
+++ b/docs/compiler-as-library.md
@@ -13,7 +13,7 @@ The [`calyx` binary][calyx-crate] is published using Rust's crates.io repository
 
 1. The [`calyx-stdlib`][calyx-stdlib] package pulls in the sources of all the primitives using the Rust `include_str!` macro.
 2. The `calyx` binary defines a build script that depends on `calyx-stdlib` as a build dependency.
-3. During build time, the script loads the string representation of all the primitives files and writes them to `$OUT_DIR/primitives`. The `OUT_DIR` environment variable is defined by `cargo`.
+3. During build time, the script loads the string representation of all the primitives files and writes them to `$CALYX_PRIMITIVE_DIR/primitives`. If the variable is not set, the location defaults to `$HOME/.calyx`.
 4. If (3) succeeds, the build scripts defines the `CALYX_PRIMITIVES_LIB` environment variable which is used when compiling the `calyx` crate.
 5. During compilation, `calyx` embeds the value of this environment variable as the default argument to the `-l` flag. If the variable is not defined, the default value of the `-l` flag is `.`.
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -70,7 +70,7 @@ fn create_primitives() -> Result<path::PathBuf> {
             // Move the old primitives back
             println!("cargo:warning=Failed to write primitives directory. Restoring old directory");
             if let Some(old) = old_prims {
-                fs::rename(&old, &prims)?;
+                fs::rename(old, &prims)?;
             }
             return Err(e);
         }

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,10 +1,19 @@
-use std::fs;
-use std::io::Result;
-use std::path;
+use std::{env, fs, io::Result, path};
+
+/// Location to install the primitives library
+const PRIM_DIR: &str = "CALYX_PRIMITIVES_DIR";
 
 fn write_primitive() -> Result<path::PathBuf> {
     // Get the OUT_DIR environment variable from Cargo.
-    let base: path::PathBuf = std::env::var("OUT_DIR").unwrap().into();
+    let base: path::PathBuf = match env::var_os(PRIM_DIR) {
+        Some(v) => path::PathBuf::from(v),
+        None => {
+            println!("cargo:warning={PRIM_DIR} is not set. Using $HOME/.calyx as the default location for the primitives library.");
+            let mut path: path::PathBuf = env::var_os("HOME").unwrap().into();
+            path.push(".calyx");
+            path
+        }
+    };
     let mut prims = base.clone();
     prims.push("primitives");
     fs::create_dir_all(&prims)?;
@@ -29,10 +38,7 @@ fn main() {
         Ok(p) => {
             // The build succeeded. We're going to define the CALYX_PRIMITVE_DIR environment variable
             // so that it can be used by the compiler.
-            println!(
-                "cargo:rustc-env=CALYX_PRIMITIVES_DIR={}",
-                p.to_string_lossy()
-            );
+            println!("cargo:rustc-env={PRIM_DIR}={}", p.to_string_lossy());
         }
         Err(e) => {
             println!(


### PR DESCRIPTION
This installs the primitives in the folder specified by the `CALYX_PRIMITIVES_DIR` environment variable. If the variable is not set, we default to `$HOME/.calyx`. Not sure if this is the best place to install things but going with it for now.