### PR TITLE
Move `std_mult_pipe` to `pipelined_mult`. Add `std_mult_seq`.

### DIFF
--- a/primitives/binary_operators.futil
+++ b/primitives/binary_operators.futil
@@ -86,18 +86,6 @@ extern "binary_operators.sv" {
   /// =================== Unsigned, Bitnum =========================
   /// Other unsigned bitnum primitives are found in the core library,
   /// since they're required for FSM encoding.
-
-  primitive std_mult_pipe<"state_share"=1>[WIDTH](
-    @clk clk: 1,
-    @reset reset: 1,
-    @write_together(1) @static(3) @go go: 1,
-    @write_together(1) @data left: WIDTH,
-    @write_together(1) @data right: WIDTH
-  ) -> (
-    @stable out: WIDTH,
-    @done done: 1
-  );
-
   primitive std_mult_seq<"state_share"=1>[WIDTH](
     @clk clk: 1,
     @reset reset: 1,

--- a/primitives/binary_operators.futil
+++ b/primitives/binary_operators.futil
@@ -86,7 +86,7 @@ extern "binary_operators.sv" {
   /// =================== Unsigned, Bitnum =========================
   /// Other unsigned bitnum primitives are found in the core library,
   /// since they're required for FSM encoding.
-  primitive std_mult_seq<"state_share"=1>[WIDTH](
+  primitive std_mult_pipe<"state_share"=1>[WIDTH](
     @clk clk: 1,
     @reset reset: 1,
     @write_together(1) @static(3) @go go: 1,

--- a/primitives/binary_operators.futil
+++ b/primitives/binary_operators.futil
@@ -98,6 +98,17 @@ extern "binary_operators.sv" {
     @done done: 1
   );
 
+  primitive std_mult_seq<"state_share"=1>[WIDTH](
+    @clk clk: 1,
+    @reset reset: 1,
+    @write_together(1) @static(3) @go go: 1,
+    @write_together(1) @data left: WIDTH,
+    @write_together(1) @data right: WIDTH
+  ) -> (
+    @stable out: WIDTH,
+    @done done: 1
+  );
+
   primitive std_div_pipe<"state_share"=1>[WIDTH](
     @clk clk: 1,
     @reset reset: 1,

--- a/primitives/binary_operators.sv
+++ b/primitives/binary_operators.sv
@@ -374,33 +374,20 @@ module std_mult_pipe #(
     output logic [WIDTH-1:0] out,
     output logic             done
 );
-  //std_fp_mult_pipe #(
-  //  .WIDTH(WIDTH),
-  //  .INT_WIDTH(WIDTH),
-  //  .FRAC_WIDTH(0),
-  //  .SIGNED(0)
-  //) comp (
-  //  .reset(reset),
-  //  .clk(clk),
-  // .done(done),
-  //  .go(go),
-  //  .left(left),
-  //  .right(right),
-  //  .out(out)
-  //);
-
-  always_ff @(posedge clk) begin
-    if (reset) begin
-        out <= 'd0;
-        done <= 1'b0;
-    end else if (go) begin
-        done <= 1'b1;
-        out <= left * right;
-    end else begin
-        done <= 1'b0;
-    end
-end
-
+  std_fp_mult_pipe #(
+    .WIDTH(WIDTH),
+    .INT_WIDTH(WIDTH),
+    .FRAC_WIDTH(0),
+    .SIGNED(0)
+  ) comp (
+    .reset(reset),
+    .clk(clk),
+   .done(done),
+    .go(go),
+    .left(left),
+    .right(right),
+    .out(out)
+  );
 endmodule
 
 module std_mult_seq #(

--- a/primitives/binary_operators.sv
+++ b/primitives/binary_operators.sv
@@ -374,6 +374,46 @@ module std_mult_pipe #(
     output logic [WIDTH-1:0] out,
     output logic             done
 );
+  //std_fp_mult_pipe #(
+  //  .WIDTH(WIDTH),
+  //  .INT_WIDTH(WIDTH),
+  //  .FRAC_WIDTH(0),
+  //  .SIGNED(0)
+  //) comp (
+  //  .reset(reset),
+  //  .clk(clk),
+  // .done(done),
+  //  .go(go),
+  //  .left(left),
+  //  .right(right),
+  //  .out(out)
+  //);
+
+  always_ff @(posedge clk) begin
+    if (reset) begin
+        out <= 'd0;
+        done <= 1'b0;
+    end else if (go) begin
+        done <= 1'b1;
+        out <= left * right;
+    end else begin
+        done <= 1'b0;
+    end
+end
+
+endmodule
+
+module std_mult_seq #(
+    parameter WIDTH = 32
+) (
+    input  logic [WIDTH-1:0] left,
+    input  logic [WIDTH-1:0] right,
+    input  logic             reset,
+    input  logic             go,
+    input  logic             clk,
+    output logic [WIDTH-1:0] out,
+    output logic             done
+);
   std_fp_mult_pipe #(
     .WIDTH(WIDTH),
     .INT_WIDTH(WIDTH),

--- a/primitives/binary_operators.sv
+++ b/primitives/binary_operators.sv
@@ -363,7 +363,7 @@ module std_fp_slt #(
 endmodule
 
 /// =================== Unsigned, Bitnum =========================
-module std_mult_seq #(
+module std_mult_pipe #(
     parameter WIDTH = 32
 ) (
     input  logic [WIDTH-1:0] left,

--- a/primitives/binary_operators.sv
+++ b/primitives/binary_operators.sv
@@ -363,33 +363,6 @@ module std_fp_slt #(
 endmodule
 
 /// =================== Unsigned, Bitnum =========================
-module std_mult_pipe #(
-    parameter WIDTH = 32
-) (
-    input  logic [WIDTH-1:0] left,
-    input  logic [WIDTH-1:0] right,
-    input  logic             reset,
-    input  logic             go,
-    input  logic             clk,
-    output logic [WIDTH-1:0] out,
-    output logic             done
-);
-  std_fp_mult_pipe #(
-    .WIDTH(WIDTH),
-    .INT_WIDTH(WIDTH),
-    .FRAC_WIDTH(0),
-    .SIGNED(0)
-  ) comp (
-    .reset(reset),
-    .clk(clk),
-   .done(done),
-    .go(go),
-    .left(left),
-    .right(right),
-    .out(out)
-  );
-endmodule
-
 module std_mult_seq #(
     parameter WIDTH = 32
 ) (

--- a/primitives/memories.sv
+++ b/primitives/memories.sv
@@ -80,7 +80,7 @@ module seq_mem_d1 #(
     always_comb begin
       if (read_en)
         if (addr0 >= SIZE)
-          $display(
+          $error(
             "std_mem_d1: Out of bounds access\n",
             "addr0: %0d\n", addr0,
             "SIZE: %0d", SIZE

--- a/primitives/memories.sv
+++ b/primitives/memories.sv
@@ -80,7 +80,7 @@ module seq_mem_d1 #(
     always_comb begin
       if (read_en)
         if (addr0 >= SIZE)
-          $error(
+          $display(
             "std_mem_d1: Out of bounds access\n",
             "addr0: %0d\n", addr0,
             "SIZE: %0d", SIZE

--- a/primitives/pipelined.futil
+++ b/primitives/pipelined.futil
@@ -1,12 +1,12 @@
 extern "pipelined.sv" {
     // A latency-sensitive multiplier that takes 4 cycles to compute its result.
-    static<4> primitive pipelined_mult (
+    static<4> primitive pipelined_mult[WIDTH] (
         @clk clk: 1,
         @reset reset: 1,
-        left: 32,
-        right: 32
+        left: WIDTH,
+        right: WIDTH
     ) -> (
-        out: 32
+        out: WIDTH
     );
 
     // A latency-sensitive multiplier that takes 4 cycles to compute its result.
@@ -20,4 +20,5 @@ extern "pipelined.sv" {
     ) -> (
         out: WIDTH
     );
+
 }

--- a/primitives/pipelined.sv
+++ b/primitives/pipelined.sv
@@ -1,34 +1,34 @@
 
 /// This is mostly used for testing the static guarantees currently.
 /// A realistic implementation would probably take four cycles.
-module pipelined_mult (
+module pipelined_mult #(
+    parameter WIDTH = 32
+) (
     input wire clk,
     input wire reset,
     // inputs
-    input wire [31:0] left,
-    input wire [31:0] right,
+    input wire [WIDTH-1:0] left,
+    input wire [WIDTH-1:0] right,
     // The input has been committed
-    output wire [31:0] out
+    output wire [WIDTH-1:0] out
 );
 
-logic [31:0] lt, rt, buff0, buff1, buff2, tmp_prod;
+logic [WIDTH-1:0] buff0, buff1, buff2, buff3, tmp_prod;
 
-assign out = buff2;
-assign tmp_prod = lt * rt;
+assign out = buff3;
+assign tmp_prod = left * right;
 
 always_ff @(posedge clk) begin
     if (reset) begin
-        lt <= 0;
-        rt <= 0;
         buff0 <= 0;
         buff1 <= 0;
         buff2 <= 0;
+        buff3 <= 0;
     end else begin
-        lt <= left;
-        rt <= right;
         buff0 <= tmp_prod;
         buff1 <= buff0;
         buff2 <= buff1;
+        buff3 <= buff2;
     end
 end
 


### PR DESCRIPTION
I am trying to get these primitives settled into the main branch so more people can use the AMC/LoopSchedule tool flow. These are the primitives that work with @andrewb1999 's LoopSchedule code.

Is this how we want to deal with multi-cycle operators? Have a `seq` version in `binary_operators.futil` and a pipelined version in `pipelined.futil`?