### PR TITLE
[Cider] Patch ref-cell bug

### DIFF
--- a/interp/runt.toml
+++ b/interp/runt.toml
@@ -105,6 +105,20 @@ fud exec --from calyx --to jq \
 """
 
 [[tests]]
+name = "correctness ref cells"
+paths = ["../tests/correctness/ref-cells/*.futil"]
+cmd = """
+fud exec --from calyx --to jq \
+         --through interpreter-out \
+         -s calyx.flags "-p compile-invoke" \
+         -s verilog.data {}.data \
+         -s interpreter.flags " --raw" \
+         -s jq.expr ".main" \
+         -s jq.flags "--sort-keys " \
+         {} -q
+"""
+
+[[tests]]
 name = "numeric types correctness and parsing"
 paths = [
   "../tests/correctness/numeric-types/parsing/*.futil",

--- a/interp/src/interpreter/component_interpreter.rs
+++ b/interp/src/interpreter/component_interpreter.rs
@@ -411,6 +411,11 @@ impl Primitive for ComponentInterpreter {
         for (port, value) in input_vec {
             env.insert(port, value);
         }
+
+        if self.done_is_high() {
+            dbg!(self.full_name_clone);
+        }
+
         self.converge().unwrap();
 
         Ok(self.look_up_outputs())
@@ -421,9 +426,13 @@ impl Primitive for ComponentInterpreter {
         _inputs: &[(ir::Id, &crate::values::Value)],
     ) -> InterpreterResult<Vec<(ir::Id, crate::values::Value)>> {
         if self.interp.is_control() {
+            if !self.is_done() && !self.go_is_high() {
+                return Ok(self.look_up_outputs());
+            }
             assert!(
                 self.is_done(),
-                "Component interpreter reset before finishing"
+                "Component {} interpreter reset before finishing",
+                self.full_name_clone
             );
         }
 

--- a/interp/src/interpreter/component_interpreter.rs
+++ b/interp/src/interpreter/component_interpreter.rs
@@ -411,7 +411,6 @@ impl Primitive for ComponentInterpreter {
         for (port, value) in input_vec {
             env.insert(port, value);
         }
-
         self.converge().unwrap();
 
         Ok(self.look_up_outputs())

--- a/interp/src/interpreter/component_interpreter.rs
+++ b/interp/src/interpreter/component_interpreter.rs
@@ -412,10 +412,6 @@ impl Primitive for ComponentInterpreter {
             env.insert(port, value);
         }
 
-        if self.done_is_high() {
-            dbg!(self.full_name_clone);
-        }
-
         self.converge().unwrap();
 
         Ok(self.look_up_outputs())


### PR DESCRIPTION
Closes #1694 

This is a little dubious but the short version of the problem is that the chains trick the interpreter into thinking that one of the sub-cells is running, this adjusts the check to avoid making changes when the sub-component interpreters have already been reset but are not currently being driven.