### PR TITLE
Cider-dap changes

### DIFF
--- a/cider-dap/src/adapter.rs
+++ b/cider-dap/src/adapter.rs
@@ -1,12 +1,71 @@
+use dap::types::{Breakpoint, Source, SourceBreakpoint};
 use std::fs::File;
 pub struct MyAdapter {
     #[allow(dead_code)]
     file: File,
-    // Other fields of the struct
+    breakpoints: Vec<(Source, i64)>,
+    break_count: Counter,
 }
 
 impl MyAdapter {
     pub fn new(file: File) -> Self {
-        MyAdapter { file }
+        MyAdapter {
+            file,
+            breakpoints: Vec::new(),
+            break_count: Counter::new(),
+        }
+    }
+
+    //Set breakpoints for adapter
+    pub fn set_breakpoint(
+        &mut self,
+        path: Source,
+        source: &Vec<SourceBreakpoint>,
+    ) -> Vec<Breakpoint> {
+        //Keep all the new breakpoints made
+        let mut out_vec: Vec<Breakpoint> = vec![];
+
+        //Loop over all breakpoints
+        for source_point in source {
+            self.breakpoints.push((path.clone(), source_point.line));
+            //Create new Breakpoint instance
+            let breakpoint = Breakpoint {
+                id: self.break_count.increment().into(),
+                verified: true,
+                message: None,
+                source: Some(path.clone()),
+                line: None,
+                column: None,
+                end_line: None,
+                end_column: None,
+                instruction_reference: None,
+                offset: None,
+            };
+
+            out_vec.push(breakpoint);
+        }
+
+        out_vec
+    }
+
+    pub fn step(&self) {}
+
+    pub fn cont(&self) {}
+}
+
+//Simple struct used to keep an index of the breakpoints used.
+pub struct Counter {
+    value: i64,
+}
+
+impl Counter {
+    pub fn new() -> Self {
+        Counter { value: 0 }
+    }
+    //Inc the counter, return the OLD value
+    pub fn increment(&mut self) -> i64 {
+        let out = self.value;
+        self.value += 1;
+        out
     }
 }

--- a/cider-dap/src/adapter.rs
+++ b/cider-dap/src/adapter.rs
@@ -48,9 +48,11 @@ impl MyAdapter {
         out_vec
     }
 
-    pub fn step(&self) {}
+    //TODO IMPLEMENT THESE
 
-    pub fn cont(&self) {}
+    // pub fn step(&self) {}
+
+    // pub fn cont(&self) {}
 }
 
 //Simple struct used to keep an index of the breakpoints used.

--- a/cider-dap/src/adapter.rs
+++ b/cider-dap/src/adapter.rs
@@ -3,9 +3,9 @@ use std::fs::File;
 pub struct MyAdapter {
     #[allow(dead_code)]
     file: File,
-    breakpoints: Vec<(Source, i64)>,
+    breakpoints: Vec<(Source, i64)>, //This field is a placeholder
     break_count: Counter,
-    threads: Vec<Thread>,
+    threads: Vec<Thread>, //This field is a placeholder
 }
 
 impl MyAdapter {
@@ -18,7 +18,7 @@ impl MyAdapter {
         }
     }
 
-    //Set breakpoints for adapter
+    ///Set breakpoints for adapter
     pub fn set_breakpoint(
         &mut self,
         path: Source,
@@ -31,18 +31,11 @@ impl MyAdapter {
         for source_point in source {
             self.breakpoints.push((path.clone(), source_point.line));
             //Create new Breakpoint instance
-            let breakpoint = Breakpoint {
-                id: self.break_count.increment().into(),
-                verified: true,
-                message: None,
-                source: Some(path.clone()),
-                line: None,
-                column: None,
-                end_line: None,
-                end_column: None,
-                instruction_reference: None,
-                offset: None,
-            };
+            let breakpoint = make_breakpoint(
+                self.break_count.increment().into(),
+                true,
+                Some(path.clone()),
+            );
 
             out_vec.push(breakpoint);
         }
@@ -50,13 +43,13 @@ impl MyAdapter {
         out_vec
     }
 
-    //Return threads
-    pub fn get_threads(&self) -> Vec<Thread> {
+    /// Clone threads
+    pub fn clone_threads(&self) -> Vec<Thread> {
         self.threads.clone()
     }
 }
 
-//Simple struct used to keep an index of the breakpoints used.
+/// Simple struct used to keep an index of the breakpoints used.
 pub struct Counter {
     value: i64,
 }
@@ -65,10 +58,34 @@ impl Counter {
     pub fn new() -> Self {
         Counter { value: 0 }
     }
-    //Inc the counter, return the OLD value
+
+    /// Increment the counter by 1 and return the OLD value
     pub fn increment(&mut self) -> i64 {
         let out = self.value;
         self.value += 1;
         out
+    }
+}
+
+/// Returns a Breakpoint object.
+///
+/// This function takes in relevant fields in Breakpoint that are used
+/// by the adapter. This is subject to change.
+pub fn make_breakpoint(
+    id: Option<i64>,
+    verified: bool,
+    source: Option<Source>,
+) -> Breakpoint {
+    Breakpoint {
+        id,
+        verified,
+        message: None,
+        source,
+        line: None,
+        column: None,
+        end_line: None,
+        end_column: None,
+        instruction_reference: None,
+        offset: None,
     }
 }

--- a/cider-dap/src/adapter.rs
+++ b/cider-dap/src/adapter.rs
@@ -1,10 +1,11 @@
-use dap::types::{Breakpoint, Source, SourceBreakpoint};
+use dap::types::{Breakpoint, Source, SourceBreakpoint, Thread};
 use std::fs::File;
 pub struct MyAdapter {
     #[allow(dead_code)]
     file: File,
     breakpoints: Vec<(Source, i64)>,
     break_count: Counter,
+    threads: Vec<Thread>,
 }
 
 impl MyAdapter {
@@ -13,6 +14,7 @@ impl MyAdapter {
             file,
             breakpoints: Vec::new(),
             break_count: Counter::new(),
+            threads: Vec::new(),
         }
     }
 
@@ -48,11 +50,10 @@ impl MyAdapter {
         out_vec
     }
 
-    //TODO IMPLEMENT THESE
-
-    // pub fn step(&self) {}
-
-    // pub fn cont(&self) {}
+    //Return threads
+    pub fn get_threads(&self) -> Vec<Thread> {
+        self.threads.clone()
+    }
 }
 
 //Simple struct used to keep an index of the breakpoints used.

--- a/cider-dap/src/error.rs
+++ b/cider-dap/src/error.rs
@@ -3,7 +3,7 @@ use dap::requests::Command;
 
 #[allow(dead_code)] // remove this later
 #[derive(thiserror::Error, Debug)]
-pub enum MyAdapterError{
+pub enum MyAdapterError {
     /// Represents an unhandled command error.
     #[error("Unhandled command: {0:?}")]
     UnhandledCommandError(Command),

--- a/cider-dap/src/error.rs
+++ b/cider-dap/src/error.rs
@@ -1,11 +1,12 @@
 use dap::errors::ServerError;
+use dap::requests::Command;
 
 #[allow(dead_code)] // remove this later
 #[derive(thiserror::Error, Debug)]
-pub enum MyAdapterError {
+pub enum MyAdapterError{
     /// Represents an unhandled command error.
-    #[error("Unhandled command")]
-    UnhandledCommandError,
+    #[error("Unhandled command: {0:?}")]
+    UnhandledCommandError(Command),
 
     /// Represents an error when unable to parse the file.
     #[error("Unable to parse the file: {0}")]

--- a/cider-dap/src/main.rs
+++ b/cider-dap/src/main.rs
@@ -81,7 +81,10 @@ where
             server.respond(rsp)?;
             server.send_event(Event::Initialized)?;
         }
-        _ => return Err(MyAdapterError::UnhandledCommandError),
+        
+        unknown_command => {
+            return Err(MyAdapterError::UnhandledCommandError(unknown_command.clone()));
+        }
     }
 
     // handle the second request (Launch)
@@ -137,8 +140,7 @@ fn run_server<R: Read, W: Write>(
             // Command::Disconnect(_) => break,
             // ...
             unknown_command => {
-                eprintln!("Unknown_command: {:?}", unknown_command);
-                return Err(MyAdapterError::UnhandledCommandError);
+                return Err(MyAdapterError::UnhandledCommandError(unknown_command.clone()));
             }
         }
     }

--- a/cider-dap/src/main.rs
+++ b/cider-dap/src/main.rs
@@ -168,7 +168,7 @@ fn run_server<R: Read, W: Write>(
             //Retrieve a list of all threads
             Command::Threads => {
                 let rsp = req.success(ResponseBody::Threads(ThreadsResponse {
-                    threads: adapter.get_threads(),
+                    threads: adapter.clone_threads(),
                 }));
                 server.respond(rsp)?;
             }

--- a/cider-dap/src/main.rs
+++ b/cider-dap/src/main.rs
@@ -2,7 +2,7 @@ mod adapter;
 mod error;
 
 use adapter::MyAdapter;
-use dap::responses::SetBreakpointsResponse;
+use dap::responses::{SetBreakpointsResponse, SetExceptionBreakpointsResponse};
 use error::MyAdapterError;
 
 use dap::prelude::*;
@@ -153,9 +153,21 @@ fn run_server<R: Read, W: Write>(
                 }
             }
 
-            Command::Continue(args) => {}
+            //TODO: Implement this request fully when adapter becomes functional
+            Command::SetExceptionBreakpoints(_) => {
+                let rsp = req.success(ResponseBody::SetExceptionBreakpoints(
+                    SetExceptionBreakpointsResponse {
+                        breakpoints: (None),
+                    },
+                ));
+                server.respond(rsp)?;
+            }
 
-            Command::Next(args) => {}
+            //TODO IMPLEMENT THESE COMMANDS
+
+            // Command::Continue(args) => {}
+
+            // Command::Next(args) => {}
 
             // Here, can add a match pattern for a disconnect or exit command
             // to break out of the loop and close the server.

--- a/cider-dap/src/main.rs
+++ b/cider-dap/src/main.rs
@@ -2,7 +2,9 @@ mod adapter;
 mod error;
 
 use adapter::MyAdapter;
-use dap::responses::{SetBreakpointsResponse, SetExceptionBreakpointsResponse};
+use dap::responses::{
+    SetBreakpointsResponse, SetExceptionBreakpointsResponse, ThreadsResponse,
+};
 use error::MyAdapterError;
 
 use dap::prelude::*;
@@ -125,7 +127,7 @@ where
 
 fn run_server<R: Read, W: Write>(
     server: &mut Server<R, W>,
-    mut _adapter: MyAdapter,
+    mut adapter: MyAdapter,
 ) -> AdapterResult<()> {
     loop {
         // Start looping here
@@ -142,8 +144,8 @@ fn run_server<R: Read, W: Write>(
             Command::SetBreakpoints(args) => {
                 //Add breakpoints
                 if let Some(breakpoint) = &args.breakpoints {
-                    let out = _adapter
-                        .set_breakpoint(args.source.clone(), breakpoint);
+                    let out =
+                        adapter.set_breakpoint(args.source.clone(), breakpoint);
 
                     //Success
                     let rsp = req.success(ResponseBody::SetBreakpoints(
@@ -163,12 +165,13 @@ fn run_server<R: Read, W: Write>(
                 server.respond(rsp)?;
             }
 
-            //TODO IMPLEMENT THESE COMMANDS
-
-            // Command::Continue(args) => {}
-
-            // Command::Next(args) => {}
-
+            //Retrieve a list of all threads
+            Command::Threads => {
+                let rsp = req.success(ResponseBody::Threads(ThreadsResponse {
+                    threads: adapter.get_threads(),
+                }));
+                server.respond(rsp)?;
+            }
             // Here, can add a match pattern for a disconnect or exit command
             // to break out of the loop and close the server.
             // Command::Disconnect(_) => break,


### PR DESCRIPTION
**main.rs**
- Implemented the SetBreakpoints, SetExecptionBreakpoints, and Threads requests from the Debug Adapter Protocol.

**adapter.rs**
- Added the fields breakpoints, break_count, and threads to the MyAdapter struct.
- Implemented the function set_breakpoint which returns a vector of Breakpoints for the SetBreakpoints request. 
- Implemented the function get_threads which returns the threads field for the Threads request.
- Created the struct Counter which makes IDs for each breakpoint, starting at 0. 

The debugger now runs!