### PR TITLE
Improve Static Inline

### DIFF
--- a/calyx-opt/src/passes/static_inliner.rs
+++ b/calyx-opt/src/passes/static_inliner.rs
@@ -262,7 +262,7 @@ impl StaticInliner {
                 if *latency == 1 {
                     // Special case: if latency = 1, we don't need a register
                     // to hold the value of the cond port.
-                    let cond_port_guard = ir::Guard::Port(Rc::clone(&port));
+                    let cond_port_guard = ir::Guard::Port(Rc::clone(port));
                     let not_cond_port_guard =
                         ir::Guard::Not(Box::new(cond_port_guard.clone()));
                     tgroup_assigns.iter_mut().for_each(|assign| {


### PR DESCRIPTION
When looking into systolic array resource usage, I realized that inlining: 

```
static if port {
  // one cycle body
} 
```
Was generating a register to hold `port`'s value. If it is more than one cycle, we need this register, in case `port` changes during execution of the `body`. But we shouldn't generate this register if the body is one cycle, since we don't need this. This was generating a ton of unnecesary registers in the systolic array. 