### PR TITLE
Queues: more `if then else`

### DIFF
--- a/calyx-py/calyx/queue_call.py
+++ b/calyx-py/calyx/queue_call.py
@@ -202,8 +202,8 @@ def insert_runner(prog, queue, name, stats_component):
             [
                 cb.if_with(
                     cmd_le_1,  # If the command was a pop or peek
-                    [raise_has_ans],  # then raise the `has_ans` flag
-                    [lower_has_ans],  # else lower the `has_ans` flag
+                    raise_has_ans,  # then raise the `has_ans` flag
+                    lower_has_ans,  # else lower the `has_ans` flag
                 ),
             ],
         ),

--- a/calyx-py/calyx/queue_call.py
+++ b/calyx-py/calyx/queue_call.py
@@ -70,38 +70,34 @@ def insert_main(prog, queue):
     i_lt_max_cmds = main.lt_use(i.out, queue_util.MAX_CMDS)
     not_err = main.not_use(err.out)
 
-    main.control += [
-        cb.while_with(
-            i_lt_max_cmds,  # Run while i < MAX_CMDS
-            [
-                read_cmd,
-                write_cmd_to_reg,  # `cmd := commands[i]`
-                read_value,
-                write_value_to_reg,  # `value := values[i]`
-                cb.invoke(  # Invoke the queue.
-                    queue,
-                    in_cmd=cmd.out,
-                    in_value=value.out,
-                    ref_ans=ans,
-                    ref_err=err,
-                ),
+    main.control += cb.while_with(
+        i_lt_max_cmds,  # Run while i < MAX_CMDS
+        [
+            read_cmd,
+            write_cmd_to_reg,  # `cmd := commands[i]`
+            read_value,
+            write_value_to_reg,  # `value := values[i]`
+            cb.invoke(  # Invoke the queue.
+                queue,
+                in_cmd=cmd.out,
+                in_value=value.out,
+                ref_ans=ans,
+                ref_err=err,
+            ),
+            cb.if_with(
+                not_err,
                 cb.if_with(
-                    not_err,
+                    cmd_le_1,  # If the command was a pop or peek,
                     [
-                        cb.if_with(
-                            cmd_le_1,  # If the command was a pop or peek,
-                            [
-                                write_ans,  # Write the answer to the answer list
-                                incr_j,  # And increment the answer index.
-                            ],
-                        ),
+                        write_ans,  # Write the answer to the answer list
+                        incr_j,  # And increment the answer index.
                     ],
                 ),
-                lower_err,  # Lower the error flag
-                incr_i,  # Increment the command index
-            ],
-        ),
-    ]
+            ),
+            lower_err,  # Lower the error flag
+            incr_i,  # Increment the command index
+        ],
+    )
 
     return main
 

--- a/calyx-py/test/correctness/fifo.futil
+++ b/calyx-py/test/correctness/fifo.futil
@@ -1,0 +1,274 @@
+import "primitives/core.futil";
+import "primitives/memories.futil";
+import "primitives/binary_operators.futil";
+component fifo(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    seq {
+      par {
+        if eq_1.out with eq_1_group {
+          if eq_6.out with eq_6_group {
+            seq {
+              raise_err;
+              flash_ans;
+            }
+          } else {
+            seq {
+              read_payload_from_mem_phase1;
+              read_payload_from_mem_phase2;
+              next_read_incr_group;
+              if eq_5.out with eq_5_group {
+                flash_read;
+              }
+              len_decr_group;
+            }
+          }
+        }
+        if eq_2.out with eq_2_group {
+          if eq_6.out with eq_6_group {
+            seq {
+              raise_err;
+              flash_ans;
+            }
+          } else {
+            seq {
+              read_payload_from_mem_phase1;
+              read_payload_from_mem_phase2;
+            }
+          }
+        }
+        if eq_3.out with eq_3_group {
+          if eq_7.out with eq_7_group {
+            seq {
+              raise_err;
+              flash_ans;
+            }
+          } else {
+            seq {
+              write_payload_to_mem;
+              next_write_incr_group;
+              if eq_4.out with eq_4_group {
+                flash_write;
+              }
+              len_incr_group;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+component main() -> () {
+  cells {
+    @external commands = seq_mem_d1(2, 20000, 32);
+    @external values = seq_mem_d1(32, 20000, 32);
+    @external ans_mem = seq_mem_d1(32, 20000, 32);
+    myqueue = fifo();
+    err = std_reg(1);
+    ans = std_reg(32);
+    i = std_reg(32);
+    j = std_reg(32);
+    command = std_reg(2);
+    value = std_reg(32);
+    i_incr = std_add(32);
+    j_incr = std_add(32);
+    le_1 = std_le(2);
+    lt_2 = std_lt(32);
+    not_3 = std_not(1);
+  }
+  wires {
+    group i_incr_group {
+      i_incr.left = i.out;
+      i_incr.right = 32'd1;
+      i.write_en = 1'd1;
+      i.in = i_incr.out;
+      i_incr_group[done] = i.done;
+    }
+    group j_incr_group {
+      j_incr.left = j.out;
+      j_incr.right = 32'd1;
+      j.write_en = 1'd1;
+      j.in = j_incr.out;
+      j_incr_group[done] = j.done;
+    }
+    group lower_err {
+      err.in = 1'd0;
+      err.write_en = 1'd1;
+      lower_err[done] = err.done;
+    }
+    comb group le_1_group {
+      le_1.left = command.out;
+      le_1.right = 2'd1;
+    }
+    group read_cmd_phase1 {
+      commands.addr0 = i.out;
+      commands.read_en = 1'd1;
+      read_cmd_phase1[done] = commands.read_done;
+    }
+    group write_cmd_phase2 {
+      command.write_en = 1'd1;
+      command.in = commands.read_data;
+      write_cmd_phase2[done] = command.done;
+    }
+    group read_value {
+      values.addr0 = i.out;
+      values.read_en = 1'd1;
+      read_value[done] = values.read_done;
+    }
+    group write_value_to_reg {
+      value.write_en = 1'd1;
+      value.in = values.read_data;
+      write_value_to_reg[done] = value.done;
+    }
+    group write_ans {
+      ans_mem.addr0 = j.out;
+      ans_mem.write_en = 1'd1;
+      ans_mem.write_data = ans.out;
+      write_ans[done] = ans_mem.write_done;
+    }
+    comb group lt_2_group {
+      lt_2.left = i.out;
+      lt_2.right = 32'd20000;
+    }
+    comb group not_3_group {
+      not_3.in = err.out;
+    }
+  }
+  control {
+    seq {
+      while lt_2.out with lt_2_group {
+        seq {
+          read_cmd_phase1;
+          write_cmd_phase2;
+          read_value;
+          write_value_to_reg;
+          invoke myqueue[ans=ans, err=err](cmd=command.out, value=value.out)();
+          if not_3.out with not_3_group {
+            seq {
+              if le_1.out with le_1_group {
+                seq {
+                  write_ans;
+                  j_incr_group;
+                }
+              }
+            }
+          }
+          lower_err;
+          i_incr_group;
+        }
+      }
+    }
+  }
+}

--- a/calyx-py/test/correctness/fifo.futil
+++ b/calyx-py/test/correctness/fifo.futil
@@ -116,54 +116,50 @@ component fifo(cmd: 2, value: 32) -> () {
     }
   }
   control {
-    seq {
-      par {
-        if eq_1.out with eq_1_group {
-          if eq_6.out with eq_6_group {
-            seq {
-              raise_err;
-              flash_ans;
-            }
-          } else {
-            seq {
-              read_payload_from_mem_phase1;
-              read_payload_from_mem_phase2;
-              next_read_incr_group;
-              if eq_5.out with eq_5_group {
-                flash_read;
-              }
-              len_decr_group;
-            }
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
           }
         }
-        if eq_2.out with eq_2_group {
-          if eq_6.out with eq_6_group {
-            seq {
-              raise_err;
-              flash_ans;
-            }
-          } else {
-            seq {
-              read_payload_from_mem_phase1;
-              read_payload_from_mem_phase2;
-            }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
           }
-        }
-        if eq_3.out with eq_3_group {
-          if eq_7.out with eq_7_group {
-            seq {
-              raise_err;
-              flash_ans;
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
             }
-          } else {
-            seq {
-              write_payload_to_mem;
-              next_write_incr_group;
-              if eq_4.out with eq_4_group {
-                flash_write;
-              }
-              len_incr_group;
-            }
+            len_incr_group;
           }
         }
       }
@@ -247,27 +243,23 @@ component main() -> () {
     }
   }
   control {
-    seq {
-      while lt_2.out with lt_2_group {
-        seq {
-          read_cmd_phase1;
-          write_cmd_phase2;
-          read_value;
-          write_value_to_reg;
-          invoke myqueue[ans=ans, err=err](cmd=command.out, value=value.out)();
-          if not_3.out with not_3_group {
+    while lt_2.out with lt_2_group {
+      seq {
+        read_cmd_phase1;
+        write_cmd_phase2;
+        read_value;
+        write_value_to_reg;
+        invoke myqueue[ans=ans, err=err](cmd=command.out, value=value.out)();
+        if not_3.out with not_3_group {
+          if le_1.out with le_1_group {
             seq {
-              if le_1.out with le_1_group {
-                seq {
-                  write_ans;
-                  j_incr_group;
-                }
-              }
+              write_ans;
+              j_incr_group;
             }
           }
-          lower_err;
-          i_incr_group;
         }
+        lower_err;
+        i_incr_group;
       }
     }
   }

--- a/calyx-py/test/correctness/fifo.py
+++ b/calyx-py/test/correctness/fifo.py
@@ -38,7 +38,6 @@ def insert_fifo(prog, name):
     # Cells and groups to compute equality
     cmd_eq_0 = fifo.eq_use(cmd, 0)
     cmd_eq_1 = fifo.eq_use(cmd, 1)
-    cmd_eq_2 = fifo.eq_use(cmd, 2)
 
     write_eq_max_queue_len = fifo.eq_use(write.out, MAX_QUEUE_LEN)
     read_eq_max_queue_len = fifo.eq_use(read.out, MAX_QUEUE_LEN)

--- a/calyx-py/test/correctness/fifo.py
+++ b/calyx-py/test/correctness/fifo.py
@@ -64,63 +64,51 @@ def insert_fifo(prog, name):
         mem, ans, "read_payload_from_mem_phase2"
     )
 
-    fifo.control += [
-        cb.par(
-            # Was it a pop or a push? We can do both cases in parallel.
-            cb.if_with(
-                # Did the user call pop?
-                cmd_eq_0,
+    fifo.control += cb.if_with(
+        cmd_eq_0,  # Did the user call pop?
+        cb.if_with(  # Yes, the user called pop.
+            len_eq_0,  # But is the queue empty?
+            [raise_err, flash_ans],  # The queue is empty: underflow.
+            [  # The queue is not empty. Proceed.
+                read_from_mem,  # Read from the queue.
+                write_to_ans,  # Write the answer to the answer register.
+                read_incr,  # Increment the read pointer.
                 cb.if_with(
-                    # Yes, the user called pop. But is the queue empty?
-                    len_eq_0,
-                    [raise_err, flash_ans],  # The queue is empty: underflow.
-                    [  # The queue is not empty. Proceed.
-                        read_from_mem,  # Read from the queue.
-                        write_to_ans,  # Write the answer to the answer register.
-                        read_incr,  # Increment the read pointer.
-                        cb.if_with(
-                            # Wrap around if necessary.
-                            read_eq_max_queue_len,
-                            flash_read,
-                        ),
-                        len_decr,  # Decrement the length.
-                    ],
+                    # Wrap around if necessary.
+                    read_eq_max_queue_len,
+                    flash_read,
                 ),
+                len_decr,  # Decrement the length.
+            ],
+        ),
+        # The user called something other than pop.
+        cb.if_with(
+            cmd_eq_1,  # Did the user call peek?
+            cb.if_with(  # Yes, the user called peek.
+                len_eq_0,  # But is the queue empty?
+                [raise_err, flash_ans],  # The queue is empty: underflow.
+                [  # The queue is not empty. Proceed.
+                    read_from_mem,  # Read from the queue.
+                    write_to_ans,  # Write answer to the answer register.
+                    # But don't increment read pointer or change length.
+                ],
             ),
-            cb.if_with(
-                # Did the user call peek?
-                cmd_eq_1,
-                cb.if_with(  # Yes, the user called peek. But is the queue empty?
-                    len_eq_0,
-                    [raise_err, flash_ans],  # The queue is empty: underflow.
-                    [  # The queue is not empty. Proceed.
-                        read_from_mem,  # Read from the queue.
-                        write_to_ans,  # Write the answer to the answer register.
-                        # But don't increment the read pointer or change the length.
-                    ],
-                ),
-            ),
-            cb.if_with(
-                # Did the user call push?
-                cmd_eq_2,
-                cb.if_with(
-                    # Yes, the user called push. But is the queue full?
-                    len_eq_max_queue_len,
-                    [raise_err, flash_ans],  # The queue is full: overflow.
-                    [  # The queue is not full. Proceed.
-                        write_to_mem,  # Write `value` to the queue.
-                        write_incr,  # Increment the write pointer.
-                        cb.if_with(
-                            # Wrap around if necessary.
-                            write_eq_max_queue_len,
-                            flash_write,
-                        ),
-                        len_incr,  # Increment the length.
-                    ],
-                ),
+            cb.if_with(  # The user must have called push.
+                len_eq_max_queue_len,  # But is the queue empty?
+                [raise_err, flash_ans],  # The queue is full: overflow.
+                [  # The queue is not full. Proceed.
+                    write_to_mem,  # Write `value` to the queue.
+                    write_incr,  # Increment the write pointer.
+                    cb.if_with(
+                        # Wrap around if necessary.
+                        write_eq_max_queue_len,
+                        flash_write,
+                    ),
+                    len_incr,  # Increment the length.
+                ],
             ),
         ),
-    ]
+    )
 
     return fifo
 

--- a/calyx-py/test/correctness/pifo.futil
+++ b/calyx-py/test/correctness/pifo.futil
@@ -445,118 +445,107 @@ component pifo(cmd: 2, value: 32) -> () {
     }
   }
   control {
-    seq {
-      par {
-        if eq_8.out with eq_8_group {
-          if eq_6.out with eq_6_group {
-            seq {
-              raise_err;
-              flash_ans;
-            }
-          } else {
-            seq {
-              lower_err;
-              par {
-                if eq_2.out with eq_2_group {
-                  seq {
-                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
-                    par {
-                      if neq_12.out with neq_12_group {
-                        seq {
-                          lower_err;
-                          invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
-                        }
-                      }
-                      if eq_11.out with eq_11_group {
-                        seq {
-                          hot_not_group;
-                        }
-                      }
+    par {
+      if eq_8.out with eq_8_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            par {
+              if eq_2.out with eq_2_group {
+                seq {
+                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                  if neq_12.out with neq_12_group {
+                    seq {
+                      lower_err;
+                      invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
                     }
-                  }
-                }
-                if eq_3.out with eq_3_group {
-                  seq {
-                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
-                    par {
-                      if neq_12.out with neq_12_group {
-                        seq {
-                          lower_err;
-                          invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
-                        }
-                      }
-                      if eq_11.out with eq_11_group {
-                        seq {
-                          hot_not_group;
-                        }
-                      }
-                    }
+                  } else {
+                    hot_not_group;
                   }
                 }
               }
-              len_decr_group;
-            }
-          }
-        }
-        if eq_9.out with eq_9_group {
-          if eq_6.out with eq_6_group {
-            seq {
-              raise_err;
-              flash_ans;
-            }
-          } else {
-            seq {
-              lower_err;
-              par {
-                if eq_2.out with eq_2_group {
-                  seq {
-                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
-                    if neq_12.out with neq_12_group {
-                      seq {
-                        lower_err;
-                        invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
-                      }
-                    }
-                  }
-                }
-                if eq_3.out with eq_3_group {
-                  seq {
-                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+              if eq_3.out with eq_3_group {
+                seq {
+                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                  par {
                     if neq_12.out with neq_12_group {
                       seq {
                         lower_err;
                         invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
                       }
                     }
+                    if eq_11.out with eq_11_group {
+                      hot_not_group;
+                    }
+                  }
+                }
+              }
+            }
+            len_decr_group;
+          }
+        }
+      }
+      if eq_9.out with eq_9_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            par {
+              if eq_2.out with eq_2_group {
+                seq {
+                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                  if neq_12.out with neq_12_group {
+                    seq {
+                      lower_err;
+                      invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                    }
+                  }
+                }
+              }
+              if eq_3.out with eq_3_group {
+                seq {
+                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                  if neq_12.out with neq_12_group {
+                    seq {
+                      lower_err;
+                      invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                    }
                   }
                 }
               }
             }
           }
         }
-        if eq_10.out with eq_10_group {
-          if eq_7.out with eq_7_group {
-            seq {
-              raise_err;
-              flash_ans;
+      }
+      if eq_10.out with eq_10_group {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            infer_flow;
+            par {
+              if eq_4.out with eq_4_group {
+                invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+              }
+              if eq_5.out with eq_5_group {
+                invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+              }
             }
-          } else {
-            seq {
-              lower_err;
-              infer_flow;
-              par {
-                if eq_4.out with eq_4_group {
-                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
-                }
-                if eq_5.out with eq_5_group {
-                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
-                }
-              }
-              if eq_11.out with eq_11_group {
-                seq {
-                  len_incr_group;
-                }
-              }
+            if eq_11.out with eq_11_group {
+              len_incr_group;
             }
           }
         }

--- a/calyx-py/test/correctness/pifo.futil
+++ b/calyx-py/test/correctness/pifo.futil
@@ -445,45 +445,44 @@ component pifo(cmd: 2, value: 32) -> () {
     }
   }
   control {
-    par {
-      if eq_8.out with eq_8_group {
-        if eq_6.out with eq_6_group {
-          seq {
-            raise_err;
-            flash_ans;
-          }
-        } else {
-          seq {
-            lower_err;
-            if eq_2.out with eq_2_group {
-              seq {
-                invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
-                if neq_12.out with neq_12_group {
-                  seq {
-                    lower_err;
-                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
-                  }
-                } else {
-                  hot_not_group;
+    if eq_8.out with eq_8_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          lower_err;
+          if eq_2.out with eq_2_group {
+            seq {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
                 }
-              }
-            } else {
-              seq {
-                invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
-                if neq_12.out with neq_12_group {
-                  seq {
-                    lower_err;
-                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
-                  }
-                } else {
-                  hot_not_group;
-                }
+              } else {
+                hot_not_group;
               }
             }
-            len_decr_group;
+          } else {
+            seq {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
           }
+          len_decr_group;
         }
       }
+    } else {
       if eq_9.out with eq_9_group {
         if eq_6.out with eq_6_group {
           seq {
@@ -516,8 +515,7 @@ component pifo(cmd: 2, value: 32) -> () {
             }
           }
         }
-      }
-      if eq_10.out with eq_10_group {
+      } else {
         if eq_7.out with eq_7_group {
           seq {
             raise_err;

--- a/calyx-py/test/correctness/pifo.futil
+++ b/calyx-py/test/correctness/pifo.futil
@@ -1,0 +1,664 @@
+import "primitives/core.futil";
+import "primitives/memories.futil";
+import "primitives/binary_operators.futil";
+component fifo_l(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
+            }
+            len_incr_group;
+          }
+        }
+      }
+    }
+  }
+}
+component fifo_r(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
+            }
+            len_incr_group;
+          }
+        }
+      }
+    }
+  }
+}
+component pifo(cmd: 2, value: 32) -> () {
+  cells {
+    queue_l = fifo_l();
+    queue_r = fifo_r();
+    flow = std_reg(1);
+    lt_1 = std_lt(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    hot = std_reg(1);
+    eq_2 = std_eq(1);
+    eq_3 = std_eq(1);
+    eq_4 = std_eq(1);
+    eq_5 = std_eq(1);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    eq_8 = std_eq(2);
+    eq_9 = std_eq(2);
+    eq_10 = std_eq(2);
+    eq_11 = std_eq(1);
+    neq_12 = std_neq(1);
+    hot_not = std_not(1);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    group infer_flow {
+      lt_1.left = 32'd200;
+      lt_1.right = value;
+      flow.write_en = 1'd1;
+      flow.in = lt_1.out;
+      infer_flow[done] = flow.done;
+    }
+    comb group eq_2_group {
+      eq_2.left = hot.out;
+      eq_2.right = 1'd0;
+    }
+    comb group eq_3_group {
+      eq_3.left = hot.out;
+      eq_3.right = 1'd1;
+    }
+    comb group eq_4_group {
+      eq_4.left = flow.out;
+      eq_4.right = 1'd0;
+    }
+    comb group eq_5_group {
+      eq_5.left = flow.out;
+      eq_5.right = 1'd1;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    comb group eq_8_group {
+      eq_8.left = cmd;
+      eq_8.right = 2'd0;
+    }
+    comb group eq_9_group {
+      eq_9.left = cmd;
+      eq_9.right = 2'd1;
+    }
+    comb group eq_10_group {
+      eq_10.left = cmd;
+      eq_10.right = 2'd2;
+    }
+    comb group eq_11_group {
+      eq_11.left = err.out;
+      eq_11.right = 1'd0;
+    }
+    comb group neq_12_group {
+      neq_12.left = err.out;
+      neq_12.right = 1'd0;
+    }
+    group hot_not_group {
+      hot_not.in = hot.out;
+      hot.write_en = 1'd1;
+      hot.in = hot_not.out;
+      hot_not_group[done] = hot.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group lower_err {
+      err.in = 1'd0;
+      err.write_en = 1'd1;
+      lower_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+  }
+  control {
+    seq {
+      par {
+        if eq_8.out with eq_8_group {
+          if eq_6.out with eq_6_group {
+            seq {
+              raise_err;
+              flash_ans;
+            }
+          } else {
+            seq {
+              lower_err;
+              par {
+                if eq_2.out with eq_2_group {
+                  seq {
+                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                    par {
+                      if neq_12.out with neq_12_group {
+                        seq {
+                          lower_err;
+                          invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                        }
+                      }
+                      if eq_11.out with eq_11_group {
+                        seq {
+                          hot_not_group;
+                        }
+                      }
+                    }
+                  }
+                }
+                if eq_3.out with eq_3_group {
+                  seq {
+                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                    par {
+                      if neq_12.out with neq_12_group {
+                        seq {
+                          lower_err;
+                          invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                        }
+                      }
+                      if eq_11.out with eq_11_group {
+                        seq {
+                          hot_not_group;
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              len_decr_group;
+            }
+          }
+        }
+        if eq_9.out with eq_9_group {
+          if eq_6.out with eq_6_group {
+            seq {
+              raise_err;
+              flash_ans;
+            }
+          } else {
+            seq {
+              lower_err;
+              par {
+                if eq_2.out with eq_2_group {
+                  seq {
+                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                    if neq_12.out with neq_12_group {
+                      seq {
+                        lower_err;
+                        invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                      }
+                    }
+                  }
+                }
+                if eq_3.out with eq_3_group {
+                  seq {
+                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                    if neq_12.out with neq_12_group {
+                      seq {
+                        lower_err;
+                        invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        if eq_10.out with eq_10_group {
+          if eq_7.out with eq_7_group {
+            seq {
+              raise_err;
+              flash_ans;
+            }
+          } else {
+            seq {
+              lower_err;
+              infer_flow;
+              par {
+                if eq_4.out with eq_4_group {
+                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+                if eq_5.out with eq_5_group {
+                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              }
+              if eq_11.out with eq_11_group {
+                seq {
+                  len_incr_group;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+component main() -> () {
+  cells {
+    @external commands = seq_mem_d1(2, 20000, 32);
+    @external values = seq_mem_d1(32, 20000, 32);
+    @external ans_mem = seq_mem_d1(32, 20000, 32);
+    myqueue = pifo();
+    err = std_reg(1);
+    ans = std_reg(32);
+    i = std_reg(32);
+    j = std_reg(32);
+    command = std_reg(2);
+    value = std_reg(32);
+    i_incr = std_add(32);
+    j_incr = std_add(32);
+    le_1 = std_le(2);
+    lt_2 = std_lt(32);
+    not_3 = std_not(1);
+  }
+  wires {
+    group i_incr_group {
+      i_incr.left = i.out;
+      i_incr.right = 32'd1;
+      i.write_en = 1'd1;
+      i.in = i_incr.out;
+      i_incr_group[done] = i.done;
+    }
+    group j_incr_group {
+      j_incr.left = j.out;
+      j_incr.right = 32'd1;
+      j.write_en = 1'd1;
+      j.in = j_incr.out;
+      j_incr_group[done] = j.done;
+    }
+    group lower_err {
+      err.in = 1'd0;
+      err.write_en = 1'd1;
+      lower_err[done] = err.done;
+    }
+    comb group le_1_group {
+      le_1.left = command.out;
+      le_1.right = 2'd1;
+    }
+    group read_cmd_phase1 {
+      commands.addr0 = i.out;
+      commands.read_en = 1'd1;
+      read_cmd_phase1[done] = commands.read_done;
+    }
+    group write_cmd_phase2 {
+      command.write_en = 1'd1;
+      command.in = commands.read_data;
+      write_cmd_phase2[done] = command.done;
+    }
+    group read_value {
+      values.addr0 = i.out;
+      values.read_en = 1'd1;
+      read_value[done] = values.read_done;
+    }
+    group write_value_to_reg {
+      value.write_en = 1'd1;
+      value.in = values.read_data;
+      write_value_to_reg[done] = value.done;
+    }
+    group write_ans {
+      ans_mem.addr0 = j.out;
+      ans_mem.write_en = 1'd1;
+      ans_mem.write_data = ans.out;
+      write_ans[done] = ans_mem.write_done;
+    }
+    comb group lt_2_group {
+      lt_2.left = i.out;
+      lt_2.right = 32'd20000;
+    }
+    comb group not_3_group {
+      not_3.in = err.out;
+    }
+  }
+  control {
+    while lt_2.out with lt_2_group {
+      seq {
+        read_cmd_phase1;
+        write_cmd_phase2;
+        read_value;
+        write_value_to_reg;
+        invoke myqueue[ans=ans, err=err](cmd=command.out, value=value.out)();
+        if not_3.out with not_3_group {
+          if le_1.out with le_1_group {
+            seq {
+              write_ans;
+              j_incr_group;
+            }
+          }
+        }
+        lower_err;
+        i_incr_group;
+      }
+    }
+  }
+}

--- a/calyx-py/test/correctness/pifo.futil
+++ b/calyx-py/test/correctness/pifo.futil
@@ -455,34 +455,28 @@ component pifo(cmd: 2, value: 32) -> () {
         } else {
           seq {
             lower_err;
-            par {
-              if eq_2.out with eq_2_group {
-                seq {
-                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
-                  if neq_12.out with neq_12_group {
-                    seq {
-                      lower_err;
-                      invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
-                    }
-                  } else {
-                    hot_not_group;
+            if eq_2.out with eq_2_group {
+              seq {
+                invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
                   }
+                } else {
+                  hot_not_group;
                 }
               }
-              if eq_3.out with eq_3_group {
-                seq {
-                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
-                  par {
-                    if neq_12.out with neq_12_group {
-                      seq {
-                        lower_err;
-                        invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
-                      }
-                    }
-                    if eq_11.out with eq_11_group {
-                      hot_not_group;
-                    }
+            } else {
+              seq {
+                invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
                   }
+                } else {
+                  hot_not_group;
                 }
               }
             }
@@ -499,26 +493,23 @@ component pifo(cmd: 2, value: 32) -> () {
         } else {
           seq {
             lower_err;
-            par {
-              if eq_2.out with eq_2_group {
-                seq {
-                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
-                  if neq_12.out with neq_12_group {
-                    seq {
-                      lower_err;
-                      invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
-                    }
+            if eq_2.out with eq_2_group {
+              seq {
+                invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
                   }
                 }
               }
-              if eq_3.out with eq_3_group {
-                seq {
-                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
-                  if neq_12.out with neq_12_group {
-                    seq {
-                      lower_err;
-                      invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
-                    }
+            } else {
+              seq {
+                invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
                   }
                 }
               }
@@ -536,13 +527,10 @@ component pifo(cmd: 2, value: 32) -> () {
           seq {
             lower_err;
             infer_flow;
-            par {
-              if eq_4.out with eq_4_group {
-                invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
-              }
-              if eq_5.out with eq_5_group {
-                invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
-              }
+            if eq_4.out with eq_4_group {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+            } else {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
             }
             if eq_11.out with eq_11_group {
               len_incr_group;

--- a/calyx-py/test/correctness/pifo.py
+++ b/calyx-py/test/correctness/pifo.py
@@ -149,52 +149,39 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None, static=False
                 [  # The queue is not empty. Proceed.
                     # We must check if `hot` is 0 or 1.
                     lower_err,
-                    cb.par(  # We'll check both cases in parallel.
-                        cb.if_with(
-                            # Check if `hot` is 0.
-                            hot_eq_0,
-                            [  # `hot` is 0. We'll invoke `pop` on `queue_l`.
-                                invoke_subqueue(queue_l, cmd, value, ans, err),
-                                # Our next step depends on whether `queue_l`
-                                # raised the error flag.
-                                cb.if_with(
-                                    err_neq_0,
-                                    [  # `queue_l` raised an error.
-                                        # We'll try to pop from `queue_r`.
-                                        # We'll pass it a lowered err
-                                        lower_err,
-                                        invoke_subqueue(queue_r, cmd, value, ans, err),
-                                    ],
-                                    # `queue_l` succeeded.
-                                    # Its answer will be our answer.
-                                    flip_hot
-                                    # We'll just make `hot` point
-                                    # to the other sub-queue.
-                                ),
-                            ],
-                        ),
-                        # If `hot` is 1, we proceed symmetrically.
-                        cb.if_with(
-                            hot_eq_1,
-                            [
-                                invoke_subqueue(queue_r, cmd, value, ans, err),
-                                cb.par(
-                                    cb.if_with(
-                                        err_neq_0,
-                                        [
-                                            lower_err,
-                                            invoke_subqueue(
-                                                queue_l, cmd, value, ans, err
-                                            ),
-                                        ],
-                                    ),
-                                    cb.if_with(
-                                        err_eq_0,
-                                        flip_hot,
-                                    ),
-                                ),
-                            ],
-                        ),
+                    cb.if_with(
+                        # Check if `hot` is 0.
+                        hot_eq_0,
+                        [  # `hot` is 0. We'll invoke `pop` on `queue_l`.
+                            invoke_subqueue(queue_l, cmd, value, ans, err),
+                            # Our next step depends on whether `queue_l`
+                            # raised the error flag.
+                            cb.if_with(
+                                err_neq_0,
+                                [  # `queue_l` raised an error.
+                                    # We'll try to pop from `queue_r`.
+                                    # We'll pass it a lowered err
+                                    lower_err,
+                                    invoke_subqueue(queue_r, cmd, value, ans, err),
+                                ],
+                                # `queue_l` succeeded.
+                                # Its answer will be our answer.
+                                flip_hot
+                                # We'll just make `hot` point
+                                # to the other sub-queue.
+                            ),
+                        ],
+                        [  # `hot` is 1; we proceed symmetrically.
+                            invoke_subqueue(queue_r, cmd, value, ans, err),
+                            cb.if_with(
+                                err_neq_0,
+                                [
+                                    lower_err,
+                                    invoke_subqueue(queue_l, cmd, value, ans, err),
+                                ],
+                                flip_hot,
+                            ),
+                        ],
                     ),
                     len_decr,  # Decrement the length.
                     # It is possible that an irrecoverable error was raised above,
@@ -214,41 +201,34 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None, static=False
                 [  # The queue is not empty. Proceed.
                     # We must check if `hot` is 0 or 1.
                     lower_err,
-                    cb.par(  # We'll check both cases in parallel.
-                        cb.if_with(
-                            # Check if `hot` is 0.
-                            hot_eq_0,
-                            [  # `hot` is 0. We'll invoke `peek` on `queue_l`.
-                                invoke_subqueue(queue_l, cmd, value, ans, err),
-                                # Our next step depends on whether `queue_l`
-                                # raised the error flag.
-                                cb.if_with(
-                                    err_neq_0,
-                                    [  # `queue_l` raised an error.
-                                        # We'll try to peek from `queue_r`.
-                                        # We'll pass it a lowered `err`.
-                                        lower_err,
-                                        invoke_subqueue(queue_r, cmd, value, ans, err),
-                                    ],
-                                ),
-                                # Peeking does not affect `hot`.
-                                # Peeking does not affect the length.
-                            ],
-                        ),
-                        # If `hot` is 1, we proceed symmetrically.
-                        cb.if_with(
-                            hot_eq_1,
-                            [
-                                invoke_subqueue(queue_r, cmd, value, ans, err),
-                                cb.if_with(
-                                    err_neq_0,
-                                    [
-                                        lower_err,
-                                        invoke_subqueue(queue_l, cmd, value, ans, err),
-                                    ],
-                                ),
-                            ],
-                        ),
+                    cb.if_with(
+                        hot_eq_0,  # Check if `hot` is 0 or 1
+                        [  # `hot` is 0. We'll invoke `peek` on `queue_l`.
+                            invoke_subqueue(queue_l, cmd, value, ans, err),
+                            # Our next step depends on whether `queue_l`
+                            # raised the error flag.
+                            cb.if_with(
+                                err_neq_0,
+                                [  # `queue_l` raised an error.
+                                    # We'll try to peek from `queue_r`.
+                                    # We'll pass it a lowered `err`.
+                                    lower_err,
+                                    invoke_subqueue(queue_r, cmd, value, ans, err),
+                                ],
+                            ),
+                            # Peeking does not affect `hot`.
+                            # Peeking does not affect the length.
+                        ],
+                        [  # `hot` is 1; we proceed symmetrically.
+                            invoke_subqueue(queue_r, cmd, value, ans, err),
+                            cb.if_with(
+                                err_neq_0,
+                                [
+                                    lower_err,
+                                    invoke_subqueue(queue_l, cmd, value, ans, err),
+                                ],
+                            ),
+                        ],
                     ),
                 ],
             ),
@@ -264,17 +244,12 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None, static=False
                     lower_err,
                     # We need to check which flow this value should be pushed to.
                     infer_flow,  # Infer the flow and write it to `fifo_{flow}`.
-                    cb.par(
-                        cb.if_with(
-                            flow_eq_0,
-                            # This value should be pushed to queue_l.
-                            invoke_subqueue(queue_l, cmd, value, ans, err),
-                        ),
-                        cb.if_with(
-                            flow_eq_1,
-                            # This value should be pushed to queue_r.
-                            invoke_subqueue(queue_r, cmd, value, ans, err),
-                        ),
+                    cb.if_with(
+                        flow_eq_0,
+                        # This value should be pushed to queue_l.
+                        invoke_subqueue(queue_l, cmd, value, ans, err),
+                        # This value should be pushed to queue_r.
+                        invoke_subqueue(queue_r, cmd, value, ans, err),
                     ),
                     cb.if_with(
                         err_eq_0,

--- a/calyx-py/test/correctness/pifo.py
+++ b/calyx-py/test/correctness/pifo.py
@@ -117,14 +117,11 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None, static=False
 
     # Some equality checks.
     hot_eq_0 = pifo.eq_use(hot.out, 0)
-    hot_eq_1 = pifo.eq_use(hot.out, 1)
     flow_eq_0 = pifo.eq_use(flow.out, 0)
-    flow_eq_1 = pifo.eq_use(flow.out, 1)
     len_eq_0 = pifo.eq_use(len.out, 0)
     len_eq_max_queue_len = pifo.eq_use(len.out, MAX_QUEUE_LEN)
     cmd_eq_0 = pifo.eq_use(cmd, 0)
     cmd_eq_1 = pifo.eq_use(cmd, 1)
-    cmd_eq_2 = pifo.eq_use(cmd, 2)
     err_eq_0 = pifo.eq_use(err.out, 0)
     err_neq_0 = pifo.neq_use(err.out, 0)
 

--- a/calyx-py/test/correctness/pifo.py
+++ b/calyx-py/test/correctness/pifo.py
@@ -137,121 +137,48 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None, static=False
     len_decr = pifo.decr(len)  # len--
 
     # The main logic.
-    pifo.control += [
-        cb.par(
-            # Was it a pop, peek, or a push? We can do all cases in parallel.
+    pifo.control += cb.par(
+        # Was it a pop, peek, or a push? We can do all cases in parallel.
+        cb.if_with(
+            # Did the user call pop?
+            cmd_eq_0,
             cb.if_with(
-                # Did the user call pop?
-                cmd_eq_0,
-                cb.if_with(
-                    # Yes, the user called pop. But is the queue empty?
-                    len_eq_0,
-                    [raise_err, flash_ans],  # The queue is empty: underflow.
-                    [  # The queue is not empty. Proceed.
-                        # We must check if `hot` is 0 or 1.
-                        lower_err,
-                        cb.par(  # We'll check both cases in parallel.
-                            cb.if_with(
-                                # Check if `hot` is 0.
-                                hot_eq_0,
-                                [  # `hot` is 0. We'll invoke `pop` on `queue_l`.
-                                    invoke_subqueue(queue_l, cmd, value, ans, err),
-                                    # Our next step depends on whether `queue_l`
-                                    # raised the error flag.
-                                    # We can check these cases in parallel.
-                                    cb.par(
-                                        cb.if_with(
-                                            err_neq_0,
-                                            [  # `queue_l` raised an error.
-                                                # We'll try to pop from `queue_r`.
-                                                # We'll pass it a lowered err
-                                                lower_err,
-                                                invoke_subqueue(
-                                                    queue_r, cmd, value, ans, err
-                                                ),
-                                            ],
-                                        ),
-                                        cb.if_with(
-                                            err_eq_0,
-                                            [  # `queue_l` succeeded.
-                                                # Its answer is our answer.
-                                                flip_hot
-                                                # We'll just make `hot` point
-                                                # to the other sub-queue.
-                                            ],
-                                        ),
-                                    ),
-                                ],
-                            ),
-                            # If `hot` is 1, we proceed symmetrically.
-                            cb.if_with(
-                                hot_eq_1,
-                                [
-                                    invoke_subqueue(queue_r, cmd, value, ans, err),
-                                    cb.par(
-                                        cb.if_with(
-                                            err_neq_0,
-                                            [
-                                                lower_err,
-                                                invoke_subqueue(
-                                                    queue_l, cmd, value, ans, err
-                                                ),
-                                            ],
-                                        ),
-                                        cb.if_with(
-                                            err_eq_0,
-                                            [flip_hot],
-                                        ),
-                                    ),
-                                ],
-                            ),
+                # Yes, the user called pop. But is the queue empty?
+                len_eq_0,
+                [raise_err, flash_ans],  # The queue is empty: underflow.
+                [  # The queue is not empty. Proceed.
+                    # We must check if `hot` is 0 or 1.
+                    lower_err,
+                    cb.par(  # We'll check both cases in parallel.
+                        cb.if_with(
+                            # Check if `hot` is 0.
+                            hot_eq_0,
+                            [  # `hot` is 0. We'll invoke `pop` on `queue_l`.
+                                invoke_subqueue(queue_l, cmd, value, ans, err),
+                                # Our next step depends on whether `queue_l`
+                                # raised the error flag.
+                                cb.if_with(
+                                    err_neq_0,
+                                    [  # `queue_l` raised an error.
+                                        # We'll try to pop from `queue_r`.
+                                        # We'll pass it a lowered err
+                                        lower_err,
+                                        invoke_subqueue(queue_r, cmd, value, ans, err),
+                                    ],
+                                    # `queue_l` succeeded.
+                                    # Its answer will be our answer.
+                                    flip_hot
+                                    # We'll just make `hot` point
+                                    # to the other sub-queue.
+                                ),
+                            ],
                         ),
-                        len_decr,  # Decrement the length.
-                        # It is possible that an irrecoverable error was raised above,
-                        # in which case the length should _not_ in fact be decremented.
-                        # However, in that case the PIFO's `err` flag would also
-                        # have been raised, and no one will check this length anyway.
-                    ],
-                ),
-            ),
-            cb.if_with(
-                # Did the user call peek?
-                cmd_eq_1,
-                cb.if_with(
-                    # Yes, the user called peek. But is the queue empty?
-                    len_eq_0,
-                    [raise_err, flash_ans],  # The queue is empty: underflow.
-                    [  # The queue is not empty. Proceed.
-                        # We must check if `hot` is 0 or 1.
-                        lower_err,
-                        cb.par(  # We'll check both cases in parallel.
-                            cb.if_with(
-                                # Check if `hot` is 0.
-                                hot_eq_0,
-                                [  # `hot` is 0. We'll invoke `peek` on `queue_l`.
-                                    invoke_subqueue(queue_l, cmd, value, ans, err),
-                                    # Our next step depends on whether `queue_l`
-                                    # raised the error flag.
-                                    cb.if_with(
-                                        err_neq_0,
-                                        [  # `queue_l` raised an error.
-                                            # We'll try to peek from `queue_r`.
-                                            # We'll pass it a lowered `err`.
-                                            lower_err,
-                                            invoke_subqueue(
-                                                queue_r, cmd, value, ans, err
-                                            ),
-                                        ],
-                                    ),
-                                    # Peeking does not affect `hot`.
-                                    # Peeking does not affect the length.
-                                ],
-                            ),
-                            # If `hot` is 1, we proceed symmetrically.
-                            cb.if_with(
-                                hot_eq_1,
-                                [
-                                    invoke_subqueue(queue_r, cmd, value, ans, err),
+                        # If `hot` is 1, we proceed symmetrically.
+                        cb.if_with(
+                            hot_eq_1,
+                            [
+                                invoke_subqueue(queue_r, cmd, value, ans, err),
+                                cb.par(
                                     cb.if_with(
                                         err_neq_0,
                                         [
@@ -261,58 +188,116 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None, static=False
                                             ),
                                         ],
                                     ),
-                                ],
-                            ),
-                        ),
-                    ],
-                ),
-            ),
-            cb.if_with(
-                # Did the user call push?
-                cmd_eq_2,
-                cb.if_with(
-                    # Yes, the user called push. But is the queue full?
-                    len_eq_max_queue_len,
-                    [raise_err, flash_ans],  # The queue is full: overflow.
-                    [  # The queue is not full. Proceed.
-                        lower_err,
-                        # We need to check which flow this value should be pushed to.
-                        infer_flow,  # Infer the flow and write it to `fifo_{flow}`.
-                        cb.par(
-                            cb.if_with(
-                                flow_eq_0,
-                                # This value should be pushed to queue_l.
-                                invoke_subqueue(queue_l, cmd, value, ans, err),
-                            ),
-                            cb.if_with(
-                                flow_eq_1,
-                                # This value should be pushed to queue_r.
-                                invoke_subqueue(queue_r, cmd, value, ans, err),
-                            ),
-                        ),
-                        cb.if_with(
-                            err_eq_0,
-                            # If no stats component is provided,
-                            # just increment the length.
-                            [len_incr]
-                            if not stats
-                            else [
-                                # If a stats component is provided,
-                                # Increment the length and also
-                                # tell the stats component what flow we pushed.
-                                len_incr,
-                                (
-                                    cb.static_invoke(stats, in_flow=flow.out)
-                                    if static
-                                    else cb.invoke(stats, in_flow=flow.out)
+                                    cb.if_with(
+                                        err_eq_0,
+                                        flip_hot,
+                                    ),
                                 ),
                             ],
                         ),
-                    ],
-                ),
+                    ),
+                    len_decr,  # Decrement the length.
+                    # It is possible that an irrecoverable error was raised above,
+                    # in which case the length should _not_ in fact be decremented.
+                    # However, in that case the PIFO's `err` flag would also
+                    # have been raised, and no one will check this length anyway.
+                ],
             ),
         ),
-    ]
+        cb.if_with(
+            # Did the user call peek?
+            cmd_eq_1,
+            cb.if_with(
+                # Yes, the user called peek. But is the queue empty?
+                len_eq_0,
+                [raise_err, flash_ans],  # The queue is empty: underflow.
+                [  # The queue is not empty. Proceed.
+                    # We must check if `hot` is 0 or 1.
+                    lower_err,
+                    cb.par(  # We'll check both cases in parallel.
+                        cb.if_with(
+                            # Check if `hot` is 0.
+                            hot_eq_0,
+                            [  # `hot` is 0. We'll invoke `peek` on `queue_l`.
+                                invoke_subqueue(queue_l, cmd, value, ans, err),
+                                # Our next step depends on whether `queue_l`
+                                # raised the error flag.
+                                cb.if_with(
+                                    err_neq_0,
+                                    [  # `queue_l` raised an error.
+                                        # We'll try to peek from `queue_r`.
+                                        # We'll pass it a lowered `err`.
+                                        lower_err,
+                                        invoke_subqueue(queue_r, cmd, value, ans, err),
+                                    ],
+                                ),
+                                # Peeking does not affect `hot`.
+                                # Peeking does not affect the length.
+                            ],
+                        ),
+                        # If `hot` is 1, we proceed symmetrically.
+                        cb.if_with(
+                            hot_eq_1,
+                            [
+                                invoke_subqueue(queue_r, cmd, value, ans, err),
+                                cb.if_with(
+                                    err_neq_0,
+                                    [
+                                        lower_err,
+                                        invoke_subqueue(queue_l, cmd, value, ans, err),
+                                    ],
+                                ),
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        cb.if_with(
+            # Did the user call push?
+            cmd_eq_2,
+            cb.if_with(
+                # Yes, the user called push. But is the queue full?
+                len_eq_max_queue_len,
+                [raise_err, flash_ans],  # The queue is full: overflow.
+                [  # The queue is not full. Proceed.
+                    lower_err,
+                    # We need to check which flow this value should be pushed to.
+                    infer_flow,  # Infer the flow and write it to `fifo_{flow}`.
+                    cb.par(
+                        cb.if_with(
+                            flow_eq_0,
+                            # This value should be pushed to queue_l.
+                            invoke_subqueue(queue_l, cmd, value, ans, err),
+                        ),
+                        cb.if_with(
+                            flow_eq_1,
+                            # This value should be pushed to queue_r.
+                            invoke_subqueue(queue_r, cmd, value, ans, err),
+                        ),
+                    ),
+                    cb.if_with(
+                        err_eq_0,
+                        # If no stats component is provided,
+                        # just increment the length.
+                        len_incr
+                        if not stats
+                        else [
+                            # If a stats component is provided,
+                            # Increment the length and also
+                            # tell the stats component what flow we pushed.
+                            len_incr,
+                            (
+                                cb.static_invoke(stats, in_flow=flow.out)
+                                if static
+                                else cb.invoke(stats, in_flow=flow.out)
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ),
+    )
 
     return pifo
 

--- a/calyx-py/test/correctness/pifo_tree.futil
+++ b/calyx-py/test/correctness/pifo_tree.futil
@@ -1,0 +1,1012 @@
+import "primitives/core.futil";
+import "primitives/memories.futil";
+import "primitives/binary_operators.futil";
+component fifo_purple(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
+            }
+            len_incr_group;
+          }
+        }
+      }
+    }
+  }
+}
+component fifo_tangerine(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
+            }
+            len_incr_group;
+          }
+        }
+      }
+    }
+  }
+}
+component pifo_red(cmd: 2, value: 32) -> () {
+  cells {
+    queue_l = fifo_purple();
+    queue_r = fifo_tangerine();
+    flow = std_reg(1);
+    lt_1 = std_lt(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    hot = std_reg(1);
+    eq_2 = std_eq(1);
+    eq_3 = std_eq(1);
+    eq_4 = std_eq(1);
+    eq_5 = std_eq(1);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    eq_8 = std_eq(2);
+    eq_9 = std_eq(2);
+    eq_10 = std_eq(2);
+    eq_11 = std_eq(1);
+    neq_12 = std_neq(1);
+    hot_not = std_not(1);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    group infer_flow {
+      lt_1.left = 32'd100;
+      lt_1.right = value;
+      flow.write_en = 1'd1;
+      flow.in = lt_1.out;
+      infer_flow[done] = flow.done;
+    }
+    comb group eq_2_group {
+      eq_2.left = hot.out;
+      eq_2.right = 1'd0;
+    }
+    comb group eq_3_group {
+      eq_3.left = hot.out;
+      eq_3.right = 1'd1;
+    }
+    comb group eq_4_group {
+      eq_4.left = flow.out;
+      eq_4.right = 1'd0;
+    }
+    comb group eq_5_group {
+      eq_5.left = flow.out;
+      eq_5.right = 1'd1;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    comb group eq_8_group {
+      eq_8.left = cmd;
+      eq_8.right = 2'd0;
+    }
+    comb group eq_9_group {
+      eq_9.left = cmd;
+      eq_9.right = 2'd1;
+    }
+    comb group eq_10_group {
+      eq_10.left = cmd;
+      eq_10.right = 2'd2;
+    }
+    comb group eq_11_group {
+      eq_11.left = err.out;
+      eq_11.right = 1'd0;
+    }
+    comb group neq_12_group {
+      neq_12.left = err.out;
+      neq_12.right = 1'd0;
+    }
+    group hot_not_group {
+      hot_not.in = hot.out;
+      hot.write_en = 1'd1;
+      hot.in = hot_not.out;
+      hot_not_group[done] = hot.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group lower_err {
+      err.in = 1'd0;
+      err.write_en = 1'd1;
+      lower_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+  }
+  control {
+    if eq_8.out with eq_8_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          lower_err;
+          if eq_2.out with eq_2_group {
+            seq {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          } else {
+            seq {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_9.out with eq_9_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            if eq_2.out with eq_2_group {
+              seq {
+                invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            } else {
+              seq {
+                invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            infer_flow;
+            if eq_4.out with eq_4_group {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+            } else {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+            }
+            if eq_11.out with eq_11_group {
+              len_incr_group;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+component fifo_blue(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
+            }
+            len_incr_group;
+          }
+        }
+      }
+    }
+  }
+}
+component pifo_root(cmd: 2, value: 32) -> () {
+  cells {
+    queue_l = pifo_red();
+    queue_r = fifo_blue();
+    flow = std_reg(1);
+    lt_1 = std_lt(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    hot = std_reg(1);
+    eq_2 = std_eq(1);
+    eq_3 = std_eq(1);
+    eq_4 = std_eq(1);
+    eq_5 = std_eq(1);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    eq_8 = std_eq(2);
+    eq_9 = std_eq(2);
+    eq_10 = std_eq(2);
+    eq_11 = std_eq(1);
+    neq_12 = std_neq(1);
+    hot_not = std_not(1);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    group infer_flow {
+      lt_1.left = 32'd200;
+      lt_1.right = value;
+      flow.write_en = 1'd1;
+      flow.in = lt_1.out;
+      infer_flow[done] = flow.done;
+    }
+    comb group eq_2_group {
+      eq_2.left = hot.out;
+      eq_2.right = 1'd0;
+    }
+    comb group eq_3_group {
+      eq_3.left = hot.out;
+      eq_3.right = 1'd1;
+    }
+    comb group eq_4_group {
+      eq_4.left = flow.out;
+      eq_4.right = 1'd0;
+    }
+    comb group eq_5_group {
+      eq_5.left = flow.out;
+      eq_5.right = 1'd1;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    comb group eq_8_group {
+      eq_8.left = cmd;
+      eq_8.right = 2'd0;
+    }
+    comb group eq_9_group {
+      eq_9.left = cmd;
+      eq_9.right = 2'd1;
+    }
+    comb group eq_10_group {
+      eq_10.left = cmd;
+      eq_10.right = 2'd2;
+    }
+    comb group eq_11_group {
+      eq_11.left = err.out;
+      eq_11.right = 1'd0;
+    }
+    comb group neq_12_group {
+      neq_12.left = err.out;
+      neq_12.right = 1'd0;
+    }
+    group hot_not_group {
+      hot_not.in = hot.out;
+      hot.write_en = 1'd1;
+      hot.in = hot_not.out;
+      hot_not_group[done] = hot.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group lower_err {
+      err.in = 1'd0;
+      err.write_en = 1'd1;
+      lower_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+  }
+  control {
+    if eq_8.out with eq_8_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          lower_err;
+          if eq_2.out with eq_2_group {
+            seq {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          } else {
+            seq {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_9.out with eq_9_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            if eq_2.out with eq_2_group {
+              seq {
+                invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            } else {
+              seq {
+                invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            infer_flow;
+            if eq_4.out with eq_4_group {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+            } else {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+            }
+            if eq_11.out with eq_11_group {
+              len_incr_group;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+component main() -> () {
+  cells {
+    @external commands = seq_mem_d1(2, 20000, 32);
+    @external values = seq_mem_d1(32, 20000, 32);
+    @external ans_mem = seq_mem_d1(32, 20000, 32);
+    myqueue = pifo_root();
+    err = std_reg(1);
+    ans = std_reg(32);
+    i = std_reg(32);
+    j = std_reg(32);
+    command = std_reg(2);
+    value = std_reg(32);
+    i_incr = std_add(32);
+    j_incr = std_add(32);
+    le_1 = std_le(2);
+    lt_2 = std_lt(32);
+    not_3 = std_not(1);
+  }
+  wires {
+    group i_incr_group {
+      i_incr.left = i.out;
+      i_incr.right = 32'd1;
+      i.write_en = 1'd1;
+      i.in = i_incr.out;
+      i_incr_group[done] = i.done;
+    }
+    group j_incr_group {
+      j_incr.left = j.out;
+      j_incr.right = 32'd1;
+      j.write_en = 1'd1;
+      j.in = j_incr.out;
+      j_incr_group[done] = j.done;
+    }
+    group lower_err {
+      err.in = 1'd0;
+      err.write_en = 1'd1;
+      lower_err[done] = err.done;
+    }
+    comb group le_1_group {
+      le_1.left = command.out;
+      le_1.right = 2'd1;
+    }
+    group read_cmd_phase1 {
+      commands.addr0 = i.out;
+      commands.read_en = 1'd1;
+      read_cmd_phase1[done] = commands.read_done;
+    }
+    group write_cmd_phase2 {
+      command.write_en = 1'd1;
+      command.in = commands.read_data;
+      write_cmd_phase2[done] = command.done;
+    }
+    group read_value {
+      values.addr0 = i.out;
+      values.read_en = 1'd1;
+      read_value[done] = values.read_done;
+    }
+    group write_value_to_reg {
+      value.write_en = 1'd1;
+      value.in = values.read_data;
+      write_value_to_reg[done] = value.done;
+    }
+    group write_ans {
+      ans_mem.addr0 = j.out;
+      ans_mem.write_en = 1'd1;
+      ans_mem.write_data = ans.out;
+      write_ans[done] = ans_mem.write_done;
+    }
+    comb group lt_2_group {
+      lt_2.left = i.out;
+      lt_2.right = 32'd20000;
+    }
+    comb group not_3_group {
+      not_3.in = err.out;
+    }
+  }
+  control {
+    while lt_2.out with lt_2_group {
+      seq {
+        read_cmd_phase1;
+        write_cmd_phase2;
+        read_value;
+        write_value_to_reg;
+        invoke myqueue[ans=ans, err=err](cmd=command.out, value=value.out)();
+        if not_3.out with not_3_group {
+          if le_1.out with le_1_group {
+            seq {
+              write_ans;
+              j_incr_group;
+            }
+          }
+        }
+        lower_err;
+        i_incr_group;
+      }
+    }
+  }
+}

--- a/calyx-py/test/correctness/sdn.futil
+++ b/calyx-py/test/correctness/sdn.futil
@@ -1,0 +1,1127 @@
+import "primitives/core.futil";
+import "primitives/binary_operators.futil";
+import "primitives/memories.futil";
+component stats(flow: 1) -> (count_0: 32, count_1: 32) {
+  cells {
+    count_0_sto = std_reg(32);
+    count_1_sto = std_reg(32);
+    count_0_sto_incr = std_add(32);
+    count_1_sto_incr = std_add(32);
+    eq_1 = std_eq(1);
+  }
+  wires {
+    group count_0_sto_incr_group {
+      count_0_sto_incr.left = count_0_sto.out;
+      count_0_sto_incr.right = 32'd1;
+      count_0_sto.write_en = 1'd1;
+      count_0_sto.in = count_0_sto_incr.out;
+      count_0_sto_incr_group[done] = count_0_sto.done;
+    }
+    group count_1_sto_incr_group {
+      count_1_sto_incr.left = count_1_sto.out;
+      count_1_sto_incr.right = 32'd1;
+      count_1_sto.write_en = 1'd1;
+      count_1_sto.in = count_1_sto_incr.out;
+      count_1_sto_incr_group[done] = count_1_sto.done;
+    }
+    comb group eq_1_group {
+      eq_1.left = flow;
+      eq_1.right = 1'd0;
+    }
+    count_0 = count_0_sto.out;
+    count_1 = count_1_sto.out;
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      count_0_sto_incr_group;
+    } else {
+      count_1_sto_incr_group;
+    }
+  }
+}
+component fifo_purple(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
+            }
+            len_incr_group;
+          }
+        }
+      }
+    }
+  }
+}
+component fifo_tangerine(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
+            }
+            len_incr_group;
+          }
+        }
+      }
+    }
+  }
+}
+component pifo_red(cmd: 2, value: 32) -> () {
+  cells {
+    queue_l = fifo_purple();
+    queue_r = fifo_tangerine();
+    flow = std_reg(1);
+    lt_1 = std_lt(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    hot = std_reg(1);
+    eq_2 = std_eq(1);
+    eq_3 = std_eq(1);
+    eq_4 = std_eq(1);
+    eq_5 = std_eq(1);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    eq_8 = std_eq(2);
+    eq_9 = std_eq(2);
+    eq_10 = std_eq(2);
+    eq_11 = std_eq(1);
+    neq_12 = std_neq(1);
+    hot_not = std_not(1);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    group infer_flow {
+      lt_1.left = 32'd100;
+      lt_1.right = value;
+      flow.write_en = 1'd1;
+      flow.in = lt_1.out;
+      infer_flow[done] = flow.done;
+    }
+    comb group eq_2_group {
+      eq_2.left = hot.out;
+      eq_2.right = 1'd0;
+    }
+    comb group eq_3_group {
+      eq_3.left = hot.out;
+      eq_3.right = 1'd1;
+    }
+    comb group eq_4_group {
+      eq_4.left = flow.out;
+      eq_4.right = 1'd0;
+    }
+    comb group eq_5_group {
+      eq_5.left = flow.out;
+      eq_5.right = 1'd1;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    comb group eq_8_group {
+      eq_8.left = cmd;
+      eq_8.right = 2'd0;
+    }
+    comb group eq_9_group {
+      eq_9.left = cmd;
+      eq_9.right = 2'd1;
+    }
+    comb group eq_10_group {
+      eq_10.left = cmd;
+      eq_10.right = 2'd2;
+    }
+    comb group eq_11_group {
+      eq_11.left = err.out;
+      eq_11.right = 1'd0;
+    }
+    comb group neq_12_group {
+      neq_12.left = err.out;
+      neq_12.right = 1'd0;
+    }
+    group hot_not_group {
+      hot_not.in = hot.out;
+      hot.write_en = 1'd1;
+      hot.in = hot_not.out;
+      hot_not_group[done] = hot.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group lower_err {
+      err.in = 1'd0;
+      err.write_en = 1'd1;
+      lower_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+  }
+  control {
+    if eq_8.out with eq_8_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          lower_err;
+          if eq_2.out with eq_2_group {
+            seq {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          } else {
+            seq {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_9.out with eq_9_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            if eq_2.out with eq_2_group {
+              seq {
+                invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            } else {
+              seq {
+                invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            infer_flow;
+            if eq_4.out with eq_4_group {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+            } else {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+            }
+            if eq_11.out with eq_11_group {
+              len_incr_group;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+component fifo_blue(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
+            }
+            len_incr_group;
+          }
+        }
+      }
+    }
+  }
+}
+component pifo_root(cmd: 2, value: 32) -> () {
+  cells {
+    queue_l = pifo_red();
+    queue_r = fifo_blue();
+    ref stats = stats();
+    flow = std_reg(1);
+    lt_1 = std_lt(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    hot = std_reg(1);
+    eq_2 = std_eq(1);
+    eq_3 = std_eq(1);
+    eq_4 = std_eq(1);
+    eq_5 = std_eq(1);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    eq_8 = std_eq(2);
+    eq_9 = std_eq(2);
+    eq_10 = std_eq(2);
+    eq_11 = std_eq(1);
+    neq_12 = std_neq(1);
+    hot_not = std_not(1);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    group infer_flow {
+      lt_1.left = 32'd200;
+      lt_1.right = value;
+      flow.write_en = 1'd1;
+      flow.in = lt_1.out;
+      infer_flow[done] = flow.done;
+    }
+    comb group eq_2_group {
+      eq_2.left = hot.out;
+      eq_2.right = 1'd0;
+    }
+    comb group eq_3_group {
+      eq_3.left = hot.out;
+      eq_3.right = 1'd1;
+    }
+    comb group eq_4_group {
+      eq_4.left = flow.out;
+      eq_4.right = 1'd0;
+    }
+    comb group eq_5_group {
+      eq_5.left = flow.out;
+      eq_5.right = 1'd1;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    comb group eq_8_group {
+      eq_8.left = cmd;
+      eq_8.right = 2'd0;
+    }
+    comb group eq_9_group {
+      eq_9.left = cmd;
+      eq_9.right = 2'd1;
+    }
+    comb group eq_10_group {
+      eq_10.left = cmd;
+      eq_10.right = 2'd2;
+    }
+    comb group eq_11_group {
+      eq_11.left = err.out;
+      eq_11.right = 1'd0;
+    }
+    comb group neq_12_group {
+      neq_12.left = err.out;
+      neq_12.right = 1'd0;
+    }
+    group hot_not_group {
+      hot_not.in = hot.out;
+      hot.write_en = 1'd1;
+      hot.in = hot_not.out;
+      hot_not_group[done] = hot.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group lower_err {
+      err.in = 1'd0;
+      err.write_en = 1'd1;
+      lower_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+  }
+  control {
+    if eq_8.out with eq_8_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          lower_err;
+          if eq_2.out with eq_2_group {
+            seq {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          } else {
+            seq {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_9.out with eq_9_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            if eq_2.out with eq_2_group {
+              seq {
+                invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            } else {
+              seq {
+                invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            infer_flow;
+            if eq_4.out with eq_4_group {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+            } else {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+            }
+            if eq_11.out with eq_11_group {
+              seq {
+                len_incr_group;
+                invoke stats(flow=flow.out)();
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+component dataplane() -> () {
+  cells {
+    ref stats_runner = stats();
+    myqueue = pifo_root();
+    ref commands = seq_mem_d1(2, 20000, 32);
+    ref values = seq_mem_d1(32, 20000, 32);
+    ref has_ans = std_reg(1);
+    ref component_ans = std_reg(32);
+    ref component_err = std_reg(1);
+    i = std_reg(32);
+    command = std_reg(2);
+    value = std_reg(32);
+    i_incr = std_add(32);
+    le_1 = std_le(2);
+    not_2 = std_not(1);
+    i_eq_MAX_CMDS = std_eq(32);
+  }
+  wires {
+    group i_incr_group {
+      i_incr.left = i.out;
+      i_incr.right = 32'd1;
+      i.write_en = 1'd1;
+      i.in = i_incr.out;
+      i_incr_group[done] = i.done;
+    }
+    comb group le_1_group {
+      le_1.left = command.out;
+      le_1.right = 2'd1;
+    }
+    group read_cmd_phase1 {
+      commands.addr0 = i.out;
+      commands.read_en = 1'd1;
+      read_cmd_phase1[done] = commands.read_done;
+    }
+    group write_cmd_phase2 {
+      command.write_en = 1'd1;
+      command.in = commands.read_data;
+      write_cmd_phase2[done] = command.done;
+    }
+    group read_value {
+      values.addr0 = i.out;
+      values.read_en = 1'd1;
+      read_value[done] = values.read_done;
+    }
+    group write_value_to_reg {
+      value.write_en = 1'd1;
+      value.in = values.read_data;
+      write_value_to_reg[done] = value.done;
+    }
+    group raise_has_ans {
+      has_ans.in = 1'd1;
+      has_ans.write_en = 1'd1;
+      raise_has_ans[done] = has_ans.done;
+    }
+    group lower_has_ans {
+      has_ans.in = 1'd0;
+      has_ans.write_en = 1'd1;
+      lower_has_ans[done] = has_ans.done;
+    }
+    comb group not_2_group {
+      not_2.in = component_err.out;
+    }
+    group i_eq_MAX_CMDS_group {
+      i_eq_MAX_CMDS.left = i.out;
+      i_eq_MAX_CMDS.right = 32'd20000;
+      component_err.write_en = 1'd1;
+      component_err.in = i_eq_MAX_CMDS.out;
+      i_eq_MAX_CMDS_group[done] = component_err.done;
+    }
+  }
+  control {
+    seq {
+      read_cmd_phase1;
+      write_cmd_phase2;
+      read_value;
+      write_value_to_reg;
+      invoke myqueue[ans=component_ans, err=component_err, stats=stats_runner](cmd=command.out, value=value.out)();
+      if not_2.out with not_2_group {
+        seq {
+          if le_1.out with le_1_group {
+            raise_has_ans;
+          } else {
+            lower_has_ans;
+          }
+        }
+      }
+      i_incr_group;
+      i_eq_MAX_CMDS_group;
+    }
+  }
+}
+component controller() -> () {
+  cells {
+    ref stats_controller = stats();
+    count_0 = std_reg(32);
+    count_1 = std_reg(32);
+  }
+  wires {
+    group get_data_locally {
+      count_0.in = stats_controller.count_0;
+      count_0.write_en = 1'd1;
+      count_1.in = stats_controller.count_1;
+      count_1.write_en = 1'd1;
+      get_data_locally[done] = count_0.done & count_1.done ? 1'd1;
+    }
+  }
+  control {
+    get_data_locally;
+  }
+}
+component main() -> () {
+  cells {
+    stats_main = stats();
+    dataplane = dataplane();
+    controller = controller();
+    has_ans = std_reg(1);
+    dataplane_ans = std_reg(32);
+    dataplane_err = std_reg(1);
+    @external commands = seq_mem_d1(2, 20000, 32);
+    @external values = seq_mem_d1(32, 20000, 32);
+    @external ans_mem = seq_mem_d1(32, 20000, 32);
+    neq_1 = std_neq(32);
+    j = std_reg(32);
+    j_incr = std_add(32);
+    not_2 = std_not(1);
+  }
+  wires {
+    comb group neq_1_group {
+      neq_1.left = dataplane_ans.out;
+      neq_1.right = 32'd0;
+    }
+    group j_incr_group {
+      j_incr.left = j.out;
+      j_incr.right = 32'd1;
+      j.write_en = 1'd1;
+      j.in = j_incr.out;
+      j_incr_group[done] = j.done;
+    }
+    group write_ans {
+      ans_mem.addr0 = j.out;
+      ans_mem.write_en = 1'd1;
+      ans_mem.write_data = dataplane_ans.out;
+      write_ans[done] = ans_mem.write_done;
+    }
+    group lower_has_ans {
+      has_ans.in = 1'd0;
+      has_ans.write_en = 1'd1;
+      lower_has_ans[done] = has_ans.done;
+    }
+    comb group not_2_group {
+      not_2.in = dataplane_err.out;
+    }
+  }
+  control {
+    while not_2.out with not_2_group {
+      seq {
+        lower_has_ans;
+        invoke dataplane[commands=commands, values=values, has_ans=has_ans, component_ans=dataplane_ans, component_err=dataplane_err, stats_runner=stats_main]()();
+        if has_ans.out {
+          if neq_1.out with neq_1_group {
+            seq {
+              write_ans;
+              j_incr_group;
+            }
+          }
+        }
+        invoke controller[stats_controller=stats_main]()();
+      }
+    }
+  }
+}

--- a/calyx-py/test/correctness/static/sdn_static.futil
+++ b/calyx-py/test/correctness/static/sdn_static.futil
@@ -1,0 +1,1123 @@
+import "primitives/core.futil";
+import "primitives/binary_operators.futil";
+import "primitives/memories.futil";
+static<1> component stats(flow: 1) -> (count_0: 32, count_1: 32) {
+  cells {
+    count_0_sto = std_reg(32);
+    count_1_sto = std_reg(32);
+    count_0_sto_incr = std_add(32);
+    count_1_sto_incr = std_add(32);
+    eq_cell = std_eq(1);
+  }
+  wires {
+    static<1> group count_0_sto_incr_group {
+      count_0_sto_incr.left = count_0_sto.out;
+      count_0_sto_incr.right = 32'd1;
+      count_0_sto.write_en = 1'd1;
+      count_0_sto.in = count_0_sto_incr.out;
+    }
+    static<1> group count_1_sto_incr_group {
+      count_1_sto_incr.left = count_1_sto.out;
+      count_1_sto_incr.right = 32'd1;
+      count_1_sto.write_en = 1'd1;
+      count_1_sto.in = count_1_sto_incr.out;
+    }
+    count_0 = count_0_sto.out;
+    count_1 = count_1_sto.out;
+    eq_cell.left = flow;
+    eq_cell.right = 1'd0;
+  }
+  control {
+    static if eq_cell.out {
+      count_0_sto_incr_group;
+    } else {
+      count_1_sto_incr_group;
+    }
+  }
+}
+component fifo_purple(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
+            }
+            len_incr_group;
+          }
+        }
+      }
+    }
+  }
+}
+component fifo_tangerine(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
+            }
+            len_incr_group;
+          }
+        }
+      }
+    }
+  }
+}
+component pifo_red(cmd: 2, value: 32) -> () {
+  cells {
+    queue_l = fifo_purple();
+    queue_r = fifo_tangerine();
+    flow = std_reg(1);
+    lt_1 = std_lt(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    hot = std_reg(1);
+    eq_2 = std_eq(1);
+    eq_3 = std_eq(1);
+    eq_4 = std_eq(1);
+    eq_5 = std_eq(1);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    eq_8 = std_eq(2);
+    eq_9 = std_eq(2);
+    eq_10 = std_eq(2);
+    eq_11 = std_eq(1);
+    neq_12 = std_neq(1);
+    hot_not = std_not(1);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    group infer_flow {
+      lt_1.left = 32'd100;
+      lt_1.right = value;
+      flow.write_en = 1'd1;
+      flow.in = lt_1.out;
+      infer_flow[done] = flow.done;
+    }
+    comb group eq_2_group {
+      eq_2.left = hot.out;
+      eq_2.right = 1'd0;
+    }
+    comb group eq_3_group {
+      eq_3.left = hot.out;
+      eq_3.right = 1'd1;
+    }
+    comb group eq_4_group {
+      eq_4.left = flow.out;
+      eq_4.right = 1'd0;
+    }
+    comb group eq_5_group {
+      eq_5.left = flow.out;
+      eq_5.right = 1'd1;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    comb group eq_8_group {
+      eq_8.left = cmd;
+      eq_8.right = 2'd0;
+    }
+    comb group eq_9_group {
+      eq_9.left = cmd;
+      eq_9.right = 2'd1;
+    }
+    comb group eq_10_group {
+      eq_10.left = cmd;
+      eq_10.right = 2'd2;
+    }
+    comb group eq_11_group {
+      eq_11.left = err.out;
+      eq_11.right = 1'd0;
+    }
+    comb group neq_12_group {
+      neq_12.left = err.out;
+      neq_12.right = 1'd0;
+    }
+    group hot_not_group {
+      hot_not.in = hot.out;
+      hot.write_en = 1'd1;
+      hot.in = hot_not.out;
+      hot_not_group[done] = hot.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group lower_err {
+      err.in = 1'd0;
+      err.write_en = 1'd1;
+      lower_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+  }
+  control {
+    if eq_8.out with eq_8_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          lower_err;
+          if eq_2.out with eq_2_group {
+            seq {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          } else {
+            seq {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_9.out with eq_9_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            if eq_2.out with eq_2_group {
+              seq {
+                invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            } else {
+              seq {
+                invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            infer_flow;
+            if eq_4.out with eq_4_group {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+            } else {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+            }
+            if eq_11.out with eq_11_group {
+              len_incr_group;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+component fifo_blue(cmd: 2, value: 32) -> () {
+  cells {
+    mem = seq_mem_d1(32, 10, 32);
+    next_write = std_reg(32);
+    next_read = std_reg(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    eq_1 = std_eq(2);
+    eq_2 = std_eq(2);
+    eq_3 = std_eq(2);
+    eq_4 = std_eq(32);
+    eq_5 = std_eq(32);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    next_write_incr = std_add(32);
+    next_read_incr = std_add(32);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    comb group eq_1_group {
+      eq_1.left = cmd;
+      eq_1.right = 2'd0;
+    }
+    comb group eq_2_group {
+      eq_2.left = cmd;
+      eq_2.right = 2'd1;
+    }
+    comb group eq_3_group {
+      eq_3.left = cmd;
+      eq_3.right = 2'd2;
+    }
+    comb group eq_4_group {
+      eq_4.left = next_write.out;
+      eq_4.right = 32'd10;
+    }
+    comb group eq_5_group {
+      eq_5.left = next_read.out;
+      eq_5.right = 32'd10;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    group next_write_incr_group {
+      next_write_incr.left = next_write.out;
+      next_write_incr.right = 32'd1;
+      next_write.write_en = 1'd1;
+      next_write.in = next_write_incr.out;
+      next_write_incr_group[done] = next_write.done;
+    }
+    group next_read_incr_group {
+      next_read_incr.left = next_read.out;
+      next_read_incr.right = 32'd1;
+      next_read.write_en = 1'd1;
+      next_read.in = next_read_incr.out;
+      next_read_incr_group[done] = next_read.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+    group flash_write {
+      next_write.in = 32'd0;
+      next_write.write_en = 1'd1;
+      flash_write[done] = next_write.done;
+    }
+    group flash_read {
+      next_read.in = 32'd0;
+      next_read.write_en = 1'd1;
+      flash_read[done] = next_read.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group write_payload_to_mem {
+      mem.addr0 = next_write.out;
+      mem.write_en = 1'd1;
+      mem.write_data = value;
+      write_payload_to_mem[done] = mem.write_done;
+    }
+    group read_payload_from_mem_phase1 {
+      mem.addr0 = next_read.out;
+      mem.read_en = 1'd1;
+      read_payload_from_mem_phase1[done] = mem.read_done;
+    }
+    group read_payload_from_mem_phase2 {
+      ans.write_en = 1'd1;
+      ans.in = mem.read_data;
+      read_payload_from_mem_phase2[done] = ans.done;
+    }
+  }
+  control {
+    if eq_1.out with eq_1_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          read_payload_from_mem_phase1;
+          read_payload_from_mem_phase2;
+          next_read_incr_group;
+          if eq_5.out with eq_5_group {
+            flash_read;
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_2.out with eq_2_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            read_payload_from_mem_phase1;
+            read_payload_from_mem_phase2;
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            write_payload_to_mem;
+            next_write_incr_group;
+            if eq_4.out with eq_4_group {
+              flash_write;
+            }
+            len_incr_group;
+          }
+        }
+      }
+    }
+  }
+}
+component pifo_root(cmd: 2, value: 32) -> () {
+  cells {
+    queue_l = pifo_red();
+    queue_r = fifo_blue();
+    ref stats = stats();
+    flow = std_reg(1);
+    lt_1 = std_lt(32);
+    ref ans = std_reg(32);
+    ref err = std_reg(1);
+    len = std_reg(32);
+    hot = std_reg(1);
+    eq_2 = std_eq(1);
+    eq_3 = std_eq(1);
+    eq_4 = std_eq(1);
+    eq_5 = std_eq(1);
+    eq_6 = std_eq(32);
+    eq_7 = std_eq(32);
+    eq_8 = std_eq(2);
+    eq_9 = std_eq(2);
+    eq_10 = std_eq(2);
+    eq_11 = std_eq(1);
+    neq_12 = std_neq(1);
+    hot_not = std_not(1);
+    len_incr = std_add(32);
+    len_decr = std_sub(32);
+  }
+  wires {
+    group infer_flow {
+      lt_1.left = 32'd200;
+      lt_1.right = value;
+      flow.write_en = 1'd1;
+      flow.in = lt_1.out;
+      infer_flow[done] = flow.done;
+    }
+    comb group eq_2_group {
+      eq_2.left = hot.out;
+      eq_2.right = 1'd0;
+    }
+    comb group eq_3_group {
+      eq_3.left = hot.out;
+      eq_3.right = 1'd1;
+    }
+    comb group eq_4_group {
+      eq_4.left = flow.out;
+      eq_4.right = 1'd0;
+    }
+    comb group eq_5_group {
+      eq_5.left = flow.out;
+      eq_5.right = 1'd1;
+    }
+    comb group eq_6_group {
+      eq_6.left = len.out;
+      eq_6.right = 32'd0;
+    }
+    comb group eq_7_group {
+      eq_7.left = len.out;
+      eq_7.right = 32'd10;
+    }
+    comb group eq_8_group {
+      eq_8.left = cmd;
+      eq_8.right = 2'd0;
+    }
+    comb group eq_9_group {
+      eq_9.left = cmd;
+      eq_9.right = 2'd1;
+    }
+    comb group eq_10_group {
+      eq_10.left = cmd;
+      eq_10.right = 2'd2;
+    }
+    comb group eq_11_group {
+      eq_11.left = err.out;
+      eq_11.right = 1'd0;
+    }
+    comb group neq_12_group {
+      neq_12.left = err.out;
+      neq_12.right = 1'd0;
+    }
+    group hot_not_group {
+      hot_not.in = hot.out;
+      hot.write_en = 1'd1;
+      hot.in = hot_not.out;
+      hot_not_group[done] = hot.done;
+    }
+    group raise_err {
+      err.in = 1'd1;
+      err.write_en = 1'd1;
+      raise_err[done] = err.done;
+    }
+    group lower_err {
+      err.in = 1'd0;
+      err.write_en = 1'd1;
+      lower_err[done] = err.done;
+    }
+    group flash_ans {
+      ans.in = 32'd0;
+      ans.write_en = 1'd1;
+      flash_ans[done] = ans.done;
+    }
+    group len_incr_group {
+      len_incr.left = len.out;
+      len_incr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_incr.out;
+      len_incr_group[done] = len.done;
+    }
+    group len_decr_group {
+      len_decr.left = len.out;
+      len_decr.right = 32'd1;
+      len.write_en = 1'd1;
+      len.in = len_decr.out;
+      len_decr_group[done] = len.done;
+    }
+  }
+  control {
+    if eq_8.out with eq_8_group {
+      if eq_6.out with eq_6_group {
+        seq {
+          raise_err;
+          flash_ans;
+        }
+      } else {
+        seq {
+          lower_err;
+          if eq_2.out with eq_2_group {
+            seq {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          } else {
+            seq {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+              if neq_12.out with neq_12_group {
+                seq {
+                  lower_err;
+                  invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                }
+              } else {
+                hot_not_group;
+              }
+            }
+          }
+          len_decr_group;
+        }
+      }
+    } else {
+      if eq_9.out with eq_9_group {
+        if eq_6.out with eq_6_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            if eq_2.out with eq_2_group {
+              seq {
+                invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            } else {
+              seq {
+                invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+                if neq_12.out with neq_12_group {
+                  seq {
+                    lower_err;
+                    invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+                  }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        if eq_7.out with eq_7_group {
+          seq {
+            raise_err;
+            flash_ans;
+          }
+        } else {
+          seq {
+            lower_err;
+            infer_flow;
+            if eq_4.out with eq_4_group {
+              invoke queue_l[ans=ans, err=err](cmd=cmd, value=value)();
+            } else {
+              invoke queue_r[ans=ans, err=err](cmd=cmd, value=value)();
+            }
+            if eq_11.out with eq_11_group {
+              seq {
+                len_incr_group;
+                static invoke stats(flow=flow.out)();
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+component dataplane() -> () {
+  cells {
+    ref stats_runner = stats();
+    myqueue = pifo_root();
+    ref commands = seq_mem_d1(2, 20000, 32);
+    ref values = seq_mem_d1(32, 20000, 32);
+    ref has_ans = std_reg(1);
+    ref component_ans = std_reg(32);
+    ref component_err = std_reg(1);
+    i = std_reg(32);
+    command = std_reg(2);
+    value = std_reg(32);
+    i_incr = std_add(32);
+    le_1 = std_le(2);
+    not_2 = std_not(1);
+    i_eq_MAX_CMDS = std_eq(32);
+  }
+  wires {
+    group i_incr_group {
+      i_incr.left = i.out;
+      i_incr.right = 32'd1;
+      i.write_en = 1'd1;
+      i.in = i_incr.out;
+      i_incr_group[done] = i.done;
+    }
+    comb group le_1_group {
+      le_1.left = command.out;
+      le_1.right = 2'd1;
+    }
+    group read_cmd_phase1 {
+      commands.addr0 = i.out;
+      commands.read_en = 1'd1;
+      read_cmd_phase1[done] = commands.read_done;
+    }
+    group write_cmd_phase2 {
+      command.write_en = 1'd1;
+      command.in = commands.read_data;
+      write_cmd_phase2[done] = command.done;
+    }
+    group read_value {
+      values.addr0 = i.out;
+      values.read_en = 1'd1;
+      read_value[done] = values.read_done;
+    }
+    group write_value_to_reg {
+      value.write_en = 1'd1;
+      value.in = values.read_data;
+      write_value_to_reg[done] = value.done;
+    }
+    group raise_has_ans {
+      has_ans.in = 1'd1;
+      has_ans.write_en = 1'd1;
+      raise_has_ans[done] = has_ans.done;
+    }
+    group lower_has_ans {
+      has_ans.in = 1'd0;
+      has_ans.write_en = 1'd1;
+      lower_has_ans[done] = has_ans.done;
+    }
+    comb group not_2_group {
+      not_2.in = component_err.out;
+    }
+    group i_eq_MAX_CMDS_group {
+      i_eq_MAX_CMDS.left = i.out;
+      i_eq_MAX_CMDS.right = 32'd20000;
+      component_err.write_en = 1'd1;
+      component_err.in = i_eq_MAX_CMDS.out;
+      i_eq_MAX_CMDS_group[done] = component_err.done;
+    }
+  }
+  control {
+    seq {
+      read_cmd_phase1;
+      write_cmd_phase2;
+      read_value;
+      write_value_to_reg;
+      invoke myqueue[ans=component_ans, err=component_err, stats=stats_runner](cmd=command.out, value=value.out)();
+      if not_2.out with not_2_group {
+        seq {
+          if le_1.out with le_1_group {
+            raise_has_ans;
+          } else {
+            lower_has_ans;
+          }
+        }
+      }
+      i_incr_group;
+      i_eq_MAX_CMDS_group;
+    }
+  }
+}
+component controller() -> () {
+  cells {
+    ref stats_controller = stats();
+    count_0 = std_reg(32);
+    count_1 = std_reg(32);
+  }
+  wires {
+    group get_data_locally {
+      count_0.in = stats_controller.count_0;
+      count_0.write_en = 1'd1;
+      count_1.in = stats_controller.count_1;
+      count_1.write_en = 1'd1;
+      get_data_locally[done] = count_0.done & count_1.done ? 1'd1;
+    }
+  }
+  control {
+    get_data_locally;
+  }
+}
+component main() -> () {
+  cells {
+    stats_main = stats();
+    dataplane = dataplane();
+    controller = controller();
+    has_ans = std_reg(1);
+    dataplane_ans = std_reg(32);
+    dataplane_err = std_reg(1);
+    @external commands = seq_mem_d1(2, 20000, 32);
+    @external values = seq_mem_d1(32, 20000, 32);
+    @external ans_mem = seq_mem_d1(32, 20000, 32);
+    neq_1 = std_neq(32);
+    j = std_reg(32);
+    j_incr = std_add(32);
+    not_2 = std_not(1);
+  }
+  wires {
+    comb group neq_1_group {
+      neq_1.left = dataplane_ans.out;
+      neq_1.right = 32'd0;
+    }
+    group j_incr_group {
+      j_incr.left = j.out;
+      j_incr.right = 32'd1;
+      j.write_en = 1'd1;
+      j.in = j_incr.out;
+      j_incr_group[done] = j.done;
+    }
+    group write_ans {
+      ans_mem.addr0 = j.out;
+      ans_mem.write_en = 1'd1;
+      ans_mem.write_data = dataplane_ans.out;
+      write_ans[done] = ans_mem.write_done;
+    }
+    group lower_has_ans {
+      has_ans.in = 1'd0;
+      has_ans.write_en = 1'd1;
+      lower_has_ans[done] = has_ans.done;
+    }
+    comb group not_2_group {
+      not_2.in = dataplane_err.out;
+    }
+  }
+  control {
+    while not_2.out with not_2_group {
+      seq {
+        lower_has_ans;
+        invoke dataplane[commands=commands, values=values, has_ans=has_ans, component_ans=dataplane_ans, component_err=dataplane_err, stats_runner=stats_main]()();
+        if has_ans.out {
+          if neq_1.out with neq_1_group {
+            seq {
+              write_ans;
+              j_incr_group;
+            }
+          }
+        }
+        invoke controller[stats_controller=stats_main]()();
+      }
+    }
+  }
+}


### PR DESCRIPTION
Promotion and compaction are not currently working on the idiom
```
par {
  if b  { foo };
  if ~b { bar };
}
```
This is because the empty `else` block causes the entire conditional to fall below the promotion radar.

This idiom can easily be translated into an `if then else` idiom. That is what this PR does.