### PR TITLE
Promotion Heuristic

### DIFF
--- a/calyx-ir/src/control.rs
+++ b/calyx-ir/src/control.rs
@@ -589,6 +589,18 @@ impl Control {
         let empty = Control::empty();
         std::mem::replace(self, empty)
     }
+
+    /// Replaces &mut self with an empty control statement, and returns StaticControl
+    /// of self. Note that this only works on Control that is static
+    pub fn take_static_control(&mut self) -> StaticControl {
+        let empty = Control::empty();
+        let control = std::mem::replace(self, empty);
+        if let Control::Static(static_control) = control {
+            static_control
+        } else {
+            unreachable!("Called take_static_control on non-static control")
+        }
+    }
 }
 
 impl StaticControl {

--- a/tests/passes/static-promotion/promote-nested.expect
+++ b/tests/passes/static-promotion/promote-nested.expect
@@ -1,0 +1,54 @@
+import "primitives/core.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    a = std_reg(2);
+    b = std_reg(2);
+    c = std_reg(2);
+    cond_reg = std_reg(1);
+    r0 = std_reg(2);
+  }
+  wires {
+    group no_upgrade {
+      r0.write_en = 1'd1;
+      no_upgrade[done] = r0.done ? 1'd1;
+    }
+    static<1> group A0 {
+      a.in = 2'd0;
+      a.write_en = 1'd1;
+    }
+    static<1> group B0 {
+      b.in = 2'd1;
+      b.write_en = 1'd1;
+    }
+    static<1> group C0 {
+      c.in = 2'd2;
+      c.write_en = 1'd1;
+    }
+  }
+  control {
+    seq {
+      @compactable static<4> seq  {
+        static<1> par {
+          A0;
+          B0;
+        }
+        @compactable static<2> seq  {
+          C0;
+          C0;
+        }
+        static<1> par {
+          A0;
+          B0;
+        }
+      }
+      no_upgrade;
+      static repeat 2 {
+        @compactable static<3> seq  {
+          A0;
+          B0;
+          C0;
+        }
+      }
+    }
+  }
+}

--- a/tests/passes/static-promotion/promote-nested.futil
+++ b/tests/passes/static-promotion/promote-nested.futil
@@ -1,0 +1,59 @@
+// -p well-formed -p static-promotion -p dead-group-removal -x static-promotion:threshold=5
+
+import "primitives/core.futil";
+
+component main() -> () {
+  cells {
+    a = std_reg(2);
+    b = std_reg(2);
+    c = std_reg(2);
+    cond_reg = std_reg(1);
+    r0 = std_reg(2);
+  }
+
+  wires {
+    group A {
+      a.in = 2'd0;
+      a.write_en = 1'b1;
+      A[done] = a.done;
+    }
+
+    group B {
+      b.in = 2'd1;
+      b.write_en = 1'b1;
+      B[done] = b.done;
+    }
+
+    group C {
+      c.in = 2'd2;
+      c.write_en = 1'b1;
+      C[done] = c.done;
+    }
+
+    group no_upgrade {
+      r0.write_en = 1'd1;
+      no_upgrade[done] = r0.done ? 1'd1;
+    }
+  }
+
+  control {
+    seq {
+      seq {
+        par {A; B;}
+        seq {C; C;}
+        par {A; B;}
+      }
+      no_upgrade;
+      @bound(2) while cond_reg.out {
+        seq {
+          A;
+          B;
+          C;
+        }
+      }
+    }
+
+
+
+  }
+}

--- a/tests/passes/static-promotion/threshold.expect
+++ b/tests/passes/static-promotion/threshold.expect
@@ -1,0 +1,33 @@
+import "primitives/core.futil";
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    a = std_reg(2);
+    b = std_reg(2);
+    c = std_reg(2);
+  }
+  wires {
+    group A<"promote_static"=1> {
+      a.in = 2'd0;
+      a.write_en = 1'd1;
+      A[done] = a.done;
+    }
+    group B<"promote_static"=1> {
+      b.in = 2'd1;
+      b.write_en = 1'd1;
+      B[done] = b.done;
+    }
+    group C<"promote_static"=1> {
+      c.in = 2'd2;
+      c.write_en = 1'd1;
+      C[done] = c.done;
+    }
+  }
+  control {
+    @promote_static(4) seq {
+      @promote_static A;
+      @promote_static B;
+      @promote_static C;
+      @promote_static C;
+    }
+  }
+}

--- a/tests/passes/static-promotion/threshold.futil
+++ b/tests/passes/static-promotion/threshold.futil
@@ -1,0 +1,36 @@
+// -p well-formed -p static-promotion -p dead-group-removal -x static-promotion:threshold=4
+
+import "primitives/core.futil";
+
+component main() -> () {
+  cells {
+    a = std_reg(2);
+    b = std_reg(2);
+    c = std_reg(2);
+  }
+
+  wires {
+    group A {
+      a.in = 2'd0;
+      a.write_en = 1'b1;
+      A[done] = a.done;
+    }
+
+    group B {
+      b.in = 2'd1;
+      b.write_en = 1'b1;
+      B[done] = b.done;
+    }
+
+    group C {
+      c.in = 2'd2;
+      c.write_en = 1'b1;
+      C[done] = c.done;
+    }
+  }
+
+  control {
+    // No promotion because size must be *greater* than the threshold
+    seq { A; B; C; C;}
+  }
+}

--- a/tests/passes/static-promotion/upgrade-bound.expect
+++ b/tests/passes/static-promotion/upgrade-bound.expect
@@ -21,7 +21,7 @@ static<15> component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done don
     }
   }
   control {
-    @bound(5) static repeat 5 {
+    static repeat 5 {
       @compactable static<3> seq  {
         A0;
         B0;


### PR DESCRIPTION
Implements heuristic for static promotion. Can pass `-x static-promotion:threshold=n` to set a "threshold" of n. The threshold is how big the static island needs to be for us to promote it. We calculate the "size" of a potential static island by counting number of groups and the number of if statements/while loops too. To be more precise, the "size" function is calculated as: (# enables) + 2 * (# if ports + while while ports). But I am open to changing it. I think it should try to approximate the complexity of the dynamic FSM that would be produced if we choose not to promote. 