### PR TITLE
Share cells in more situations

### DIFF
--- a/calyx-opt/src/analysis/live_range_analysis.rs
+++ b/calyx-opt/src/analysis/live_range_analysis.rs
@@ -863,7 +863,7 @@ impl LiveRangeAnalysis {
             .collect();
 
         let written_in_group =
-            comb_group_info.as_ref().is_some_and(|comb_group| {
+            comb_group_info.as_ref().map_or(false, |comb_group| {
                 ReadWriteSet::must_write_set(
                     comb_group.borrow().assignments.iter(),
                 )

--- a/calyx-opt/src/analysis/live_range_analysis.rs
+++ b/calyx-opt/src/analysis/live_range_analysis.rs
@@ -862,13 +862,15 @@ impl LiveRangeAnalysis {
             })
             .collect();
 
-        let written_in_group =
-            comb_group_info.as_ref().map_or(false, |comb_group| {
+        let written_in_group = comb_group_info
+            .as_ref()
+            .map(|comb_group| {
                 ReadWriteSet::must_write_set(
                     comb_group.borrow().assignments.iter(),
                 )
                 .any(|cell| Rc::ptr_eq(comp, &cell))
-            });
+            })
+            .unwrap_or_default();
 
         let comp_is_written = (!inputs.is_empty() || written_in_group)
             && shareable_components.is_shareable_component(comp);

--- a/calyx-opt/src/analysis/live_range_analysis.rs
+++ b/calyx-opt/src/analysis/live_range_analysis.rs
@@ -862,7 +862,15 @@ impl LiveRangeAnalysis {
             })
             .collect();
 
-        let comp_is_written = !inputs.is_empty()
+        let written_in_group =
+            comb_group_info.as_ref().is_some_and(|comb_group| {
+                ReadWriteSet::must_write_set(
+                    comb_group.borrow().assignments.iter(),
+                )
+                .any(|cell| Rc::ptr_eq(comp, &cell))
+            });
+
+        let comp_is_written = (!inputs.is_empty() || written_in_group)
             && shareable_components.is_shareable_component(comp);
         if comp_is_written {
             write_set.insert((

--- a/calyx-opt/src/default_passes.rs
+++ b/calyx-opt/src/default_passes.rs
@@ -89,9 +89,10 @@ impl PassManager {
                 InferShare,
                 ComponentInliner,
                 CombProp,
-                CellShare, // LiveRangeAnalaysis should handle comb groups
+                DeadCellRemoval, // Clean up dead wires left by CombProp
+                CellShare,       // LiveRangeAnalaysis should handle comb groups
                 SimplifyWithControl, // Must run before compile-invoke
-                CompileInvoke, // creates dead comb groups
+                CompileInvoke,   // creates dead comb groups
                 AttributePromotion,
                 StaticPromotion,
                 ScheduleCompaction,

--- a/tests/passes/cell-share/empty-invoke.expect
+++ b/tests/passes/cell-share/empty-invoke.expect
@@ -1,0 +1,58 @@
+import "primitives/core.futil";
+component write_one<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (out: 32, @done done: 1) {
+  cells {
+    @data x = std_reg(32);
+  }
+  wires {
+    group invoke0<"promote_static"=1> {
+      x.write_en = 1'd1;
+      invoke0[done] = x.done;
+      x.in = 32'd1;
+    }
+    out = x.out;
+  }
+  control {
+    @promote_static invoke0;
+  }
+}
+component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    @external @data mem = std_mem_d1(32, 2, 1);
+    @data x = write_one();
+  }
+  wires {
+    group invoke0 {
+      x.go = 1'd1;
+      invoke0[done] = x.done;
+    }
+    group invoke1 {
+      x.go = 1'd1;
+      invoke1[done] = x.done;
+    }
+    group invoke2<"promote_static"=1> {
+      mem.write_en = 1'd1;
+      invoke2[done] = mem.done;
+      mem.addr0 = 1'd0;
+      mem.write_data = x.out;
+    }
+    group invoke3 {
+      x.go = 1'd1;
+      invoke3[done] = x.done;
+    }
+    group invoke4<"promote_static"=1> {
+      mem.write_en = 1'd1;
+      invoke4[done] = mem.done;
+      mem.addr0 = 1'd1;
+      mem.write_data = x.out;
+    }
+  }
+  control {
+    seq {
+      invoke0;
+      invoke1;
+      @promote_static invoke2;
+      invoke3;
+      @promote_static invoke4;
+    }
+  }
+}

--- a/tests/passes/cell-share/empty-invoke.futil
+++ b/tests/passes/cell-share/empty-invoke.futil
@@ -1,0 +1,33 @@
+// -p pre-opt -p post-opt
+import "primitives/core.futil";
+
+component write_one() -> (out: 32) {
+  cells {
+    x = std_reg(32);
+  }
+  wires {
+    out = x.out;
+  }
+  control {
+    invoke x(in = 32'd1)();
+  }
+}
+
+component main() -> () {
+  cells {
+    @external mem = std_mem_d1(32, 2, 1);
+    // these should be shared
+    x = write_one();
+    y = write_one();
+  }
+  wires {}
+  control {
+    seq {
+      invoke x()();
+      invoke y()(); // x is dead here
+      invoke mem(addr0 = 1'd0, write_data = y.out)();
+      invoke x()();
+      invoke mem(addr0 = 1'd1, write_data = x.out)();
+    }
+  }
+}

--- a/tests/passes/cell-share/inline.expect
+++ b/tests/passes/cell-share/inline.expect
@@ -1,0 +1,66 @@
+import "primitives/core.futil";
+component my_reg<"state_share"=1>(@data in: 32, @go go: 1, @clk clk: 1, @reset reset: 1) -> (@stable out: 32, @done done: 1) {
+  cells {
+    @data r = std_reg(32);
+  }
+  wires {
+    group invoke0<"promote_static"=1> {
+      r.write_en = 1'd1;
+      invoke0[done] = r.done;
+      r.in = in;
+    }
+    out = r.out;
+  }
+  control {
+    @promote_static invoke0;
+  }
+}
+static<4> component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
+  cells {
+    @external @data mem = std_mem_d1(32, 2, 1);
+    @generated r = std_reg(32);
+  }
+  wires {
+    static<1> group invoke00 {
+      r.write_en = 1'd1;
+      r.in = 32'd0;
+    }
+    static<1> group invoke10 {
+      mem.write_en = 1'd1;
+      mem.addr0 = 1'd0;
+      mem.write_data = r.out;
+    }
+    static<1> group invoke20 {
+      r.write_en = 1'd1;
+      r.in = 32'd1;
+    }
+    static<1> group invoke30 {
+      mem.write_en = 1'd1;
+      mem.addr0 = 1'd1;
+      mem.write_data = r.out;
+    }
+    static<1> group no-op {
+    }
+    static<2> group no-op0 {
+    }
+    static<3> group no-op1 {
+    }
+  }
+  control {
+    static<4> par {
+      invoke00;
+      static<2> seq  {
+        no-op;
+        invoke10;
+      }
+      static<3> seq  {
+        no-op0;
+        invoke20;
+      }
+      static<4> seq  {
+        no-op1;
+        invoke30;
+      }
+    }
+  }
+}

--- a/tests/passes/cell-share/inline.futil
+++ b/tests/passes/cell-share/inline.futil
@@ -1,0 +1,31 @@
+// -p pre-opt -p post-opt
+import "primitives/core.futil";
+
+component my_reg<"state_share"=1>(@data in: 32) -> (@stable out: 32) {
+  cells {
+    r = std_reg(32);
+  }
+  wires {
+    out = r.out;
+  }
+  control {
+    invoke r(in = in)();
+  }
+}
+
+component main() -> () {
+  cells {
+    @external mem = std_mem_d1(32, 2, 1);
+    @inline r0 = my_reg();
+    @inline r1 = my_reg();
+  }
+  wires {}
+  control {
+    seq {
+      invoke r0(in = 32'd0)();
+      invoke mem(addr0 = 1'd0, write_data = r0.out)();
+      invoke r1(in = 32'd1)();
+      invoke mem(addr0 = 1'd1, write_data = r1.out)();
+    }
+  }
+}

--- a/tests/passes/cell-share/inline.futil
+++ b/tests/passes/cell-share/inline.futil
@@ -16,6 +16,7 @@ component my_reg<"state_share"=1>(@data in: 32) -> (@stable out: 32) {
 component main() -> () {
   cells {
     @external mem = std_mem_d1(32, 2, 1);
+    // the two `std_reg` created after inlining should be shared
     @inline r0 = my_reg();
     @inline r1 = my_reg();
   }

--- a/tests/passes/cell-share/ref-share.expect
+++ b/tests/passes/cell-share/ref-share.expect
@@ -26,6 +26,8 @@ component foo(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
 component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
     f = foo();
+    r1 = std_reg(32);
+    r2 = std_reg(32);
   }
   wires {}
   control {


### PR DESCRIPTION
This hopefully fixes two deficiencies with cell sharing:

- After inlining a component, it's often the case that wires are created that are later rendered dead by the `comb-prop` pass. However, the continuous writes to these wires don’t get cleaned up until after the cell sharing pass has run, which can prevent sharing of inlined cells (see [`inline.futil`](https://github.com/cucapra/calyx/blob/ed56f007407916d70cd61ccb64bcc7e296ad3492/tests/passes/cell-share/inline.futil) for an example). This PR changes the default pass plan to run `dead-cell-removal` after `comb-prop` and before `cell-share`. To make this ordering work, I attempted to add support for `ref` cells and static timing to `dead-cell-removal`.
- The live range analysis considers an invoked cell to be written to if its list of input connections is nonempty. I'm not sure why that requirement is there—it doesn't seem to agree with the specification of the [`state_share`](https://docs.calyxir.org/lang/attributes.html#state_share) attribute—but in keeping with that condition, I've expanded the check to also look for assignments to the invoked cell in the attached comb group. This enables sharing in a few more places.