### PR TITLE
Queues: more `par`s when possible

### DIFF
--- a/calyx-py/test/correctness/fifo.futil
+++ b/calyx-py/test/correctness/fifo.futil
@@ -119,7 +119,7 @@ component fifo(cmd: 2, value: 32) -> () {
     par {
       if eq_1.out with eq_1_group {
         if eq_6.out with eq_6_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }
@@ -137,7 +137,7 @@ component fifo(cmd: 2, value: 32) -> () {
       }
       if eq_2.out with eq_2_group {
         if eq_6.out with eq_6_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }
@@ -150,7 +150,7 @@ component fifo(cmd: 2, value: 32) -> () {
       }
       if eq_3.out with eq_3_group {
         if eq_7.out with eq_7_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }

--- a/calyx-py/test/correctness/fifo.py
+++ b/calyx-py/test/correctness/fifo.py
@@ -72,7 +72,7 @@ def insert_fifo(prog, name):
             cb.if_with(
                 # Yes, the user called pop. But is the queue empty?
                 len_eq_0,
-                [raise_err, flash_ans],  # The queue is empty: underflow.
+                cb.par(raise_err, flash_ans),  # The queue is empty: underflow.
                 [  # The queue is not empty. Proceed.
                     read_from_mem,  # Read from the queue.
                     write_to_ans,  # Write the answer to the answer register.
@@ -91,7 +91,7 @@ def insert_fifo(prog, name):
             cmd_eq_1,
             cb.if_with(  # Yes, the user called peek. But is the queue empty?
                 len_eq_0,
-                [raise_err, flash_ans],  # The queue is empty: underflow.
+                cb.par(raise_err, flash_ans),  # The queue is empty: underflow.
                 [  # The queue is not empty. Proceed.
                     read_from_mem,  # Read from the queue.
                     write_to_ans,  # Write the answer to the answer register.
@@ -105,7 +105,7 @@ def insert_fifo(prog, name):
             cb.if_with(
                 # Yes, the user called push. But is the queue full?
                 len_eq_max_queue_len,
-                [raise_err, flash_ans],  # The queue is full: overflow.
+                cb.par(raise_err, flash_ans),  # The queue is empty: underflow.
                 [  # The queue is not full. Proceed.
                     write_to_mem,  # Write `value` to the queue.
                     write_incr,  # Increment the write pointer.

--- a/calyx-py/test/correctness/pifo.futil
+++ b/calyx-py/test/correctness/pifo.futil
@@ -119,7 +119,7 @@ component fifo_l(cmd: 2, value: 32) -> () {
     par {
       if eq_1.out with eq_1_group {
         if eq_6.out with eq_6_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }
@@ -137,7 +137,7 @@ component fifo_l(cmd: 2, value: 32) -> () {
       }
       if eq_2.out with eq_2_group {
         if eq_6.out with eq_6_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }
@@ -150,7 +150,7 @@ component fifo_l(cmd: 2, value: 32) -> () {
       }
       if eq_3.out with eq_3_group {
         if eq_7.out with eq_7_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }
@@ -286,7 +286,7 @@ component fifo_r(cmd: 2, value: 32) -> () {
     par {
       if eq_1.out with eq_1_group {
         if eq_6.out with eq_6_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }
@@ -304,7 +304,7 @@ component fifo_r(cmd: 2, value: 32) -> () {
       }
       if eq_2.out with eq_2_group {
         if eq_6.out with eq_6_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }
@@ -317,7 +317,7 @@ component fifo_r(cmd: 2, value: 32) -> () {
       }
       if eq_3.out with eq_3_group {
         if eq_7.out with eq_7_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }
@@ -437,7 +437,7 @@ component pifo(cmd: 2, value: 32) -> () {
     par {
       if eq_5.out with eq_5_group {
         if eq_3.out with eq_3_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }
@@ -475,7 +475,7 @@ component pifo(cmd: 2, value: 32) -> () {
       }
       if eq_6.out with eq_6_group {
         if eq_3.out with eq_3_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }
@@ -508,7 +508,7 @@ component pifo(cmd: 2, value: 32) -> () {
       }
       if eq_7.out with eq_7_group {
         if eq_4.out with eq_4_group {
-          seq {
+          par {
             raise_err;
             flash_ans;
           }

--- a/calyx-py/test/correctness/pifo.py
+++ b/calyx-py/test/correctness/pifo.py
@@ -142,7 +142,7 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None, static=False
             cb.if_with(
                 # Yes, the user called pop. But is the queue empty?
                 len_eq_0,
-                [raise_err, flash_ans],  # The queue is empty: underflow.
+                cb.par(raise_err, flash_ans),  # The queue is empty: underflow.
                 [  # The queue is not empty. Proceed.
                     # We must check if `hot` is 0 or 1.
                     lower_err,
@@ -195,7 +195,7 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None, static=False
             cb.if_with(
                 # Yes, the user called peek. But is the queue empty?
                 len_eq_0,
-                [raise_err, flash_ans],  # The queue is empty: underflow.
+                cb.par(raise_err, flash_ans),  # The queue is empty: underflow.
                 [  # The queue is not empty. Proceed.
                     # We must check if `hot` is 0 or 1.
                     lower_err,
@@ -238,7 +238,7 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None, static=False
             cb.if_with(
                 # Yes, the user called push. But is the queue full?
                 len_eq_max_queue_len,
-                [raise_err, flash_ans],  # The queue is full: overflow.
+                cb.par(raise_err, flash_ans),  # The queue is full: overflow.
                 [  # The queue is not full. Proceed.
                     lower_err,
                     # We need to check which flow this value should be pushed to.
@@ -256,7 +256,7 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None, static=False
                         # just increment the length.
                         len_incr
                         if not stats
-                        else [
+                        else cb.par(
                             # If a stats component is provided,
                             # Increment the length and also
                             # tell the stats component what flow we pushed.
@@ -266,7 +266,7 @@ def insert_pifo(prog, name, queue_l, queue_r, boundary, stats=None, static=False
                                 if static
                                 else cb.invoke(stats, in_flow=flow.out)
                             ),
-                        ],
+                        ),
                     ),
                 ],
             ),


### PR DESCRIPTION
I just noticed that I was frequently defaulting to `seq` blocks when `par` would have been totally possible. This is probably in part due to the fact that `seq`s are just a teeny bit easier to write in the eDSL!