### PR TITLE
bump runt version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ ADD . calyx
 WORKDIR /home/calyx
 RUN cargo build --all && \
     cargo install vcdump && \
-    cargo install runt --version $(grep ^ver runt.toml | awk '{print $3}' | tr -d '"')
+    cargo install runt --version 0.4.1
 
 # Install fud
 WORKDIR /home/calyx/fud


### PR DESCRIPTION
Bumps the version of `runt` in the dockerfile. This doesn't change our current testing infrastructure which uses the `calyx:0.3.0` container. Once we release a new version of the code, we can bump the testing container which will allow for #1698 to be merged.