### PR TITLE
[PIFO Tree]: Telemetry without a `report` flag

### DIFF
--- a/calyx-py/test/correctness/piezo_pifotree.py
+++ b/calyx-py/test/correctness/piezo_pifotree.py
@@ -11,29 +11,21 @@ ANS_MEM_LEN = 10
 def insert_stats(prog, name):
     """Inserts a stats component called `name` into the program `prog`.
 
-    It accepts, as input ports, two things:
-    - a flag that indicates whether a _report_ is sought.
-    - the index of a flow (0 or 1).
-
-    It maintains two output ports, `count_0` and `count_1`.
+    It maintains:
+    - One input port, the index of a flow (0 or 1).
+    - Two output ports, `count_0` and `count_1`.
 
     It also maintains two internal registers, `count_0_sto` and `count_1_sto`.
 
-    If the `report` flag is set:
-    The component doesn't change the stored counts, it just copies them over
-    to the output ports.
+    The component continously outputs the values of the two registers into the
+    two output ports.
 
-    If the `report` flag is not set:
-    The component reads the flow index and increments `count_0_sto` or `count_1_sto`.
+    When invoked, the component reads the flow index and increments
+    `count_0_sto` or `count_1_sto` as appropriate.
     """
 
     stats: cb.ComponentBuilder = prog.component(name)
-    report = stats.input(
-        "report", 1
-    )  # If 0, increment a counter. If 1, report the counts so far.
-    flow = stats.input(
-        "flow", 1
-    )  # If 0, increment `count_0_sto`. If 1, increment `count_1_sto`.
+    flow = stats.input("flow", 1)
     stats.output("count_0", 32)
     stats.output("count_1", 32)
 
@@ -48,7 +40,6 @@ def insert_stats(prog, name):
     # Equality checks.
     flow_eq_0 = stats.eq_use(flow, 0)
     flow_eq_1 = stats.eq_use(flow, 1)
-    report_eq_0 = stats.eq_use(report, 0)
 
     with stats.continuous:
         stats.this().count_0 = count_0_sto.out
@@ -56,12 +47,9 @@ def insert_stats(prog, name):
 
     # The main logic.
     stats.control += [
-        cb.if_with(
-            report_eq_0,  # Report is low, so the user wants to update the counts.
-            cb.par(
-                cb.if_with(flow_eq_0, [count_0_incr]),
-                cb.if_with(flow_eq_1, [count_1_incr]),
-            ),
+        cb.par(
+            cb.if_with(flow_eq_0, [count_0_incr]),
+            cb.if_with(flow_eq_1, [count_1_incr]),
         ),
     ]
 

--- a/calyx-py/test/correctness/piezo_pifotree.py
+++ b/calyx-py/test/correctness/piezo_pifotree.py
@@ -78,10 +78,6 @@ def insert_controller(prog, name, stats_component):
 
     # The main logic.
     controller.control += [
-        cb.invoke(  # Invoke the stats component.
-            stats,
-            in_report=cb.LO,  # Yes, please give me a report.
-        ),
         get_data_locally,
         # Great, now I have the data around locally.
     ]

--- a/calyx-py/test/correctness/piezo_pifotree.yx
+++ b/calyx-py/test/correctness/piezo_pifotree.yx
@@ -1,7 +1,7 @@
 import "primitives/core.futil";
 import "primitives/binary_operators.futil";
 import "primitives/memories.futil";
-component stats(report: 1, flow: 1) -> (count_0: 32, count_1: 32) {
+component stats(flow: 1) -> (count_0: 32, count_1: 32) {
   cells {
     count_0_sto = std_reg(32);
     count_1_sto = std_reg(32);
@@ -9,7 +9,6 @@ component stats(report: 1, flow: 1) -> (count_0: 32, count_1: 32) {
     count_1_sto_incr = std_add(32);
     eq_1 = std_eq(1);
     eq_2 = std_eq(1);
-    eq_3 = std_eq(1);
   }
   wires {
     group count_0_sto_incr_group {
@@ -34,26 +33,20 @@ component stats(report: 1, flow: 1) -> (count_0: 32, count_1: 32) {
       eq_2.left = flow;
       eq_2.right = 1'd1;
     }
-    comb group eq_3_group {
-      eq_3.left = report;
-      eq_3.right = 1'd0;
-    }
     count_0 = count_0_sto.out;
     count_1 = count_1_sto.out;
   }
   control {
     seq {
-      if eq_3.out with eq_3_group {
-        par {
-          if eq_1.out with eq_1_group {
-            seq {
-              count_0_sto_incr_group;
-            }
+      par {
+        if eq_1.out with eq_1_group {
+          seq {
+            count_0_sto_incr_group;
           }
-          if eq_2.out with eq_2_group {
-            seq {
-              count_1_sto_incr_group;
-            }
+        }
+        if eq_2.out with eq_2_group {
+          seq {
+            count_1_sto_incr_group;
           }
         }
       }
@@ -1025,7 +1018,7 @@ component pifo_root(cmd: 2, value: 32) -> () {
               if eq_11.out with eq_11_group {
                 seq {
                   len_incr_group;
-                  invoke stats(flow=flow.out, report=1'd0)();
+                  invoke stats(flow=flow.out)();
                 }
               }
             }
@@ -1147,7 +1140,6 @@ component controller() -> () {
   }
   control {
     seq {
-      invoke stats_controller(report=1'd0)();
       get_data_locally;
     }
   }

--- a/calyx-py/test/correctness/pifo.py
+++ b/calyx-py/test/correctness/pifo.py
@@ -300,13 +300,8 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None):
                                 # If a stats component is provided,
                                 # Increment the length and also
                                 # tell the stats component what flow we pushed.
-                                # Do not request a report.
                                 len_incr,
-                                cb.invoke(
-                                    stats,
-                                    in_flow=flow.out,
-                                    in_report=cb.LO,  # Not requesting a report.
-                                ),
+                                cb.invoke(stats, in_flow=flow.out),
                             ],
                         ),
                     ],


### PR DESCRIPTION
@calebmkim pointed out that the `stats` component could probably do away with its `report` flag since it just continuously outputs its counter values to its outports. This PR does this. Indeed, the eDSL and Calyx code is simpler.
