### PR TITLE
Fix pretty-printing for static invokes (#1795)

### DIFF
--- a/calyx-ir/src/printer.rs
+++ b/calyx-ir/src/printer.rs
@@ -553,11 +553,11 @@ impl Printer {
                 }
                 if outputs.is_empty() {
                     write!(f, ")")?;
+                } else {
+                    write!(f, "\n{})", " ".repeat(indent_level))?;
                 }
                 if let Some(group) = comb_group {
                     writeln!(f, " with {};", group.borrow().name)?;
-                } else {
-                    write!(f, "\n{})", " ".repeat(indent_level))?;
                 }
                 writeln!(f, ";")
             }

--- a/calyx-ir/src/printer.rs
+++ b/calyx-ir/src/printer.rs
@@ -557,7 +557,7 @@ impl Printer {
                     write!(f, "\n{})", " ".repeat(indent_level))?;
                 }
                 if let Some(group) = comb_group {
-                    writeln!(f, " with {};", group.borrow().name)?;
+                    write!(f, " with {}", group.borrow().name)?;
                 }
                 writeln!(f, ";")
             }

--- a/tests/passes/static-promotion/invoke.expect
+++ b/tests/passes/static-promotion/invoke.expect
@@ -16,8 +16,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       static<2> invoke exp0(
         base = r.out,
         exp = r.out
-      )()
-      );
+      )();
     }
   }
 }

--- a/tests/passes/static-promotion/multi-static.expect
+++ b/tests/passes/static-promotion/multi-static.expect
@@ -16,8 +16,7 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       static<2> invoke exp0(
         base = r.out,
         exp = r.out
-      )()
-      );
+      )();
     }
   }
 }


### PR DESCRIPTION
This fixes a few mistakes in the pretty-printer for `static invoke` statements (#1795). Please note the tricky `}` before an `else` that is misleadingly identified in the diff.

It doesn't fix the `componentmain` "feature" described in https://github.com/cucapra/calyx/issues/1795#issuecomment-1839521239. 😄 