### PR TITLE
Add back the vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,5 @@ __pycache__
 
 tests/xilinx/cocotb/**/hdl
 
-.vscode/settings.json
 
 !cider-dap/calyxDebug/package.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "[rust]": {
+        "editor.defaultFormatter": "rust-lang.rust-analyzer",
+        "editor.formatOnSave": true,
+    },
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+    // Please only make changes to this file if they are useful/necessary for
+    // the whole project. For all other things use your own local settings.
     "[rust]": {
         "editor.defaultFormatter": "rust-lang.rust-analyzer",
         "editor.formatOnSave": true,


### PR DESCRIPTION
As discussed on Slack a while back

Adds back the vscode settings with a default snippet to format rust on save within the project workspace thing. Please commit stuff to the file very sparingly and only if it is something that should impact everyone. Thx