### PR TITLE
[Docker] bump rust version number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official rust image as a parent image.
-FROM rust:1.69
+FROM rust:1.70
 
 # Connect to the Calux repository.
 LABEL org.opencontainers.image.source https://github.com/cucapra/calyx


### PR DESCRIPTION
One way to fix the issues with the CI is just to bump the version of rust being used.

Alternatively `runt` can restrict what version of `colored` it uses to one that has an msrv of `1.69` via a cargo.lock? Not sure if that's good practice or not.

cc: @rachitnigam @sampsyo 