### PR TITLE
Better parsing and help for pass options

### DIFF
--- a/calyx-opt/src/pass_manager.rs
+++ b/calyx-opt/src/pass_manager.rs
@@ -157,7 +157,7 @@ impl PassManager {
         passes.iter().chain(excl_set.iter()).try_for_each(|pass| {
             if !self.passes.contains_key(pass) {
                 Err(Error::misc(format!(
-                    "Unknown pass: {pass}. Run compiler with --list-passes to view registered passes."
+                    "Unknown pass: {pass}. Run compiler with pass-help subcommand to view registered passes."
                 )))
             } else {
                 Ok(())

--- a/calyx-opt/src/pass_manager.rs
+++ b/calyx-opt/src/pass_manager.rs
@@ -48,8 +48,9 @@ impl PassManager {
         });
         self.passes.insert(name.clone(), pass_closure);
         let mut help = format!("- {}: {}", name, Pass::description());
-        for (opt, desc) in Pass::opts() {
-            write!(&mut help, "\n  * {}: {}", opt, desc).unwrap();
+        for opt in Pass::opts() {
+            write!(&mut help, "\n  * {}: {}", opt.name(), opt.description())
+                .unwrap();
         }
         self.help.insert(name, help);
         Ok(())

--- a/calyx-opt/src/pass_manager.rs
+++ b/calyx-opt/src/pass_manager.rs
@@ -49,8 +49,14 @@ impl PassManager {
         self.passes.insert(name.clone(), pass_closure);
         let mut help = format!("- {}: {}", name, Pass::description());
         for opt in Pass::opts() {
-            write!(&mut help, "\n  * {}: {}", opt.name(), opt.description())
-                .unwrap();
+            write!(
+                &mut help,
+                "\n  * {}: {} (default: {})",
+                opt.name(),
+                opt.description(),
+                opt.default()
+            )
+            .unwrap();
         }
         self.help.insert(name, help);
         Ok(())
@@ -87,10 +93,15 @@ impl PassManager {
         Ok(())
     }
 
+    /// Return the help string for a specific pass.
+    pub fn specific_help(&self, pass: &str) -> Option<String> {
+        self.help.get(pass).cloned()
+    }
+
     /// Return a string representation to show all available passes and aliases.
     /// Appropriate for help text.
-    pub fn show_names(&self) -> String {
-        let mut ret = String::with_capacity(100);
+    pub fn complete_help(&self) -> String {
+        let mut ret = String::with_capacity(1000);
 
         // Push all passes.
         let mut pass_names = self.passes.keys().collect::<Vec<_>>();

--- a/calyx-opt/src/pass_manager.rs
+++ b/calyx-opt/src/pass_manager.rs
@@ -95,7 +95,16 @@ impl PassManager {
 
     /// Return the help string for a specific pass.
     pub fn specific_help(&self, pass: &str) -> Option<String> {
-        self.help.get(pass).cloned()
+        self.help.get(pass).cloned().or_else(|| {
+            self.aliases.get(pass).map(|passes| {
+                let pass_str = passes
+                    .iter()
+                    .map(|p| format!("- {p}"))
+                    .collect::<Vec<String>>()
+                    .join("\n");
+                format!("`{pass}' is an alias for pass pipeline:\n{}", pass_str)
+            })
+        })
     }
 
     /// Return a string representation to show all available passes and aliases.

--- a/calyx-opt/src/passes/comb_prop.rs
+++ b/calyx-opt/src/passes/comb_prop.rs
@@ -220,8 +220,8 @@ impl Named for CombProp {
         "propagate unconditional continuous assignments"
     }
 
-    fn opts() -> &'static [PassOpt] {
-        &[PassOpt::new(
+    fn opts() -> Vec<PassOpt> {
+        vec![PassOpt::new(
             "no-eliminate",
             "mark dead assignments with @dead instead of removing them",
             ParseVal::Bool(false),

--- a/calyx-opt/src/passes/comb_prop.rs
+++ b/calyx-opt/src/passes/comb_prop.rs
@@ -1,4 +1,6 @@
-use crate::traversal::{Action, ConstructVisitor, Named, VisResult, Visitor};
+use crate::traversal::{
+    Action, ConstructVisitor, Named, ParseVal, PassOpt, VisResult, Visitor,
+};
 use calyx_ir::{self as ir, RRC};
 use itertools::Itertools;
 use std::rc::Rc;
@@ -200,7 +202,7 @@ impl ConstructVisitor for CombProp {
     {
         let opts = Self::get_opts(ctx);
         Ok(CombProp {
-            no_eliminate: opts[0],
+            no_eliminate: opts[&"no-eliminate"].bool(),
         })
     }
 
@@ -218,10 +220,12 @@ impl Named for CombProp {
         "propagate unconditional continuous assignments"
     }
 
-    fn opts() -> &'static [(&'static str, &'static str)] {
-        &[(
+    fn opts() -> &'static [PassOpt] {
+        &[PassOpt::new(
             "no-eliminate",
             "mark dead assignments with @dead instead of removing them",
+            ParseVal::Bool(false),
+            PassOpt::parse_bool,
         )]
     }
 }

--- a/calyx-opt/src/passes/component_iniliner.rs
+++ b/calyx-opt/src/passes/component_iniliner.rs
@@ -84,7 +84,7 @@ impl ConstructVisitor for ComponentInliner {
     {
         let opts = Self::get_opts(ctx);
         Ok(ComponentInliner::new(
-            opts[&"always-inline"].bool(),
+            opts[&"always"].bool(),
             opts[&"new-fsms"].bool(),
         ))
     }

--- a/calyx-opt/src/passes/schedule_compaction.rs
+++ b/calyx-opt/src/passes/schedule_compaction.rs
@@ -20,7 +20,7 @@ impl Named for ScheduleCompaction {
     }
 
     fn description() -> &'static str {
-        "Aggressively compact schedule for static seqs which were promoted from generic seqs"
+        "compact execution scheduled for reschedulable static programs"
     }
 }
 

--- a/calyx-opt/src/passes/top_down_compile_control.rs
+++ b/calyx-opt/src/passes/top_down_compile_control.rs
@@ -1,6 +1,8 @@
 use super::math_utilities::get_bit_width_from;
 use crate::passes;
-use crate::traversal::{Action, ConstructVisitor, Named, VisResult, Visitor};
+use crate::traversal::{
+    Action, ConstructVisitor, Named, ParseVal, PassOpt, VisResult, Visitor,
+};
 use calyx_ir::{self as ir, GetAttributes, LibrarySignatures, Printer, RRC};
 use calyx_ir::{build_assignments, guard, structure};
 use calyx_utils::CalyxResult;
@@ -780,8 +782,8 @@ impl ConstructVisitor for TopDownCompileControl {
         let opts = Self::get_opts(ctx);
 
         Ok(TopDownCompileControl {
-            dump_fsm: opts[0],
-            early_transitions: opts[1],
+            dump_fsm: opts[&"dump-fsm"].bool(),
+            early_transitions: opts[&"early-transitions"].bool(),
         })
     }
 
@@ -799,15 +801,19 @@ impl Named for TopDownCompileControl {
         "Top-down compilation for removing control constructs"
     }
 
-    fn opts() -> &'static [(&'static str, &'static str)] {
-        &[
-            (
+    fn opts() -> Vec<PassOpt> {
+        vec![
+            PassOpt::new(
                 "dump-fsm",
                 "Print out the state machine implementing the schedule",
+                ParseVal::Bool(false),
+                PassOpt::parse_bool,
             ),
-            (
+            PassOpt::new(
                 "early-transitions",
                 "Experimental: Enable early transitions for group enables",
+                ParseVal::Bool(false),
+                PassOpt::parse_bool,
             ),
         ]
     }

--- a/calyx-opt/src/passes/top_down_static_timing/tdst.rs
+++ b/calyx-opt/src/passes/top_down_static_timing/tdst.rs
@@ -2,7 +2,9 @@ use super::compute_states::{END, START};
 use crate::analysis::WithStatic;
 use crate::passes::top_down_static_timing::{ComputeStates, Normalize};
 use crate::passes::{self, math_utilities::get_bit_width_from};
-use crate::traversal::{Action, ConstructVisitor, Named, VisResult, Visitor};
+use crate::traversal::{
+    Action, ConstructVisitor, Named, ParseVal, PassOpt, VisResult, Visitor,
+};
 use calyx_ir::{
     self as ir, build_assignments, guard, structure, GetAttributes,
     LibrarySignatures, Printer, RRC,
@@ -759,8 +761,8 @@ impl ConstructVisitor for TopDownStaticTiming {
         let opts = Self::get_opts(ctx);
 
         Ok(TopDownStaticTiming {
-            dump_fsm: opts[0],
-            force: opts[1],
+            dump_fsm: opts[&"dump-fsm"].bool(),
+            force: opts[&"force"].bool(),
         })
     }
 
@@ -778,10 +780,10 @@ impl Named for TopDownStaticTiming {
         "Top-down latency-sensitive compilation for removing control constructs"
     }
 
-    fn opts() -> &'static [(&'static str, &'static str)] {
-        &[
-            ("dump-fsm", "Print out the state machine implementing the schedule"),
-            ("force", "Error if the program cannot be fully compiled using static timing")
+    fn opts() -> Vec<PassOpt> {
+        vec![
+            PassOpt::new("dump-fsm", "Print out the state machine implementing the schedule", ParseVal::Bool(false), PassOpt::parse_bool),
+            PassOpt::new("force", "Error if the program cannot be fully compiled using static timing", ParseVal::Bool(false), PassOpt::parse_bool)
         ]
     }
 }

--- a/calyx-opt/src/traversal/construct.rs
+++ b/calyx-opt/src/traversal/construct.rs
@@ -106,6 +106,10 @@ impl PassOpt {
         self.description
     }
 
+    pub const fn default(&self) -> &ParseVal {
+        &self.default
+    }
+
     fn parse(&self, s: &str) -> Option<ParseVal> {
         (self.parse)(s)
     }

--- a/calyx-opt/src/traversal/construct.rs
+++ b/calyx-opt/src/traversal/construct.rs
@@ -1,0 +1,228 @@
+use super::Visitor;
+use calyx_ir as ir;
+use calyx_utils::CalyxResult;
+use itertools::Itertools;
+use linked_hash_map::LinkedHashMap;
+
+#[derive(Clone)]
+/// The value returned from parsing an option.
+pub enum ParseVal {
+    /// A boolean option.
+    Bool(bool),
+    /// A number option.
+    Num(usize),
+    /// A list of values.
+    List(Vec<ParseVal>),
+}
+impl ParseVal {
+    pub fn bool(self) -> bool {
+        let ParseVal::Bool(b) = self else {
+            panic!("Expected bool, got {self}");
+        };
+        b
+    }
+
+    pub fn num(self) -> usize {
+        let ParseVal::Num(n) = self else {
+            panic!("Expected number, got {self}");
+        };
+        n
+    }
+
+    pub fn num_list(self) -> Vec<usize> {
+        match self {
+            ParseVal::List(l) => {
+                l.into_iter().map(ParseVal::num).collect::<Vec<_>>()
+            }
+            _ => panic!("Expected list of numbers, got {self}"),
+        }
+    }
+}
+impl std::fmt::Display for ParseVal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseVal::Bool(b) => write!(f, "{}", b),
+            ParseVal::Num(n) => write!(f, "{}", n),
+            ParseVal::List(l) => {
+                write!(f, "[")?;
+                for (i, e) in l.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", e)?;
+                }
+                write!(f, "]")
+            }
+        }
+    }
+}
+
+/// Option that can be passed to a pass.
+pub struct PassOpt {
+    name: &'static str,
+    description: &'static str,
+    default: ParseVal,
+    parse: fn(&str) -> Option<ParseVal>,
+}
+
+impl PassOpt {
+    pub const fn new(
+        name: &'static str,
+        description: &'static str,
+        default: ParseVal,
+        parse: fn(&str) -> Option<ParseVal>,
+    ) -> Self {
+        Self {
+            name,
+            description,
+            default,
+            parse,
+        }
+    }
+
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    pub const fn description(&self) -> &'static str {
+        self.description
+    }
+
+    fn parse(&self, s: &str) -> Option<ParseVal> {
+        (self.parse)(s)
+    }
+
+    pub fn parse_bool(s: &str) -> Option<ParseVal> {
+        match s {
+            "true" => Some(ParseVal::Bool(true)),
+            "false" => Some(ParseVal::Bool(false)),
+            _ => None,
+        }
+    }
+
+    /// Parse a number from a string.
+    pub fn parse_num(s: &str) -> Option<ParseVal> {
+        s.parse::<usize>().ok().map(ParseVal::Num)
+    }
+
+    /// Parse of list using parser for the elements.
+    /// Returns `None` if any of the elements fail to parse.
+    fn parse_list(
+        s: &str,
+        parse: fn(&str) -> Option<ParseVal>,
+    ) -> Option<ParseVal> {
+        let mut res = Vec::new();
+        for e in s.split(',') {
+            res.push(parse(e)?);
+        }
+        Some(ParseVal::List(res))
+    }
+
+    /// Parse a list of numbers from a string.
+    pub fn parse_num_list(s: &str) -> Option<ParseVal> {
+        Self::parse_list(s, Self::parse_num)
+    }
+}
+
+/// Trait that describes named things. Calling [`do_pass`](Visitor::do_pass) and [`do_pass_default`](Visitor::do_pass_default).
+/// require this to be implemented.
+///
+/// This has to be a separate trait from [`Visitor`] because these methods don't recieve `self` which
+/// means that it is impossible to create dynamic trait objects.
+pub trait Named {
+    /// The name of a pass. Is used for identifying passes.
+    fn name() -> &'static str;
+    /// A short description of the pass.
+    fn description() -> &'static str;
+    /// Set of options that can be passed to the pass.
+    /// The options contains a tuple of the option name and a description.
+    fn opts() -> &'static [PassOpt] {
+        &[]
+    }
+}
+
+/// Trait defining method that can be used to construct a Visitor from an
+/// [ir::Context].
+/// This is useful when a pass needs to construct information using the context
+/// *before* visiting the components.
+///
+/// For passes that don't need to use the context, this trait can be automatically
+/// be derived from [Default].
+pub trait ConstructVisitor {
+    fn get_opts(ctx: &ir::Context) -> LinkedHashMap<&'static str, ParseVal>
+    where
+        Self: Named,
+    {
+        let opts = Self::opts();
+        let n = Self::name();
+        let values: LinkedHashMap<&'static str, ParseVal> = ctx
+            .extra_opts
+            .iter()
+            .filter_map(|opt| {
+                // The format is either -x pass:opt or -x pass:opt=val
+                let mut splits = opt.split(':');
+                if let Some(pass) = splits.next() {
+                    if pass == n {
+                        let mut splits = splits.next()?.split('=');
+                        let opt = splits.next()?.to_string();
+                        let Some(opt) = opts.iter().find(|o| o.name == opt) else {
+                            log::warn!("Ignoring unknown option for pass `{n}`: {opt}");
+                                return None;
+                        };
+                        let val = if let Some(v) = splits.next() {
+                            let Some(v) = opt.parse(v) else {
+                                log::warn!(
+                                    "Ignoring invalid value for option `{n}:{}`: {v}",
+                                    opt.name(),
+                                );
+                                return None;
+                            };
+                            v
+                        } else {
+                            ParseVal::Bool(true)
+                        };
+                        return Some((opt.name(), val));
+                    }
+                }
+                None
+            })
+            .collect();
+
+        if log::log_enabled!(log::Level::Debug) {
+            log::debug!(
+                "Extra options for {}: {}",
+                Self::name(),
+                values.iter().map(|(o, v)| format!("{o}->{v}")).join(", ")
+            );
+        }
+
+        // For all options that were not provided with values, fill in the defaults.
+        for opt in opts {
+            if !values.contains_key(opt.name()) {
+                values.insert(opt.name(), opt.default.clone());
+            }
+        }
+
+        values
+    }
+
+    /// Construct the visitor using information from the Context
+    fn from(_ctx: &ir::Context) -> CalyxResult<Self>
+    where
+        Self: Sized;
+
+    /// Clear the data stored in the visitor. Called before traversing the
+    /// next component by [ir::traversal::Visitor].
+    fn clear_data(&mut self);
+}
+
+/// Derive ConstructVisitor when [Default] is provided for a visitor.
+impl<T: Default + Sized + Visitor> ConstructVisitor for T {
+    fn from(_ctx: &ir::Context) -> CalyxResult<Self> {
+        Ok(T::default())
+    }
+
+    fn clear_data(&mut self) {
+        *self = T::default();
+    }
+}

--- a/calyx-opt/src/traversal/mod.rs
+++ b/calyx-opt/src/traversal/mod.rs
@@ -1,8 +1,10 @@
 //! Helpers for traversing Control programs
 mod action;
+mod construct;
 mod post_order;
 mod visitor;
 
 pub use action::{Action, VisResult};
+pub use construct::{ConstructVisitor, Named, ParseVal, PassOpt};
 pub use post_order::{CompTraversal, Order};
-pub use visitor::{ConstructVisitor, Named, Visitable, Visitor};
+pub use visitor::{Visitable, Visitor};

--- a/calyx-utils/src/out_file.rs
+++ b/calyx-utils/src/out_file.rs
@@ -10,6 +10,7 @@ use std::{
 pub enum OutputFile {
     #[default]
     Stdout,
+    Stderr,
     File(PathBuf),
 }
 
@@ -17,6 +18,7 @@ impl OutputFile {
     pub fn as_path_string(&self) -> String {
         match self {
             OutputFile::Stdout => "<stdout>".to_string(),
+            OutputFile::Stderr => "<stderr>".to_string(),
             OutputFile::File(path) => path.to_string_lossy().to_string(),
         }
     }
@@ -27,6 +29,7 @@ impl FromStr for OutputFile {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
             "-" => Ok(OutputFile::Stdout),
+            "<err>" => Ok(OutputFile::Stderr),
             _ => Ok(OutputFile::File(PathBuf::from(s))),
         }
     }
@@ -36,6 +39,7 @@ impl ToString for OutputFile {
     fn to_string(&self) -> String {
         match self {
             OutputFile::Stdout => "-".to_string(),
+            OutputFile::Stderr => "<err>".to_string(),
             OutputFile::File(p) => p.to_str().unwrap().to_string(),
         }
     }
@@ -45,6 +49,7 @@ impl OutputFile {
     pub fn isatty(&self) -> bool {
         match self {
             OutputFile::Stdout => atty::is(atty::Stream::Stdout),
+            OutputFile::Stderr => atty::is(atty::Stream::Stderr),
             OutputFile::File(_) => false,
         }
     }
@@ -52,6 +57,7 @@ impl OutputFile {
     pub fn get_write(&self) -> Box<dyn io::Write> {
         match self {
             OutputFile::Stdout => Box::new(BufWriter::new(std::io::stdout())),
+            OutputFile::Stderr => Box::new(BufWriter::new(std::io::stderr())),
             OutputFile::File(path) => {
                 Box::new(BufWriter::new(std::fs::File::create(path).unwrap()))
             }

--- a/interp/src/interpreter/control_interpreter.rs
+++ b/interp/src/interpreter/control_interpreter.rs
@@ -835,7 +835,7 @@ impl WhileInterpreter {
                         .copy_span()
                         .into_option()
                         .map(|x| x.show())
-                        .unwrap_or_else(|| "".to_string());
+                        .unwrap_or_default();
                     warn!(logger,"While loop has violated its bounds. The annotation suggests that the body should execute {target} times, but it exited after {current} iterations. \n     {line}");
                 }
             }
@@ -853,7 +853,7 @@ impl WhileInterpreter {
                         .copy_span()
                         .into_option()
                         .map(|x| x.show())
-                        .unwrap_or_else(|| "".to_string());
+                        .unwrap_or_default();
                     warn!(logger,"While loop has violated its bounds. The annotation suggests that the body should execute {target} times, but it has entered its {current} iteration. \n     {line}");
                 }
             }

--- a/interp/src/main.rs
+++ b/interp/src/main.rs
@@ -30,7 +30,7 @@ pub struct Opts {
         option,
         short = 'o',
         long = "output",
-        default = "OutputFile::default()"
+        default = "OutputFile::Stdout"
     )]
     pub output: OutputFile,
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -13,9 +13,29 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+/// help information about passes
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "pass-help")]
+pub struct Help {
+    /// alias or pass name to get help for
+    #[argh(positional)]
+    pub name: Option<String>,
+}
+
+/// supported subcommands
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand)]
+pub enum Subcommand {
+    /// Help mode
+    Help(Help),
+}
+
 #[derive(FromArgs)]
 /// Options passed to the Calyx compiler.
 pub struct Opts {
+    #[argh(subcommand)]
+    pub sub: Option<Subcommand>,
+
     /// input calyx program
     #[argh(positional, from_str_fn(read_path))]
     pub file: Option<PathBuf>,
@@ -63,10 +83,6 @@ pub struct Opts {
     /// extra options passed to the context
     #[argh(option, short = 'x', long = "extra-opt")]
     pub extra_opts: Vec<String>,
-
-    /// list all avaliable pass options
-    #[argh(switch, long = "list-passes")]
-    pub list_passes: bool,
 
     /// enable verbose printing
     #[argh(option, long = "log", default = "log::LevelFilter::Warn")]

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -21,7 +21,7 @@ pub struct Opts {
     pub file: Option<PathBuf>,
 
     /// output file
-    #[argh(option, short = 'o', default = "OutputFile::default()")]
+    #[argh(option, short = 'o', default = "OutputFile::Stdout")]
     pub output: OutputFile,
 
     /// path to the primitives library

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> CalyxResult<()> {
 
     let pm = PassManager::default_passes()?;
 
-    // list all the avaliable pass options when flag --list-passes is enabled
+    // list all the avaliable pass options when pass-help subcommand is used
     if let Some(sub) = opts.sub {
         match sub {
             cmdline::Subcommand::Help(cmdline::Help { name }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,9 +38,22 @@ fn main() -> CalyxResult<()> {
     let pm = PassManager::default_passes()?;
 
     // list all the avaliable pass options when flag --list-passes is enabled
-    if opts.list_passes {
-        println!("{}", pm.show_names());
-        return Ok(());
+    if let Some(sub) = opts.sub {
+        match sub {
+            cmdline::Subcommand::Help(cmdline::Help { name }) => {
+                match name {
+                    Some(n) => {
+                        if let Some(help) = pm.specific_help(&n) {
+                            println!("{}", help);
+                        } else {
+                            println!("Unknown pass or alias: {}", n);
+                        }
+                    }
+                    None => println!("{}", pm.complete_help()),
+                }
+                return Ok(());
+            }
+        }
     }
 
     // Construct the namespace.

--- a/tests/passes/dom-map-static/par-if.expect
+++ b/tests/passes/dom-map-static/par-if.expect
@@ -1,31 +1,3 @@
-This maps ids of par blocks to "node timing maps", which map node ids to the first interval (i,j) that the node (i.e., enable/invoke/if conditional) is active for, 
- relative to the start of the given par block
-============ Map for Component "example" ============
-========Par Node ID: 0========
-====MUST EXECUTE====
-2 -- (0, 4)
-3 -- (4, 5)
-4 -- (5, 6)
-14 -- (12, 15)
-16 -- (0, 3)
-17 -- (3, 5)
-18 -- (5, 8)
-19 -- (8, 10)
-====MAY EXECUTE====
-7 -- (5, 9)
-8 -- (9, 12)
-10 -- (5, 6)
-11 -- (6, 8)
-12 -- (5, 10)
-========Par Node ID: 5========
-====MUST EXECUTE====
-7 -- (0, 4)
-8 -- (4, 7)
-10 -- (0, 1)
-11 -- (1, 3)
-====MAY EXECUTE====
-
-
 import "primitives/core.futil";
 component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
@@ -100,3 +72,31 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     invoke e()();
   }
 }
+---STDERR---
+This maps ids of par blocks to "node timing maps", which map node ids to the first interval (i,j) that the node (i.e., enable/invoke/if conditional) is active for, 
+ relative to the start of the given par block
+============ Map for Component "example" ============
+========Par Node ID: 0========
+====MUST EXECUTE====
+2 -- (0, 4)
+3 -- (4, 5)
+4 -- (5, 6)
+14 -- (12, 15)
+16 -- (0, 3)
+17 -- (3, 5)
+18 -- (5, 8)
+19 -- (8, 10)
+====MAY EXECUTE====
+7 -- (5, 9)
+8 -- (9, 12)
+10 -- (5, 6)
+11 -- (6, 8)
+12 -- (5, 10)
+========Par Node ID: 5========
+====MUST EXECUTE====
+7 -- (0, 4)
+8 -- (4, 7)
+10 -- (0, 1)
+11 -- (1, 3)
+====MAY EXECUTE====
+

--- a/tests/passes/dom-map-static/par-if.futil
+++ b/tests/passes/dom-map-static/par-if.futil
@@ -1,8 +1,8 @@
-// -p infer-share -x infer-share:print-static-analysis
+// -p infer-share -x infer-share:print-static-analysis=<err>
 import "primitives/core.futil";
 component example() -> () {
   cells {
-    lt = std_lt(4); 
+    lt = std_lt(4);
   }
   wires {
     static<4> group A {
@@ -37,8 +37,8 @@ component example() -> () {
   control {
     static par {
       static seq {
-        A; 
-        B; 
+        A;
+        B;
         static if lt.out {
           static par {
             static seq { G; H; }
@@ -46,9 +46,9 @@ component example() -> () {
           }
         }
         else {
-          Z; 
+          Z;
         }
-        J; 
+        J;
       }
       static seq {C; D; E; F;}
     }
@@ -65,6 +65,6 @@ component main() -> () {
   }
 
   control {
-    invoke e()(); 
+    invoke e()();
   }
 }

--- a/tests/passes/dom-map-static/repeat.expect
+++ b/tests/passes/dom-map-static/repeat.expect
@@ -1,15 +1,3 @@
-This maps ids of par blocks to "node timing maps", which map node ids to the first interval (i,j) that the node (i.e., enable/invoke/if conditional) is active for, 
- relative to the start of the given par block
-============ Map for Component "example" ============
-========Par Node ID: 0========
-====MUST EXECUTE====
-2 -- (0, 4)
-4 -- (4, 5)
-5 -- (14, 17)
-7 -- (0, 5)
-====MAY EXECUTE====
-
-
 import "primitives/core.futil";
 component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
@@ -49,3 +37,15 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
     invoke e()();
   }
 }
+---STDERR---
+This maps ids of par blocks to "node timing maps", which map node ids to the first interval (i,j) that the node (i.e., enable/invoke/if conditional) is active for, 
+ relative to the start of the given par block
+============ Map for Component "example" ============
+========Par Node ID: 0========
+====MUST EXECUTE====
+2 -- (0, 4)
+4 -- (4, 5)
+5 -- (14, 17)
+7 -- (0, 5)
+====MAY EXECUTE====
+

--- a/tests/passes/dom-map-static/repeat.futil
+++ b/tests/passes/dom-map-static/repeat.futil
@@ -1,8 +1,8 @@
-// -p infer-share -x infer-share:print-static-analysis
+// -p infer-share -x infer-share:print-static-analysis=<err>
 import "primitives/core.futil";
 component example() -> () {
   cells {
-    lt = std_lt(4); 
+    lt = std_lt(4);
   }
   wires {
     static<4> group A {
@@ -17,14 +17,14 @@ component example() -> () {
   control {
     static par {
       static seq {
-        A; 
+        A;
         static repeat 10 {
-          B; 
+          B;
         }
-        C; 
+        C;
       }
       static repeat 3 {
-        D; 
+        D;
       }
     }
   }
@@ -40,6 +40,6 @@ component main() -> () {
   }
 
   control {
-    invoke e()(); 
+    invoke e()();
   }
 }

--- a/tests/passes/domination-map/blank.expect
+++ b/tests/passes/domination-map/blank.expect
@@ -1,9 +1,3 @@
-The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
-that are attached to each non-empty control statement when the domination map is built. 
-To see which ID's refer to which control statement, look at the Calyx Program, which should 
-be printed along with the map when it is printed.
-Domination Map for component "example"  {
-}
 import "primitives/core.futil";
 component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {}
@@ -18,4 +12,11 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   control {
     invoke e()();
   }
+}
+---STDERR---
+The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
+that are attached to each non-empty control statement when the domination map is built. 
+To see which ID's refer to which control statement, look at the Calyx Program, which should 
+be printed along with the map when it is printed.
+Domination Map for component "example"  {
 }

--- a/tests/passes/domination-map/blank.futil
+++ b/tests/passes/domination-map/blank.futil
@@ -1,13 +1,13 @@
-// -p infer-share -x infer-share:print-dmap
+// -p infer-share -x infer-share:print-dmap=<err>
 import "primitives/core.futil";
 component example() -> () {
   cells {
   }
   wires {
-    
+
   }
   control {
-    
+
   }
 }
 
@@ -21,7 +21,7 @@ component main() -> () {
   }
 
   control {
-    invoke e() (); 
+    invoke e() ();
   }
-  
+
 }

--- a/tests/passes/domination-map/complex-test.expect
+++ b/tests/passes/domination-map/complex-test.expect
@@ -1,29 +1,3 @@
-The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
-that are attached to each non-empty control statement when the domination map is built. 
-To see which ID's refer to which control statement, look at the Calyx Program, which should 
-be printed along with the map when it is printed.
-Domination Map for component "example"  {
-Node: 1 -- Dominators: [1]
-Node: 2 -- Dominators: [1, 2]
-Node: 3 -- Dominators: [1, 2, 3]
-Node: 4 -- Dominators: [1, 2, 3, 4]
-Node: 5 -- Dominators: [1, 2, 3, 4, 5]
-Node: 8 -- Dominators: [1, 2, 3, 4, 5, 8]
-Node: 9 -- Dominators: [1, 2, 3, 4, 5, 9]
-Node: 10 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10]
-Node: 12 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 12]
-Node: 14 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 12, 14]
-Node: 15 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 12, 15]
-Node: 17 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 17]
-Node: 18 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 18]
-Node: 19 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 19]
-Node: 20 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 20]
-Node: 22 -- Dominators: [1, 2, 3, 4, 22]
-Node: 23 -- Dominators: [1, 2, 3, 4, 23]
-Node: 24 -- Dominators: [1, 2, 3, 4, 24]
-Node: 25 -- Dominators: [1, 2, 3, 4, 25]
-Node: 26 -- Dominators: [1, 2, 3, 4, 25, 26]
-}
 import "primitives/core.futil";
 component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
@@ -113,4 +87,31 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
       invoke e()();
     }
   }
+}
+---STDERR---
+The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
+that are attached to each non-empty control statement when the domination map is built. 
+To see which ID's refer to which control statement, look at the Calyx Program, which should 
+be printed along with the map when it is printed.
+Domination Map for component "example"  {
+Node: 1 -- Dominators: [1]
+Node: 2 -- Dominators: [1, 2]
+Node: 3 -- Dominators: [1, 2, 3]
+Node: 4 -- Dominators: [1, 2, 3, 4]
+Node: 5 -- Dominators: [1, 2, 3, 4, 5]
+Node: 8 -- Dominators: [1, 2, 3, 4, 5, 8]
+Node: 9 -- Dominators: [1, 2, 3, 4, 5, 9]
+Node: 10 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10]
+Node: 12 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 12]
+Node: 14 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 12, 14]
+Node: 15 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 12, 15]
+Node: 17 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 17]
+Node: 18 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 18]
+Node: 19 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 19]
+Node: 20 -- Dominators: [1, 2, 3, 4, 5, 8, 9, 10, 20]
+Node: 22 -- Dominators: [1, 2, 3, 4, 22]
+Node: 23 -- Dominators: [1, 2, 3, 4, 23]
+Node: 24 -- Dominators: [1, 2, 3, 4, 24]
+Node: 25 -- Dominators: [1, 2, 3, 4, 25]
+Node: 26 -- Dominators: [1, 2, 3, 4, 25, 26]
 }

--- a/tests/passes/domination-map/complex-test.futil
+++ b/tests/passes/domination-map/complex-test.futil
@@ -1,8 +1,8 @@
-// -p infer-share -x infer-share:print-dmap
+// -p infer-share -x infer-share:print-dmap=<err>
 import "primitives/core.futil";
 component example() -> () {
   cells {
-    lt = std_lt(4); 
+    lt = std_lt(4);
   }
   wires {
     group P0{
@@ -63,9 +63,9 @@ component example() -> () {
         par {X;Y;Z;}
       }
       Z;
-    } 
+    }
   }
- 
+
 }
 
 
@@ -78,9 +78,9 @@ component main() -> () {
   }
 
   control {
-    par { 
-        invoke e() (); 
+    par {
+        invoke e() ();
     }
   }
-  
+
 }

--- a/tests/passes/domination-map/dyn-repeat.expect
+++ b/tests/passes/domination-map/dyn-repeat.expect
@@ -1,11 +1,3 @@
-The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
-that are attached to each non-empty control statement when the domination map is built. 
-To see which ID's refer to which control statement, look at the Calyx Program, which should 
-be printed along with the map when it is printed.
-Domination Map for component "example"  {
-Node: 4 -- Dominators: [4]
-Node: 5 -- Dominators: [4, 5]
-}
 import "primitives/core.futil";
 component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
@@ -39,4 +31,13 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   control {
     invoke e()();
   }
+}
+---STDERR---
+The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
+that are attached to each non-empty control statement when the domination map is built. 
+To see which ID's refer to which control statement, look at the Calyx Program, which should 
+be printed along with the map when it is printed.
+Domination Map for component "example"  {
+Node: 4 -- Dominators: [4]
+Node: 5 -- Dominators: [4, 5]
 }

--- a/tests/passes/domination-map/dyn-repeat.futil
+++ b/tests/passes/domination-map/dyn-repeat.futil
@@ -1,9 +1,9 @@
-// -p infer-share -x infer-share:print-dmap
-// should ignore `repeat 0` stmts in domination map 
+// -p infer-share -x infer-share:print-dmap=<err>
+// should ignore `repeat 0` stmts in domination map
 import "primitives/core.futil";
 component example() -> () {
   cells {
-    lt = std_lt(4); 
+    lt = std_lt(4);
   }
   wires {
     group A{
@@ -15,12 +15,12 @@ component example() -> () {
   }
   control {
     repeat 0 {
-      A; 
+      A;
     }
     repeat 2 {
-      B; 
+      B;
     }
-    C; 
+    C;
   }
 }
 
@@ -34,7 +34,7 @@ component main() -> () {
   }
 
   control {
-    invoke e() (); 
+    invoke e() ();
   }
-  
+
 }

--- a/tests/passes/domination-map/empty-fbranch.expect
+++ b/tests/passes/domination-map/empty-fbranch.expect
@@ -1,17 +1,3 @@
-The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
-that are attached to each non-empty control statement when the domination map is built. 
-To see which ID's refer to which control statement, look at the Calyx Program, which should 
-be printed along with the map when it is printed.
-Domination Map for component "example"  {
-Node: 1 -- Dominators: [1]
-Node: 2 -- Dominators: [1, 2]
-Node: 3 -- Dominators: [1, 2, 3]
-Node: 5 -- Dominators: [1, 2, 3, 5]
-Node: 6 -- Dominators: [1, 2, 3, 6]
-Node: 7 -- Dominators: [1, 2, 3, 7]
-Node: 8 -- Dominators: [1, 2, 8]
-Node: 9 -- Dominators: [1, 2, 8, 9]
-}
 import "primitives/core.futil";
 component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
@@ -54,4 +40,19 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   control {
     invoke e()();
   }
+}
+---STDERR---
+The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
+that are attached to each non-empty control statement when the domination map is built. 
+To see which ID's refer to which control statement, look at the Calyx Program, which should 
+be printed along with the map when it is printed.
+Domination Map for component "example"  {
+Node: 1 -- Dominators: [1]
+Node: 2 -- Dominators: [1, 2]
+Node: 3 -- Dominators: [1, 2, 3]
+Node: 5 -- Dominators: [1, 2, 3, 5]
+Node: 6 -- Dominators: [1, 2, 3, 6]
+Node: 7 -- Dominators: [1, 2, 3, 7]
+Node: 8 -- Dominators: [1, 2, 8]
+Node: 9 -- Dominators: [1, 2, 8, 9]
 }

--- a/tests/passes/domination-map/empty-fbranch.futil
+++ b/tests/passes/domination-map/empty-fbranch.futil
@@ -1,8 +1,8 @@
-// -p infer-share -x infer-share:print-dmap
+// -p infer-share -x infer-share:print-dmap=<err>
 import "primitives/core.futil";
 component example() -> () {
   cells {
-    lt = std_lt(4); 
+    lt = std_lt(4);
   }
   wires {
     group A0{
@@ -27,7 +27,7 @@ component example() -> () {
         }
       }
       Z;
-    }    
+    }
   }
 }
 
@@ -41,7 +41,7 @@ component main() -> () {
   }
 
   control {
-    invoke e() (); 
+    invoke e() ();
   }
-  
+
 }

--- a/tests/passes/domination-map/if-dominated.expect
+++ b/tests/passes/domination-map/if-dominated.expect
@@ -1,14 +1,3 @@
-The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
-that are attached to each non-empty control statement when the domination map is built. 
-To see which ID's refer to which control statement, look at the Calyx Program, which should 
-be printed along with the map when it is printed.
-Domination Map for component "example"  {
-Node: 2 -- Dominators: [2]
-Node: 3 -- Dominators: [2, 3, 6]
-Node: 4 -- Dominators: [2, 3, 4, 6]
-Node: 5 -- Dominators: [2, 3, 5]
-Node: 6 -- Dominators: [6]
-}
 import "primitives/core.futil";
 component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
@@ -42,4 +31,16 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   control {
     invoke e()();
   }
+}
+---STDERR---
+The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
+that are attached to each non-empty control statement when the domination map is built. 
+To see which ID's refer to which control statement, look at the Calyx Program, which should 
+be printed along with the map when it is printed.
+Domination Map for component "example"  {
+Node: 2 -- Dominators: [2]
+Node: 3 -- Dominators: [2, 3, 6]
+Node: 4 -- Dominators: [2, 3, 4, 6]
+Node: 5 -- Dominators: [2, 3, 5]
+Node: 6 -- Dominators: [6]
 }

--- a/tests/passes/domination-map/if-dominated.futil
+++ b/tests/passes/domination-map/if-dominated.futil
@@ -1,8 +1,8 @@
-// -p infer-share -x infer-share:print-dmap
+// -p infer-share -x infer-share:print-dmap=<err>
 import "primitives/core.futil";
 component example() -> () {
   cells {
-    lt = std_lt(4); 
+    lt = std_lt(4);
   }
   wires {
     static<4> group A{
@@ -15,10 +15,10 @@ component example() -> () {
   control {
     static par {
       static seq {
-        A; 
+        A;
         static if lt.out {B;}
       }
-      C; 
+      C;
     }
   }
 }
@@ -33,7 +33,7 @@ component main() -> () {
   }
 
   control {
-    invoke e() (); 
+    invoke e() ();
   }
-  
+
 }

--- a/tests/passes/domination-map/nested-seq.expect
+++ b/tests/passes/domination-map/nested-seq.expect
@@ -1,12 +1,3 @@
-The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
-that are attached to each non-empty control statement when the domination map is built. 
-To see which ID's refer to which control statement, look at the Calyx Program, which should 
-be printed along with the map when it is printed.
-Domination Map for component "example"  {
-Node: 2 -- Dominators: [2]
-Node: 3 -- Dominators: [2, 3]
-Node: 4 -- Dominators: [2, 3, 4]
-}
 import "primitives/core.futil";
 component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
@@ -40,4 +31,14 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   control {
     invoke e()();
   }
+}
+---STDERR---
+The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
+that are attached to each non-empty control statement when the domination map is built. 
+To see which ID's refer to which control statement, look at the Calyx Program, which should 
+be printed along with the map when it is printed.
+Domination Map for component "example"  {
+Node: 2 -- Dominators: [2]
+Node: 3 -- Dominators: [2, 3]
+Node: 4 -- Dominators: [2, 3, 4]
 }

--- a/tests/passes/domination-map/nested-seq.futil
+++ b/tests/passes/domination-map/nested-seq.futil
@@ -1,8 +1,8 @@
-// -p infer-share -x infer-share:print-dmap
+// -p infer-share -x infer-share:print-dmap=<err>
 import "primitives/core.futil";
 component example() -> () {
   cells {
-    lt = std_lt(4); 
+    lt = std_lt(4);
   }
   wires {
     group A{
@@ -33,7 +33,7 @@ component main() -> () {
   wires {
   }
   control {
-    invoke e() (); 
+    invoke e() ();
   }
-  
+
 }

--- a/tests/passes/domination-map/par-if-nested.expect
+++ b/tests/passes/domination-map/par-if-nested.expect
@@ -1,23 +1,3 @@
-The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
-that are attached to each non-empty control statement when the domination map is built. 
-To see which ID's refer to which control statement, look at the Calyx Program, which should 
-be printed along with the map when it is printed.
-Domination Map for component "example"  {
-Node: 1 -- Dominators: [1]
-Node: 2 -- Dominators: [1, 2]
-Node: 3 -- Dominators: [1, 2, 3]
-Node: 5 -- Dominators: [1, 2, 3, 5]
-Node: 7 -- Dominators: [1, 2, 3, 5, 7]
-Node: 9 -- Dominators: [1, 2, 3, 5, 9]
-Node: 10 -- Dominators: [1, 2, 3, 5, 9, 10]
-Node: 11 -- Dominators: [1, 2, 3, 5, 9, 10, 11]
-Node: 13 -- Dominators: [1, 2, 3, 5, 13]
-Node: 14 -- Dominators: [1, 2, 3, 5, 14]
-Node: 15 -- Dominators: [1, 2, 3, 5, 15]
-Node: 16 -- Dominators: [1, 2, 3, 16]
-Node: 17 -- Dominators: [1, 2, 3, 17]
-Node: 18 -- Dominators: [1, 2, 3, 5, 15, 16, 17, 18]
-}
 import "primitives/core.futil";
 component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
@@ -89,4 +69,25 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   control {
     invoke e()();
   }
+}
+---STDERR---
+The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
+that are attached to each non-empty control statement when the domination map is built. 
+To see which ID's refer to which control statement, look at the Calyx Program, which should 
+be printed along with the map when it is printed.
+Domination Map for component "example"  {
+Node: 1 -- Dominators: [1]
+Node: 2 -- Dominators: [1, 2]
+Node: 3 -- Dominators: [1, 2, 3]
+Node: 5 -- Dominators: [1, 2, 3, 5]
+Node: 7 -- Dominators: [1, 2, 3, 5, 7]
+Node: 9 -- Dominators: [1, 2, 3, 5, 9]
+Node: 10 -- Dominators: [1, 2, 3, 5, 9, 10]
+Node: 11 -- Dominators: [1, 2, 3, 5, 9, 10, 11]
+Node: 13 -- Dominators: [1, 2, 3, 5, 13]
+Node: 14 -- Dominators: [1, 2, 3, 5, 14]
+Node: 15 -- Dominators: [1, 2, 3, 5, 15]
+Node: 16 -- Dominators: [1, 2, 3, 16]
+Node: 17 -- Dominators: [1, 2, 3, 17]
+Node: 18 -- Dominators: [1, 2, 3, 5, 15, 16, 17, 18]
 }

--- a/tests/passes/domination-map/par-if-nested.futil
+++ b/tests/passes/domination-map/par-if-nested.futil
@@ -1,8 +1,8 @@
-// -p infer-share -x infer-share:print-dmap
+// -p infer-share -x infer-share:print-dmap=<err>
 import "primitives/core.futil";
 component example() -> () {
   cells {
-    lt = std_lt(4); 
+    lt = std_lt(4);
   }
   wires {
     group P0{
@@ -70,6 +70,6 @@ component main() -> () {
   }
 
   control {
-    invoke e() (); 
+    invoke e() ();
   }
 }

--- a/tests/passes/domination-map/static-par.expect
+++ b/tests/passes/domination-map/static-par.expect
@@ -1,22 +1,3 @@
-The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
-that are attached to each non-empty control statement when the domination map is built. 
-To see which ID's refer to which control statement, look at the Calyx Program, which should 
-be printed along with the map when it is printed.
-Domination Map for component "example"  {
-Node: 1 -- Dominators: [1]
-Node: 4 -- Dominators: [1, 4]
-Node: 5 -- Dominators: [1, 4, 5, 8, 11]
-Node: 6 -- Dominators: [1, 4, 5, 6, 8, 9, 10, 11]
-Node: 8 -- Dominators: [1, 8]
-Node: 9 -- Dominators: [1, 8, 9, 11]
-Node: 10 -- Dominators: [1, 4, 8, 9, 10, 11]
-Node: 11 -- Dominators: [1, 11]
-Node: 14 -- Dominators: [1, 11, 14]
-Node: 15 -- Dominators: [1, 4, 8, 11, 14, 15, 16]
-Node: 16 -- Dominators: [1, 11, 16]
-Node: 17 -- Dominators: [1, 11, 17]
-Node: 18 -- Dominators: [1, 4, 5, 6, 8, 9, 10, 11, 17, 18]
-}
 import "primitives/core.futil";
 component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
@@ -82,4 +63,24 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   control {
     invoke e()();
   }
+}
+---STDERR---
+The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
+that are attached to each non-empty control statement when the domination map is built. 
+To see which ID's refer to which control statement, look at the Calyx Program, which should 
+be printed along with the map when it is printed.
+Domination Map for component "example"  {
+Node: 1 -- Dominators: [1]
+Node: 4 -- Dominators: [1, 4]
+Node: 5 -- Dominators: [1, 4, 5, 8, 11]
+Node: 6 -- Dominators: [1, 4, 5, 6, 8, 9, 10, 11]
+Node: 8 -- Dominators: [1, 8]
+Node: 9 -- Dominators: [1, 8, 9, 11]
+Node: 10 -- Dominators: [1, 4, 8, 9, 10, 11]
+Node: 11 -- Dominators: [1, 11]
+Node: 14 -- Dominators: [1, 11, 14]
+Node: 15 -- Dominators: [1, 4, 8, 11, 14, 15, 16]
+Node: 16 -- Dominators: [1, 11, 16]
+Node: 17 -- Dominators: [1, 11, 17]
+Node: 18 -- Dominators: [1, 4, 5, 6, 8, 9, 10, 11, 17, 18]
 }

--- a/tests/passes/domination-map/static-par.futil
+++ b/tests/passes/domination-map/static-par.futil
@@ -1,8 +1,8 @@
-// -p infer-share -x infer-share:print-dmap
+// -p infer-share -x infer-share:print-dmap=<err>
 import "primitives/core.futil";
 component example() -> () {
   cells {
-    lt = std_lt(4); 
+    lt = std_lt(4);
   }
   wires {
     group A{
@@ -30,14 +30,14 @@ component example() -> () {
   }
   control {
     seq {
-      A; 
+      A;
       static par {
         static seq {B; C; D;}
         static seq {E; F; G;}
         static if lt.out {
           static par {
             static seq {X; Y;}
-            Z; 
+            Z;
           }
         }
       }
@@ -56,7 +56,7 @@ component main() -> () {
   }
 
   control {
-    invoke e() (); 
+    invoke e() ();
   }
-  
+
 }

--- a/tests/passes/domination-map/while-nested.expect
+++ b/tests/passes/domination-map/while-nested.expect
@@ -1,18 +1,3 @@
-The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
-that are attached to each non-empty control statement when the domination map is built. 
-To see which ID's refer to which control statement, look at the Calyx Program, which should 
-be printed along with the map when it is printed.
-Domination Map for component "example"  {
-Node: 0 -- Dominators: [0]
-Node: 1 -- Dominators: [0, 1]
-Node: 2 -- Dominators: [0, 1, 2]
-Node: 4 -- Dominators: [0, 1, 2, 4]
-Node: 5 -- Dominators: [0, 1, 2, 4, 5]
-Node: 7 -- Dominators: [0, 1, 2, 4, 5, 7]
-Node: 8 -- Dominators: [0, 1, 2, 4, 5, 7, 8]
-Node: 9 -- Dominators: [0, 1, 2, 4, 5, 9]
-Node: 10 -- Dominators: [0, 1, 2, 4, 5, 9, 10]
-}
 import "primitives/core.futil";
 component example<"state_share"=1>(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   cells {
@@ -62,4 +47,20 @@ component main(@go go: 1, @clk clk: 1, @reset reset: 1) -> (@done done: 1) {
   control {
     invoke e()();
   }
+}
+---STDERR---
+The numbers in the domination map refer to the BEGIN_ID, END_ID, and NODE_ID attributes 
+that are attached to each non-empty control statement when the domination map is built. 
+To see which ID's refer to which control statement, look at the Calyx Program, which should 
+be printed along with the map when it is printed.
+Domination Map for component "example"  {
+Node: 0 -- Dominators: [0]
+Node: 1 -- Dominators: [0, 1]
+Node: 2 -- Dominators: [0, 1, 2]
+Node: 4 -- Dominators: [0, 1, 2, 4]
+Node: 5 -- Dominators: [0, 1, 2, 4, 5]
+Node: 7 -- Dominators: [0, 1, 2, 4, 5, 7]
+Node: 8 -- Dominators: [0, 1, 2, 4, 5, 7, 8]
+Node: 9 -- Dominators: [0, 1, 2, 4, 5, 9]
+Node: 10 -- Dominators: [0, 1, 2, 4, 5, 9, 10]
 }

--- a/tests/passes/domination-map/while-nested.futil
+++ b/tests/passes/domination-map/while-nested.futil
@@ -1,8 +1,8 @@
-// -p infer-share -x infer-share:print-dmap
+// -p infer-share -x infer-share:print-dmap=<err>
 import "primitives/core.futil";
 component example() -> () {
   cells {
-    lt = std_lt(4); 
+    lt = std_lt(4);
   }
   wires {
     group A{
@@ -25,7 +25,7 @@ component example() -> () {
       while lt.out with less_than{
         while lt.out with less_than{
           seq{
-            A; 
+            A;
             while lt.out with less_than{
               seq{
                 B1;
@@ -51,7 +51,7 @@ component main() -> () {
   }
 
   control {
-    invoke e() (); 
+    invoke e() ();
   }
-  
+
 }


### PR DESCRIPTION
Fixes https://github.com/cucapra/calyx/issues/1814. Adds new `PassOpt` and `ParseVal` structs to define pass options along with mechanisms to parse more complex command line options.