### PR TITLE
Revert "Move `numeric_types.py` from `fud/verilator` to `calyx-py` (#…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,7 @@ jobs:
 
     - name: Run Python Tests
       working-directory: /home/calyx
-      run: pytest calyx-py/test/numeric_types.py
+      run: pytest fud/fud/stages/verilator/tests/numeric_types.py
 
   evaluation:
     name: Polybench Integration

--- a/calyx-py/calyx/gen_exp.py
+++ b/calyx-py/calyx/gen_exp.py
@@ -8,8 +8,9 @@ from calyx.py_ast import (
 )
 from calyx.utils import float_to_fixed_point
 from math import factorial, log2
-from calyx.numeric_types import FixedPoint
+from fud.stages.verilator import numeric_types
 from calyx.gen_ln import generate_ln
+
 from calyx.builder import (
     Builder,
     ComponentBuilder,
@@ -18,6 +19,7 @@ from calyx.builder import (
     if_with,
     invoke,
     CellBuilder,
+    ExprBuilder,
     const,
     HI,
     par,
@@ -50,7 +52,7 @@ def generate_fp_pow_component(
 
     # groups
     with comp.group("init") as init:
-        pow.in_ = FixedPoint(
+        pow.in_ = numeric_types.FixedPoint(
             "1.0", width, int_width, is_signed=is_signed
         ).unsigned_integer()
         pow.write_en = 1
@@ -103,12 +105,14 @@ def generate_cells(
     comp.const(
         "one",
         width,
-        FixedPoint("1.0", width, int_width, is_signed=is_signed).unsigned_integer(),
+        numeric_types.FixedPoint(
+            "1.0", width, int_width, is_signed=is_signed
+        ).unsigned_integer(),
     )
     comp.const(
         "e",
         width,
-        FixedPoint(
+        numeric_types.FixedPoint(
             str(float_to_fixed_point(2.7182818284, frac_width)),
             width,
             int_width,
@@ -120,7 +124,7 @@ def generate_cells(
         comp.const(
             "negative_one",
             width,
-            FixedPoint(
+            numeric_types.FixedPoint(
                 "-1.0", width, int_width, is_signed=is_signed
             ).unsigned_integer(),
         )
@@ -164,7 +168,7 @@ def generate_cells(
     # reciprocal factorials
     for i in range(2, degree + 1):
         fixed_point_value = float_to_fixed_point(1.0 / factorial(i), frac_width)
-        value = FixedPoint(
+        value = numeric_types.FixedPoint(
             str(fixed_point_value), width, int_width, is_signed=is_signed
         ).unsigned_integer()
         comp.const(f"reciprocal_factorial{i}", width, value)
@@ -536,7 +540,9 @@ def gen_constant_cell(
     return comp.const(
         name,
         width,
-        FixedPoint(value, width, int_width, is_signed=is_signed).unsigned_integer(),
+        numeric_types.FixedPoint(
+            value, width, int_width, is_signed=is_signed
+        ).unsigned_integer(),
     )
 
 
@@ -565,12 +571,16 @@ def generate_fp_pow_full(
     const_one = comp.const(
         "one",
         width,
-        FixedPoint("1.0", width, int_width, is_signed=is_signed).unsigned_integer(),
+        numeric_types.FixedPoint(
+            "1.0", width, int_width, is_signed=is_signed
+        ).unsigned_integer(),
     )
     const_zero = comp.const(
         "zero",
         width,
-        FixedPoint("0.0", width, int_width, is_signed=is_signed).unsigned_integer(),
+        numeric_types.FixedPoint(
+            "0.0", width, int_width, is_signed=is_signed
+        ).unsigned_integer(),
     )
     mult = comp.cell(
         "mult",
@@ -587,7 +597,7 @@ def generate_fp_pow_full(
         const_neg_one = comp.const(
             "neg_one",
             width,
-            FixedPoint(
+            numeric_types.FixedPoint(
                 "-1.0", width, int_width, is_signed=is_signed
             ).unsigned_integer(),
         )

--- a/calyx-py/calyx/gen_ln.py
+++ b/calyx-py/calyx/gen_ln.py
@@ -6,7 +6,7 @@ from calyx.py_ast import (
     Import,
 )
 from calyx.utils import float_to_fixed_point
-from calyx import numeric_types
+from fud.stages.verilator import numeric_types
 from calyx.gen_msb import gen_msb_calc
 
 from calyx.builder import Builder, ComponentBuilder, CellBuilder, HI, par, invoke

--- a/calyx-py/calyx/gen_msb.py
+++ b/calyx-py/calyx/gen_msb.py
@@ -1,11 +1,26 @@
 from typing import List
 from calyx.py_ast import (
+    Connect,
+    CompVar,
+    Cell,
+    Group,
+    ConstantPort,
+    CompPort,
     Stdlib,
     Component,
+    ThisPort,
+    HolePort,
+    PortDef,
+    SeqComp,
+    Enable,
+    While,
+    Control,
+    CombGroup,
 )
 from calyx.builder import (
     Builder,
     CellAndGroup,
+    ComponentBuilder,
     const,
     HI,
     while_with,

--- a/frontends/relay/relay_visitor.py
+++ b/frontends/relay/relay_visitor.py
@@ -24,7 +24,7 @@ from calyx.py_ast import (
     Component,
 )
 from calyx.utils import float_to_fixed_point
-from calyx import numeric_types
+from fud.stages.verilator import numeric_types
 from dahlia_impl import emit_components
 
 calyx_keywords_list = ["input"]

--- a/frontends/systolic-lang/convert-mems.py
+++ b/frontends/systolic-lang/convert-mems.py
@@ -1,6 +1,6 @@
 import argparse
 import json
-from calyx import numeric_types
+from fud.stages.verilator import numeric_types
 
 
 if __name__ == "__main__":

--- a/frontends/systolic-lang/gen_array_component.py
+++ b/frontends/systolic-lang/gen_array_component.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from gen_pe import pe, PE_NAME, BITWIDTH
-from calyx import builder as cb
+import calyx.builder as cb
 from calyx import py_ast
 
 # Global constant for the current bitwidth.

--- a/frontends/systolic-lang/gen_post_op.py
+++ b/frontends/systolic-lang/gen_post_op.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
-from calyx import builder as cb
+import calyx.builder as cb
 from calyx import py_ast
 from gen_array_component import NAME_SCHEME
 from gen_pe import BITWIDTH, INTWIDTH, FRACWIDTH
-from calyx import numeric_types
+from fud.stages.verilator import numeric_types
 from calyx.utils import float_to_fixed_point
 
 

--- a/fud/fud/errors.py
+++ b/fud/fud/errors.py
@@ -255,6 +255,16 @@ class SourceConversionNotDirectory(FudError):
         super().__init__(msg)
 
 
+class InvalidNumericType(FudError):
+    """
+    An error raised when an invalid numeric type is provided.
+    """
+
+    def __init__(self, msg):
+        msg = f"""Invalid Numeric Type: {msg}"""
+        super().__init__(msg)
+
+
 class Malformed(FudError):
     """
     An error raised when the input to a stage is malformed in some manner.

--- a/fud/fud/stages/interpreter.py
+++ b/fud/fud/stages/interpreter.py
@@ -3,7 +3,8 @@ from fud.stages import Stage, SourceType, Source
 from pathlib import Path
 import simplejson as sjson
 import numpy as np
-from calyx.numeric_types import FixedPoint, Bitnum, InvalidNumericType
+from fud.stages.verilator.numeric_types import FixedPoint, Bitnum
+from fud.errors import InvalidNumericType
 from fud.stages.verilator.json_to_dat import parse_fp_widths, float_to_fixed
 from fud.utils import shell, TmpDir, unwrap_or, transparent_shell
 from fud import config as cfg
@@ -87,9 +88,8 @@ class InterpreterStage(Stage):
 
     def _define_steps(self, input_data, builder, config):
         script = config["stages", self.name, "exec"]
-        data_path_exists: bool = config["stages", "verilog", "data"] or config.get(
-            ["stages", "mrxl", "data"]
-        )
+        data_path_exists: bool = (config["stages", "verilog", "data"] or
+                                  config.get(["stages", "mrxl", "data"]))
 
         cmd = [
             script,
@@ -118,9 +118,7 @@ class InterpreterStage(Stage):
             """
             return TmpDir()
 
-        @builder.step(
-            description="Dynamically retrieve the value of stages.verilog.data"
-        )
+        @builder.step(description="Dynamically retrieve the value of stages.verilog.data")
         def get_verilog_data() -> SourceType.Path:
             data_path = config.get(["stages", "verilog", "data"])
             path = Path(data_path) if data_path else None
@@ -199,7 +197,9 @@ class InterpreterStage(Stage):
         data_path = get_verilog_data()
 
         if data_path_exists:
-            convert_json_to_interp_json(tmpdir, data_path)
+            convert_json_to_interp_json(
+                tmpdir, data_path
+            )
 
         if self._is_data_converter():
             if data_path_exists:
@@ -213,7 +213,9 @@ class InterpreterStage(Stage):
             result = interpret(input_data, tmpdir)
 
             if "--raw" in cmd:
-                return parse_output(result, data_path, tmpdir)
+                return parse_output(
+                    result, data_path, tmpdir
+                )
             else:
                 return result
 

--- a/fud/fud/stages/verilator/json_to_dat.py
+++ b/fud/fud/stages/verilator/json_to_dat.py
@@ -1,8 +1,8 @@
 import simplejson as sjson
 import numpy as np
-from calyx.numeric_types import FixedPoint, Bitnum, InvalidNumericType
+from .numeric_types import FixedPoint, Bitnum
 from pathlib import Path
-from fud.errors import Malformed
+from fud.errors import InvalidNumericType, Malformed
 import logging as log
 
 

--- a/fud/fud/stages/verilator/numeric_types.py
+++ b/fud/fud/stages/verilator/numeric_types.py
@@ -5,18 +5,9 @@ from math import log2
 from fractions import Fraction
 from dataclasses import dataclass
 from decimal import Decimal, getcontext
+from fud.errors import InvalidNumericType
 import math
 import logging as log
-
-
-class InvalidNumericType(Exception):
-    """
-    An error raised when an invalid numeric type is provided.
-    """
-
-    def __init__(self, msg):
-        msg = f"""Invalid Numeric Type: {msg}"""
-        super().__init__(msg)
 
 
 @dataclass

--- a/fud/fud/stages/verilator/tables.py
+++ b/fud/fud/stages/verilator/tables.py
@@ -1,6 +1,6 @@
 from itertools import product
 from decimal import Decimal
-from calyx.numeric_types import FixedPoint
+from fud.stages.verilator.numeric_types import FixedPoint
 
 
 def compute_exp_frac_table(frac_width: int):

--- a/fud/fud/stages/verilator/tests/numeric_types.py
+++ b/fud/fud/stages/verilator/tests/numeric_types.py
@@ -1,5 +1,6 @@
 from random import randint
-from calyx.numeric_types import FixedPoint, Bitnum, InvalidNumericType
+from fud.stages.verilator.numeric_types import FixedPoint, Bitnum
+from fud.errors import InvalidNumericType
 from hypothesis import given, strategies as st  # type: ignore
 import numpy as np
 import pytest  # type: ignore

--- a/fud/fud/xclrun.py
+++ b/fud/fud/xclrun.py
@@ -36,7 +36,7 @@ import sys
 from typing import Mapping, Any, Dict
 from pathlib import Path
 from fud.stages.verilator.json_to_dat import parse_fp_widths, float_to_fixed
-from calyx.numeric_types import InvalidNumericType
+from fud.errors import InvalidNumericType
 
 
 def mem_to_buf(mem):
@@ -96,9 +96,8 @@ def run(xclbin: Path, data: Mapping[str, Any]) -> Dict[str, Any]:
     # Collect the output data.
     for buf in buffers:
         buf.sync_from_device()
-    mems = {
-        name: buf_to_mem(data[name]["format"], buf) for name, buf in zip(data, buffers)
-    }
+    mems = {name: buf_to_mem(data[name]["format"], buf)
+            for name, buf in zip(data, buffers)}
 
     # PYNQ recommends explicitly freeing its resources.
     del buffers
@@ -119,16 +118,14 @@ def _dtype(fmt) -> np.dtype:
 def xclrun():
     # Parse command-line arguments.
     parser = argparse.ArgumentParser(
-        description="run a compiled XRT program",
+        description='run a compiled XRT program',
     )
-    parser.add_argument("bin", metavar="XCLBIN", help="the .xclbin binary file to run")
-    parser.add_argument("data", metavar="DATA", help="the JSON input data file")
-    parser.add_argument(
-        "--out",
-        "-o",
-        metavar="FILE",
-        help="write JSON results to a file instead of stdout",
-    )
+    parser.add_argument('bin', metavar='XCLBIN',
+                        help='the .xclbin binary file to run')
+    parser.add_argument('data', metavar='DATA',
+                        help='the JSON input data file')
+    parser.add_argument('--out', '-o', metavar='FILE',
+                        help='write JSON results to a file instead of stdout')
     args = parser.parse_args()
 
     # Load the input JSON data file.
@@ -139,7 +136,7 @@ def xclrun():
     out_data = run(Path(args.bin), in_data)
 
     # Dump the output JSON data.
-    outfile = open(args.out, "w") if args.out else sys.stdout
+    outfile = open(args.out, 'w') if args.out else sys.stdout
     sjson.dump(out_data, outfile, indent=2, use_decimal=True)
 
 


### PR DESCRIPTION
…1715)"

This reverts commit 1edf3eccafc2fe57d3712771132bc65eb71baa57.

I committed it without realizing that docker would be messed up. 